### PR TITLE
Move `libcnb-test` TLS support behind a new `remote-docker` feature flag

### DIFF
--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Allow starting a container without using the default process type. Removed `PrepareContainerContext::start`, added `PrepareContainerContext::start_with_default_process`, `PrepareContainerContext::start_with_default_process_args`, `PrepareContainerContext::start_with_process`, `PrepareContainerContext::start_with_process_args`, `PrepareContainerContext::start_with_shell_command` ([#366](https://github.com/Malax/libcnb.rs/pull/366))
 - Add `ContainerContext::logs_now` and `ContainerContext::logs_wait` to access the logs of the container. Useful when used in conjunction with the new `PrepareContainerContext::start_with_shell_command` method to get the shell command output. ([#366](https://github.com/Malax/libcnb.rs/pull/366))
 - Replaced `container_context::ContainerExecResult` with `log::LogOutput` which is now also returned by `ContainerContext::logs` and `ContainerContext::logs_follow`. ([#366](https://github.com/Malax/libcnb.rs/pull/366))
+- Move support for connecting to the Docker daemon over TLS behind a new `remote-docker` feature flag, since remote Docker support is not fully implemented and pulls in many additional dependencies ([#376](https://github.com/Malax/libcnb.rs/pull/376)).
 
 ## [0.2.0] 2022-02-28
 

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 include = ["src/**/*", "../LICENSE", "README.md"]
 
 [dependencies]
-bollard = { version = "0.11.1", features = ["ssl"] }
+bollard = "0.11.1"
 cargo_metadata = "0.14.2"
 fastrand = "1.7.0"
 fs_extra = "1.2.0"
@@ -21,3 +21,9 @@ serde = "1.0.136"
 tempfile = "3.3.0"
 tokio = "1.17.0"
 tokio-stream = "0.1.8"
+
+[features]
+# Enables experimental support for connecting to a remote Docker daemon.
+# Disabled by default since support is only partly implemented, and also
+# results in many more dependencies due to requiring TLS.
+remote-docker = ["bollard/ssl"]

--- a/libcnb-test/README.md
+++ b/libcnb-test/README.md
@@ -46,3 +46,9 @@ fn call_test_fixture_service(addr: std::net::SocketAddr, payload: &str) -> Resul
    unimplemented!()
 }
 ```
+
+## Known issues
+
+- Only local Docker daemons are fully supported. If using Circle CI you must use the
+  [`machine` executor](https://circleci.com/docs/2.0/executor-types/#using-machine) rather
+  than the [remote docker](https://circleci.com/docs/2.0/building-docker-images/) feature.

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -98,6 +98,9 @@ impl IntegrationTest {
             Ok(docker_host)
                 if docker_host.starts_with("tcp://") || docker_host.starts_with("https://") =>
             {
+                #[cfg(not(feature = "remote-docker"))]
+                panic!("Cannot connect to DOCKER_HOST '{docker_host}' since it requires TLS. Please use a local Docker daemon instead (recommended), or else enable the experimental `remote-docker` feature.");
+                #[cfg(feature = "remote-docker")]
                 Docker::connect_with_ssl_defaults()
             }
             Ok(docker_host) => panic!("Cannot connect to unsupported DOCKER_HOST '{docker_host}'"),


### PR DESCRIPTION
Since:
- Remote Docker support is only partly implemented (#307).
- The unimplemented parts can cause user confusion: https://github.com/Malax/libcnb.rs/issues/364#issuecomment-1057246583
- The bollard `ssl` feature adds another 17 dependencies, which are unused by projects not using remote docker (which is all projects at the moment). This dependency count difference will increase to 25, once a new bollard release exists that includes fussybeaver/bollard#204.

Fixes #364.
GUS-W-10801321.