### PR TITLE
Add IntegrationTest::app_dir_preprocessor

### DIFF
--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add `IntegrationTest::app_dir_preprocessor`, allowing users to modify the app directory before an integration test run ([#000](https://github.com/heroku/libcnb.rs/pull/000)).
+
 ## [0.3.1] 2022-04-12
 
 - Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Add `IntegrationTest::app_dir_preprocessor`, allowing users to modify the app directory before an integration test run ([#000](https://github.com/heroku/libcnb.rs/pull/000)).
+- Add `IntegrationTest::app_dir_preprocessor`, allowing users to modify the app directory before an integration test run ([#397](https://github.com/heroku/libcnb.rs/pull/397)).
 
 ## [0.3.1] 2022-04-12
 


### PR DESCRIPTION
This allows users to have the app directory (test fixture) to be modified in a safe way, just before the
integration test runs.

## Usage Example

This is a `cutlass` test ported to `libcnb-test` for `heroku/maven`. Original cutlass test can be found here: https://github.com/heroku/buildpacks-jvm/blob/e91747a4310d566a2ecf3b88ce94ed86744c6346/test/specs/maven/misc_spec.rb#L3-L13

```rust
#[test]
#[cfg(target_family = "unix")]
pub fn maven_wrapper_executable_bit() {
    IntegrationTest::new(BUILDER_NAME, "../../test/fixtures/simple-http-service")
        .buildpacks(vec![
            BuildpackReference::Other(String::from("heroku/jvm")),
            BuildpackReference::Crate,
        ])
        .app_dir_preprocessor(|app_dir| {
            use std::os::unix::fs::PermissionsExt;
            fs::set_permissions(app_dir.join("mvnw"), Permissions::from_mode(0o444)).unwrap();
        })
        .run_test(|context| {
            assert_contains!(context.pack_stdout, "Successfully built image");
        });
}
```

Closes GUS-W-11177468