### PR TITLE
Refactor buildpack Deserialize

### DIFF
--- a/src/data/buildpack.rs
+++ b/src/data/buildpack.rs
@@ -253,7 +253,7 @@ impl StackId {
 
 #[derive(thiserror::Error, Debug)]
 pub enum BuildpackTomlError {
-    #[error("Found `{0}` but value MUST only contain numbers, letters, and the characters `.`, `/`, and `-`. Value MUST NOT be 'config' or 'app'.")]
+    #[error("Found `{0}` but value MUST be in the form `<major>.<minor>` or `<major>` and only contain numbers.")]
     InvalidBuildpackApi(String),
 
     #[error("Stack with id `*` MUST not contain mixins. mixins: [{0}]")]


### PR DESCRIPTION
## Deserializing error background

When we deserialize TOML into structs there are requirements from the spec. For instance in https://github.com/Malax/libcnb.rs/pull/109 we see where this is invalid:

```
[[stacks]]
id = "*"
mixins = ["yolo"]
```

Because a stack cannot have an id of `*` and mixins. We need a consistent place to enforce this logic and rules and the most straightforward approach has been to check that the data at deserialize time.

## Existing approach

This deserialize validation behavior is already happening in the buildpack. For example, the `Deserialize` trait is manually implemented on `BuildpackAPI` here https://github.com/Malax/libcnb.rs/blob/2ca9fff2d449889ae0b9893326b068e43f370238/src/data/buildpack.rs#L86-L151.

## This approach

As part of the work with #109 it was found that serde has `try_from` that can be used to simplify this logic. Instead of having to manually implement all of Deserialize, the technique is to:

- Introduce an "unchecked" struct that holds the raw data before validation
- Implement a conversion between the "unchecked" struct and the "real" struct using TryFrom
- Implement the validation and error checking logic inside of TryFrom
- Set `#[serde(try_from=` on the "real" struct

A much longer example is demonstrated in this blog post https://dev.to/equalma/validate-fields-and-types-in-serde-with-tryfrom-c2n as pulled from https://github.com/serde-rs/s
erde/issues/939#issuecomment-939514114

Close #110