### PR TITLE
Support the new buildpack.toml `description`, `keywords` and `licenses` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Support the new `buildpack.toml` fields `description`, `keywords` and `licenses`
 - Set a minumim required Rust version of 1.56 and switch to the 2021 Rust edition
 - Stack id in `buildpack.toml` can now be `*` indicating "any" stack
 - LayerContentMetadata values (build, cache, launch) are now under a "types" key


### PR DESCRIPTION
In order to support [Buildpack API 0.6](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.6), we need to handle the new `buildpack.toml` fields `description`, `keywords` and `licenses`:
https://github.com/buildpacks/spec/blob/buildpack/0.6/buildpack.md#buildpacktoml-toml

See:
https://github.com/buildpacks/rfcs/blob/main/text/0070-new-buildpack-toml-keys.md

Closes #100.
GUS-W-10023681.