### PR TITLE
Prepare new release of all crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libcnb = "0.6.0"
+libcnb = "0.7.0"
 ```
 
 Since we're writing a Cloud Native Buildpack, we also need a `buildpack.toml`. Use the template below and write it to a

--- a/examples/ruby-sample/Cargo.toml
+++ b/examples/ruby-sample/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.58"
 publish = false
 
 [dependencies]
-flate2 = "1.0.22"
+flate2 = "1.0.23"
 libcnb = { path = "../../libcnb" }
 serde = "1.0.136"
 sha2 = "0.10.2"

--- a/libcnb-cargo/CHANGELOG.md
+++ b/libcnb-cargo/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 
+## [0.4.0] 2022-04-12
+
 - Move the packaging library parts of `libcnb-cargo` to a new `libcnb-package` crate. Consumers of the library should substitute all `libcnb-cargo` references with `libcnb-package` for equivalent functionality. ([#362](https://github.com/heroku/libcnb.rs/pull/362))
+- Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).
 
 ## [0.3.0] 2022-02-28
 

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-cargo"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.58"
 license = "BSD-3-Clause"
@@ -17,13 +17,13 @@ path = "src/main.rs"
 
 [dependencies]
 cargo_metadata = "0.14.2"
-clap = { version = "3.1.1", default-features = false, features = [
+clap = { version = "3.1.8", default-features = false, features = [
   "std",
   "derive",
 ] }
 fs_extra = "1.2.0"
-libcnb-package = { version = "0.1.0", path = "../libcnb-package" }
-log = "0.4.14"
+libcnb-package = { version = "0.1.1", path = "../libcnb-package" }
+log = "0.4.16"
 pathdiff = "0.2.1"
 size_format = "1.0.2"
 stderrlog = "0.5.1"

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
 ## [Unreleased]
+
+## [0.6.0] 2022-04-12
+
 - Make `BuildPlan`'s `or` field public. ([#381](https://github.com/heroku/libcnb.rs/pull/381))
 - Add way to construct `Require` with metadata field and integrate with `BuildPlanBuilder`. ([#382](https://github.com/heroku/libcnb.rs/pull/382))
 - Add way to deserialize `Entry` metadata into a custom type. ([#382](https://github.com/heroku/libcnb.rs/pull/382))
+- Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).
 
 ## [0.5.0] 2022-02-28
 

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-data"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.58"
 license = "BSD-3-Clause"
@@ -13,7 +13,7 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
 fancy-regex = "0.8.0"
-libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.2.0" }
+libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.2.1" }
 serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 toml = "0.5.8"

--- a/libcnb-package/CHANGELOG.md
+++ b/libcnb-package/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.1.1] 2022-04-12
+
+- Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).
+
 ## [0.1.0] 2022-03-08
 
 - Initial release, containing the packaging functionality extracted from `libcnb-cargo` ([#362](https://github.com/heroku/libcnb.rs/pull/362)).

--- a/libcnb-package/Cargo.toml
+++ b/libcnb-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-package"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.58"
 license = "BSD-3-Clause"
@@ -13,6 +13,6 @@ include = ["src/**/*", "../LICENSE", "README.md"]
 
 [dependencies]
 cargo_metadata = "0.14.2"
-libcnb-data = { version = "0.5.0", path = "../libcnb-data" }
+libcnb-data = { version = "0.6.0", path = "../libcnb-data" }
 toml = "0.5.8"
-which = "4.2.4"
+which = "4.2.5"

--- a/libcnb-proc-macros/CHANGELOG.md
+++ b/libcnb-proc-macros/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.2.1] 2022-04-12
+
+- Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).
+
 ## [0.2.0] 2022-02-28
 
 - Add a `verify_bin_target_exists!` macro for verifying existence of binary targets in the current crate. ([#320](https://github.com/heroku/libcnb.rs/pull/320))

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-proc-macros"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.58"
 license = "BSD-3-Clause"
@@ -16,5 +16,5 @@ proc-macro = true
 [dependencies]
 cargo_metadata = "0.14.2"
 fancy-regex = "0.8.0"
-quote = "1.0.15"
-syn = { version = "1.0.86", features = ["full"] }
+quote = "1.0.18"
+syn = { version = "1.0.91", features = ["full"] }

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.3.1] 2022-04-12
+
+- Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).
+
 ## [0.3.0] 2022-03-08
 
 - Add `IntegrationTest::env` and `IntegrationTest::envs`, allowing users to set environment variables for the build process. ([#346](https://github.com/heroku/libcnb.rs/pull/346))
@@ -19,7 +23,7 @@
 - `libcnb-test` now cross-compiles and packages all binary targets of the buildpack for an integration test. The main buildpack binary is either the only binary target or the target with the same name as the crate. This feature allows the usage of additional binaries for i.e. execd. ([#314](https://github.com/heroku/libcnb.rs/pull/314))
 - Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/heroku/libcnb.rs/pull/318)).
 - Add `assert_contains!` macro for easier matching of `pack` output in integration tests. ([#322](https://github.com/heroku/libcnb.rs/pull/322))
-- Fail tests early with a clearer error message, if expected cross-compilation toolchains are not found ([#347](https://github.com/heroku/libcnb.rs/pull/347).
+- Fail tests early with a clearer error message, if expected cross-compilation toolchains are not found ([#347](https://github.com/heroku/libcnb.rs/pull/347)).
 - Update `libcnb-cargo` from `0.2.1` to `0.3.0` - see the [libcnb-cargo changelog](../libcnb-cargo/CHANGELOG.md#030-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
 
 ## [0.1.1] 2022-02-04

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-test"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.58"
 license = "BSD-3-Clause"
@@ -16,7 +16,7 @@ bollard = "0.12.0"
 cargo_metadata = "0.14.2"
 fastrand = "1.7.0"
 fs_extra = "1.2.0"
-libcnb-package = { version = "0.1.0", path = "../libcnb-package" }
+libcnb-package = { version = "0.1.1", path = "../libcnb-package" }
 serde = "1.0.136"
 tempfile = "3.3.0"
 tokio = "1.17.0"

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## [Unreleased]
 
+## [0.7.0] 2022-04-12
+
 - Allow compilation of libcnb.rs buildpacks on Windows. Please note that this does not imply Windows container support, it's meant to allow running unit tests without cross-compiling. ([#368](https://github.com/heroku/libcnb.rs/pull/368))
 - Expose `runtime::libcnb_runtime_detect`, `runtime::libcnb_runtime_build` and their related types for advanced use-cases. Buildpack authors should not use these. ([#375](https://github.com/heroku/libcnb.rs/pull/375)).
 - Only create layer `env`, `env.build` and `env.launch` directories when environment variables are being set within them ([#385](https://github.com/heroku/libcnb.rs/pull/385)).
 - Add `WriteLayerError::MissingExecDFile` error to ease debugging when an exec.d path is missing ([#387](https://github.com/heroku/libcnb.rs/pull/387)).
+- Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).
+- Update `libcnb-data` (which provides the types in the `data` module) from `0.5.0` to `0.6.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#060-2022-04-12) ([#391](https://github.com/heroku/libcnb.rs/pull/391)).
 
 ## [0.6.0] 2022-02-28
 

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.58"
 license = "BSD-3-Clause"
@@ -12,9 +12,9 @@ readme = "../README.md"
 include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
-anyhow = { version = "1.0.55", optional = true }
-libcnb-data = { path = "../libcnb-data", version = "0.5.0" }
-libcnb-proc-macros = { version = "0.2.0", path = "../libcnb-proc-macros" }
+anyhow = { version = "1.0.56", optional = true }
+libcnb-data = { path = "../libcnb-data", version = "0.6.0" }
+libcnb-proc-macros = { version = "0.2.1", path = "../libcnb-proc-macros" }
 serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 toml = "0.5.8"


### PR DESCRIPTION
To pick up the crate metadata updates for the repository move, as well as a handful of not yet released other changes.

I've added a mention of the repo move to the changelogs to:
(a) raise awareness (eg for updating git remotes)
(b) so it's clearer why the crates with no other changes (aside from the metadata) have been released.

I've also used `cargo upgrade` to bump the in-range (ie: patch) dependency versions (technically a no-op given how cargo version resolution works, but will help keep deps up to date for projects that don't manually refresh their lockfile).

The release will be performed following the process documented in #335.

GUS-W-10969178.