### PR TITLE
Switch to `heroku/builder:22` in docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ version = "0.1.0"
 name = "My Buildpack"
 
 [[stacks]]
-id = "heroku-20"
+id = "*"
 ```
 
 That's all we need! We can now move on to finally write some buildpack code!
@@ -179,14 +179,14 @@ In your project directory, run `cargo libcnb package` to start packaging:
 $ cargo libcnb package
 INFO - Reading buildpack metadata...
 INFO - Found buildpack libcnb-examples/my-buildpack with version 0.1.0.
-INFO - Building buildpack binary (x86_64-unknown-linux-musl)...
-Compiling my-buildpack v0.1.0 (/Users/manuel.fuchs/projects/my-buildpack)
+INFO - Determining automatic cross-compile settings...
+INFO - Building binaries (x86_64-unknown-linux-musl)...
 # Omitting compilation output...
-Finished dev [unoptimized + debuginfo] target(s) in 2.67s
+    Finished dev [unoptimized + debuginfo] target(s) in 4.29s
 INFO - Writing buildpack directory...
-INFO - Successfully wrote buildpack directory: target/debug/libcnb-examples_my-buildpack_0.1.0 (53.1M)
+INFO - Successfully wrote buildpack directory: target/buildpack/debug/libcnb-examples_my-buildpack (55.5M)
 INFO - Packaging successfully finished!
-INFO - Hint: To test your buildpack locally with pack, run: pack build my-image --buildpack target/debug/libcnb-examples_my-buildpack_0.1.0 --path /path/to/application
+INFO - Hint: To test your buildpack locally with pack, run: pack build my-image --buildpack target/buildpack/debug/libcnb-examples_my-buildpack --path /path/to/application
 ```
 
 If you get errors with hints about how to install required tools to cross-compile from your host platform to the
@@ -201,31 +201,33 @@ application code at all, we just create an empty directory and use that as our a
 
 ```shell
 $ mkdir bogus-app
-$ pack build my-image --buildpack target/debug/libcnb-examples_my-buildpack_0.1.0 --path bogus-app --builder heroku/buildpacks:20
-20: Pulling from heroku/buildpacks
-Digest: sha256:04e8ea7a1f482f289d432d9518edcfaaf9f3a10432cd1b624e58225f22e7c416
-Status: Image is up to date for heroku/buildpacks:20
-20: Pulling from heroku/pack
-Digest: sha256:21ea4b85bc937b47e017bf43136a5295ec08e093e3c210b20e69e9c1b0f2bd57
-Status: Image is up to date for heroku/pack:20
+$ pack build my-image --buildpack target/buildpack/debug/libcnb-examples_my-buildpack --path bogus-app --builder heroku/builder:22
+22: Pulling from heroku/builder
+Digest: sha256:0e1db52b480805c63b793a1c0155ea30cabffbf7977f722c88dc42cef750a1d1
+Status: Image is up to date for heroku/builder:22
+22-cnb: Pulling from heroku/heroku
+Digest: sha256:3fd7866f22dcbcd3a72c7ab4b47728dcfbaacfa9730341d0fb10665f63d93788
+Status: Image is up to date for heroku/heroku:22-cnb
+===> ANALYZING
+Previous image with name "my-image" not found
 ===> DETECTING
 libcnb-examples/my-buildpack 0.1.0
-===> ANALYZING
-Skipping buildpack layer analysis
+===> RESTORING
 ===> BUILDING
 Hello World!
-Build runs on stack heroku-20!
+Build runs on stack heroku-22!
 ===> EXPORTING
-Reusing 1/1 app layer(s)
-Reusing layer 'launcher'
-Reusing layer 'config'
-Reusing layer 'process-types'
+Adding layer 'launch.sbom'
+Adding 1/1 app layer(s)
+Adding layer 'launcher'
+Adding layer 'config'
+Adding layer 'process-types'
 Adding label 'io.buildpacks.lifecycle.metadata'
 Adding label 'io.buildpacks.build.metadata'
 Adding label 'io.buildpacks.project.metadata'
 Setting default process type 'web'
 Saving my-image...
-*** Images (d4f67a828236):
+*** Images (24eed75bb2e6):
       my-image
 Successfully built image my-image
 ```

--- a/examples/execd/tests/integration_test.rs
+++ b/examples/execd/tests/integration_test.rs
@@ -12,7 +12,7 @@ use libcnb_test::{assert_contains, IntegrationTest};
 #[test]
 #[ignore]
 fn basic() {
-    IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/empty-app").run_test(|context| {
+    IntegrationTest::new("heroku/builder:22", "test-fixtures/empty-app").run_test(|context| {
         context
             .prepare_container()
             .start_with_shell_command("env", |container| {

--- a/libcnb-test/README.md
+++ b/libcnb-test/README.md
@@ -19,7 +19,7 @@ use libcnb_test::{IntegrationTest, BuildpackReference, assert_contains};
 
 #[test]
 fn test() {
-    IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/app")
+    IntegrationTest::new("heroku/builder:22", "test-fixtures/app")
         .buildpacks(vec![
             BuildpackReference::Other(String::from("heroku/openjdk")),
             BuildpackReference::Crate,

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -40,7 +40,7 @@ impl<'a> PrepareContainerContext<'a> {
     /// ```no_run
     /// use libcnb_test::IntegrationTest;
     ///
-    /// IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/app").run_test(|context| {
+    /// IntegrationTest::new("heroku/builder:22", "test-fixtures/app").run_test(|context| {
     ///     context
     ///         .prepare_container()
     ///         .env("FOO", "FOO_VALUE")
@@ -60,7 +60,7 @@ impl<'a> PrepareContainerContext<'a> {
     /// ```no_run
     /// use libcnb_test::IntegrationTest;
     ///
-    /// IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/app").run_test(|context| {
+    /// IntegrationTest::new("heroku/builder:22", "test-fixtures/app").run_test(|context| {
     ///     context
     ///         .prepare_container()
     ///         .envs(vec![("FOO", "FOO_VALUE"), ("BAR", "BAR_VALUE")])

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -39,7 +39,7 @@ use std::process::{Command, Stdio};
 /// # fn call_test_fixture_service(addr: std::net::SocketAddr, payload: &str) -> Result<String, ()> {
 /// #    unimplemented!()
 /// # }
-/// IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/app")
+/// IntegrationTest::new("heroku/builder:22", "test-fixtures/app")
 ///     .buildpacks(vec![
 ///         BuildpackReference::Other(String::from("heroku/openjdk")),
 ///         BuildpackReference::Crate,
@@ -153,7 +153,7 @@ impl IntegrationTest {
     /// ```no_run
     /// use libcnb_test::IntegrationTest;
     ///
-    /// IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/app")
+    /// IntegrationTest::new("heroku/builder:22", "test-fixtures/app")
     ///     .env("ENV_VAR_ONE", "VALUE ONE")
     ///     .env("ENV_VAR_TWO", "SOME OTHER VALUE")
     ///     .run_test(|context| {
@@ -174,7 +174,7 @@ impl IntegrationTest {
     /// ```no_run
     /// use libcnb_test::IntegrationTest;
     ///
-    /// IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/app")
+    /// IntegrationTest::new("heroku/builder:22", "test-fixtures/app")
     ///     .envs(vec![("ENV_VAR_ONE", "VALUE ONE"), ("ENV_VAR_TWO", "SOME OTHER VALUE")])
     ///     .run_test(|context| {
     ///         // ...
@@ -203,7 +203,7 @@ impl IntegrationTest {
     /// ```no_run
     /// use libcnb_test::IntegrationTest;
     ///
-    /// IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/app")
+    /// IntegrationTest::new("heroku/builder:22", "test-fixtures/app")
     ///     .app_dir_preprocessor(|app_dir| {
     ///         std::fs::remove_file(app_dir.join("Procfile")).unwrap()
     ///     })
@@ -235,7 +235,7 @@ impl IntegrationTest {
     /// ```no_run
     /// use libcnb_test::{IntegrationTest, assert_contains};
     ///
-    /// IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/app")
+    /// IntegrationTest::new("heroku/builder:22", "test-fixtures/app")
     ///     .run_test(|context| {
     ///         assert_contains!(context.pack_stdout, "---> Ruby Buildpack");
     ///         assert_contains!(context.pack_stdout, "---> Installing bundler");
@@ -354,7 +354,7 @@ impl<'a> IntegrationTestContext<'a> {
     /// ```no_run
     /// use libcnb_test::IntegrationTest;
     ///
-    /// IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/empty-app").run_test(|context| {
+    /// IntegrationTest::new("heroku/builder:22", "test-fixtures/empty-app").run_test(|context| {
     ///     context.prepare_container().start_with_default_process(|container| {
     ///         // ...
     ///     });


### PR DESCRIPTION
Since it supersedes `heroku/buildpacks:20`:
https://github.com/heroku/builder#heroku-builder-images

Whilst updating the example build output in the README, I noticed that the specified commands were incorrect (eg wrong buildpack `--path`), so those have been fixed. In addition, I've switched the hello world example to use the wildcard stack, since the code is not stack-specific, and it will save us having to remember to update it in the future.

Lastly, updating the Ruby example buildpack to `heroku/builder:22` revealed that the buildpack was actually broken and relying on system Ruby, so that buildpack has been excluded from using the new builder until that is resolved (#398).