### PR TITLE
Switch to the recommended regional S3 domain

### DIFF
--- a/examples/ruby-sample/buildpack.toml
+++ b/examples/ruby-sample/buildpack.toml
@@ -9,4 +9,4 @@ name = "Example libcnb buildpack: ruby"
 id = "heroku-20"
 
 [metadata]
-ruby_url = "https://heroku-buildpack-ruby.s3.amazonaws.com/heroku-20/ruby-2.7.4.tgz"
+ruby_url = "https://heroku-buildpack-ruby.s3.us-east-1.amazonaws.com/heroku-20/ruby-2.7.4.tgz"


### PR DESCRIPTION
Whilst the global S3 endpoint (`s3.amazonaws.com`) still works, AWS now recommends using the appropriate regional endpoint to access the bucket:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#s3-legacy-endpoints

The example Ruby buildpack's bucket is in `us-east-1`, whose regional domain is `*.s3.us-east-1.amazonaws.com`:
https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region

GUS-W-11283397.