### PR TITLE
Add support for "any" stack `*` in StackId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Stack id in `buildpack.toml` can now be `*` indicating "any" stack
 - LayerContentMetadata values (build, cache, launch) are now under a "types" key
 - Allow ProcessType to contain a dot (`.`) character
 


### PR DESCRIPTION
When a `Stack` struct has a `StackId` of `*` then it should have no mixins.

This is validated by a "shadow" struct deserializing working from https://dev.to/equalma/validate-fields-and-types-in-serde-with-tryfrom-c2n.

Based on the comment from https://github.com/serde-rs/serde/issues/939#issuecomment-939514114

In my own words it works like this: We create a duplicate struct and use serde's normal `derive(Deserialize)` on it. Then we specify that the `Stack` struct should be converted using the duplicate struct with `#[serde(try_from = "StackUnchecked")]. Finally we implement `try_from` and include our special logic that checks to see we don't have a `*` stack id AND any mixins.

I also hard wrapped a few comments and put backpacks around special characters in the error output to make them clearer

Close #104 

GUS-W-10055742