### PR TITLE
Document `LayerLifecycle`

### DIFF
--- a/src/layer_lifecycle.rs
+++ b/src/layer_lifecycle.rs
@@ -5,10 +5,10 @@
 //!
 //! Layers have two main components:
 //!
-//! 1. A <layer> directory (<https://github.com/buildpacks/spec/blob/main/buildpack.md#layers>)
-//! 2. A <layer>/<layer>.toml file (<https://github.com/buildpacks/spec/blob/main/buildpack.md#layer-content-metadata-toml>)
+//! 1. A `<layer>` directory (<https://github.com/buildpacks/spec/blob/main/buildpack.md#layers>)
+//! 2. A `<layer>/<layer>.toml` file (<https://github.com/buildpacks/spec/blob/main/buildpack.md#layer-content-metadata-toml>)
 //!
-//! The <layer>.toml file can be further broken down into compomponents. First,
+//! The `<layer>.toml` file can be further broken down into components. First,
 //! the `types` key holds information on when a given layer is available
 //! (build, launch, cache) <https://github.com/buildpacks/spec/blob/main/buildpack.md#layer-types>.
 //! Second, the `metadata` key persists buildpack specific data about the layer
@@ -31,7 +31,7 @@
 //! ## Implementing the lifecycle
 //!
 //! The function [`crate::layer_lifecycle::execute_layer_lifecycle`] modifies the
-//! directory and <layer>.toml via the [`LayerLifecycle`] trait which expects the
+//! directory and `<layer>.toml` via the [`LayerLifecycle`] trait which expects the
 //! following user implemented functions:
 //!
 //! Create and update a layer:
@@ -48,7 +48,7 @@
 //!
 //! - [`LayerLifecycle::layer_lifecycle_data`] (defaults to calling `::default`)
 //!
-//! When invalid data is detected via a serilization error (`try_from`)
+//! When invalid data is detected via a serialization error (`try_from`)
 //! there is a mechanism to register a metadata recovery strategy:
 //!
 //! - [`LayerLifecycle::recover_from_invalid_metadata`] (defaults to [`MetadataRecoveryStrategy::DeleteLayer`])
@@ -99,15 +99,15 @@
 //!
 //! ## Metadata recovery
 //!
-//! Metadata is in the <layer>.toml file. TOML data in libcnb is represented by
-//! structs with the `Deserialize` trait from the `serde` library. If the
-//! TOML on disk does not exactly match the format of the struct (and there
-//! are not appropriate defaults) then the deserialization can fail.
+//! Metadata is in the `<layer>.toml` file. TOML data in libcnb is represented
+//! by structs with the `Deserialize` trait from the `serde` library. If a
+//! value is changed (for example a field is changed from a string to an
+//! integer) then deserialization can fail.
 //!
 //! The most common time this would happen is if TOML data was saved by an
-//! older copy of a buildpack, then the developer updated the struct to add
-//! or remove a field, then on the next run the old data from <layer>.toml
-//! cannot deserialize to the new struct and it would fail.
+//! older copy of a buildpack, and the developer updated the struct to add
+//! a field without a default. In that case, on the next run the old data from
+//! `<layer>.toml` cannot deserialize to the new struct, and it would fail.
 //!
 //! When that happens we must tell libcnb what to do. The way to do that is to
 //! specify [`LayerLifecycle::recover_from_invalid_metadata`]. This function


### PR DESCRIPTION
The "layer lifecycle" interface is used by the JVM function invoker https://github.com/heroku/buildpacks-jvm/blob/f7ee3a8e3af657e386ff91d82adfee2fa44cd9ad/buildpacks/jvm-function-invoker/src/build.rs .

Several developers have reported being confused by the purpose of the interface. I was personally not sure why it existed and how all the various functions interacted with each other.

I grabbed a 2-hour pairing session with Ed and we looked at it together to figure out what exactly is going on. For the purposes of addressing part two of https://github.com/Malax/libcnb.rs/issues/103 which is a blocker for https://github.com/Malax/libcnb.rs/milestone/2.

This documentation is a result of those efforts to understand the current state of the "layer lifecycle".

If I could have written some doctests, I would have, however they're blocked by not having an easy way to generate a context for the test environment (stalled PR to implement context builder https://github.com/Malax/libcnb.rs/pull/96).

These docs represent the current state of this feature based on the intentions of the code, however, due to the change in behavior mentioned in https://github.com/Malax/libcnb.rs/issues/103, the behavior of `ValidateResult::KeepLayer` is no longer accurate. Because layers are no longer kept by default, using `ValidateResult::KeepLayer` with CNB spec version `0.6` means the layer actually gets deleted (basically the opposite of "keeping" it).

Despite that, I am suggesting we merge this in based on original intentions, and then update it when we implement a fix for #103. 

I am looking for spelling and grammar edits. (Feel free to make inline suggestions liberally). I'm also looking for feedback around the clarity of my descriptions of behavior. Essentially: did you understand what I wrote? Why or why not?