### PR TITLE
Update to Rust 1.56 and 2021 edition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Update Rust toolchain
+      # Most of the time this will be a no-op, since GitHub releases new images every week
+      # which include the latest stable release of Rust, Rustup, Clippy and rustfmt.
+      run: rustup update
     - name: Build
       # Not using --locked since Cargo.lock is in .gitignore.
       run: cargo build --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Set a minumim required Rust version of 1.56 and switch to the 2021 Rust edition
 - Stack id in `buildpack.toml` can now be `*` indicating "any" stack
 - LayerContentMetadata values (build, cache, launch) are now under a "types" key
 - Allow ProcessType to contain a dot (`.`) character

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,15 +2,14 @@
 name = "libcnb"
 version = "0.3.0"
 authors = ["Manuel Fuchs <malax@malax.de>", "Terence Lee <hone02@gmail.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 description = "Rust language binding of the Cloud Native Buildpack spec."
 repository = "https://github.com/Malax/libcnb.rs"
 documentation = "https://docs.rs/libcnb"
 readme = "README.md"
 include = ["src/**/*", "LICENSE", "README.md"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 lazy_static = "^1.4.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# libcnb.rs [![Build Status]][ci] [![Docs]][docs.rs] [![Latest Version]][crates.io] [![Rustc Version 1.31+]][rustc]
+# libcnb.rs [![Build Status]][ci] [![Docs]][docs.rs] [![Latest Version]][crates.io] [![Rustc Version 1.56+]][rustc]
 
 [Build Status]: https://img.shields.io/github/workflow/status/Malax/libcnb/Rust/master
 [ci]: https://github.com/Malax/libcnb/actions?query=branch%3Amaster
@@ -6,8 +6,8 @@
 [docs.rs]: https://docs.rs/libcnb/*/libcnb/
 [Latest Version]: https://img.shields.io/crates/v/libcnb.svg
 [crates.io]: https://crates.io/crates/libcnb
-[Rustc Version 1.31+]: https://img.shields.io/badge/rustc-1.31+-lightgray.svg
-[rustc]: https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html
+[Rustc Version 1.56+]: https://img.shields.io/badge/rustc-1.56+-lightgray.svg
+[rustc]: https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html
 
 `libcnb.rs` is a Rust language binding of the [Cloud Native Buildpacks](https://buildpacks.io) [spec](https://github.com/buildpacks/spec). It is a non-opinionated implementation adding language constructs and convenience methods for working with the spec. It values strong adherence to the spec and data formats.
 
@@ -78,4 +78,4 @@ Add the following to your `Cargo.toml` file:
 libcnb = "0.1.0"
 ```
 
-*Compiler support requires rustc 1.31+ for 2018 edition*
+*Compiler support requires rustc 1.56+ for 2021 edition*

--- a/examples/example-01-basics/Cargo.toml
+++ b/examples/example-01-basics/Cargo.toml
@@ -2,9 +2,8 @@
 name = "example-01-basics"
 version = "0.1.0"
 authors = ["Manuel Fuchs <malax@malax.de>"]
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 "libcnb" = { path = "../../" }

--- a/examples/example-02-ruby-sample/Cargo.toml
+++ b/examples/example-02-ruby-sample/Cargo.toml
@@ -2,9 +2,8 @@
 name = "example-02-ruby-sample"
 version = "0.1.0"
 authors = ["Terence Lee <hone02@gmail.com>"]
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
Rust 1.56 has just been released:
https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html

Compatibility with the 2021 edition was ensured by running `cargo fix --edition` (which found no required changes).

A minimum Rust version has been set using:
https://doc.rust-lang.org/nightly/cargo/reference/manifest.html#the-rust-version-field

GUS-W-10066573.