### PR TITLE
Allow process type to contain `.`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 ## [Unreleased]
 
+- Allow ProcessType to contain a dot (`.`) character
+
 ## [0.3.0] 2021/09/17

--- a/src/data/launch.rs
+++ b/src/data/launch.rs
@@ -113,7 +113,7 @@ impl FromStr for ProcessType {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         lazy_static! {
-            static ref RE: Regex = Regex::new(r"^[[:alnum:]_-]+$").unwrap();
+            static ref RE: Regex = Regex::new(r"^[[:alnum:]\._-]+$").unwrap();
         }
 
         let string = String::from(value);
@@ -148,5 +148,14 @@ mod tests {
             ProcessType::from_str("web").unwrap(),
             ProcessType::from_str("nope").unwrap()
         )
+    }
+
+    #[test]
+    fn test_process_type_with_special_chars() {
+        assert!(ProcessType::from_str("java_jar").is_ok());
+        assert!(ProcessType::from_str("java-jar").is_ok());
+        assert!(ProcessType::from_str("java.jar").is_ok());
+
+        assert!(ProcessType::from_str("java~jar").is_err());
     }
 }


### PR DESCRIPTION
From the spec:

> MUST only contain numbers, letters, and the characters ., _, and -.

https://github.com/buildpacks/spec/blob/main/buildpack.md#launchtoml-toml

A dot (`.`) is allowed.

Fixes #105. 
GUS-W-10055113