### PR TITLE
Fix `LayerLifecycle` doctests warning

### DIFF
--- a/src/layer_lifecycle.rs
+++ b/src/layer_lifecycle.rs
@@ -21,7 +21,7 @@
 //!
 //! Example:
 //!
-//! ```no-run
+//! ```ignore
 //! let run_sh_path: PathBuf = execute_layer_lifecycle("opt", OptLayerLifecycle {}, &context)?;
 //! ```
 //!


### PR DESCRIPTION
Here's the warning:

```
   Doc-tests libcnb
warning: unknown attribute `no-run`. Did you mean `no_run`?
   --> /Users/rschneeman/Documents/projects/work/libcnb.rs/src/layer_lifecycle.rs:1:1
    |
1   | / //! Layer Lifecycle controller
2   | | //!
3   | | //! This represents a controller that manages state associated with the lifecycle
4   | | //! of a given layer (CRUD).
...   |
118 | | //! - [`MetadataRecoveryStrategy::ReplaceMetadata<M>`] will replace the old layer
119 | | //!   metadata with the contents in `<M>`
    | |_________________________________________^
    |
    = note: `#[warn(rustdoc::invalid_codeblock_attributes)]` on by default
    = help: the code block will either not be tested if not marked as a rust one or will be run (which you might not want)

warning: 1 warning emitted
```

Changing it to `no_run` causes the tests to fail since it still tries to make sure the code compiles https://doc.rust-lang.org/rustdoc/documentation-tests.html#attributes

Switching to `ignore` skips over it entirely.