### PR TITLE
Add FromIterator<Process> for Launch

### DIFF
--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -43,6 +43,18 @@ impl Launch {
     }
 }
 
+impl FromIterator<Process> for Launch {
+    fn from_iter<I: IntoIterator<Item = Process>>(process_iter: I) -> Self {
+        let mut launch = Launch::new();
+
+        for process in process_iter {
+            launch = launch.process(process);
+        }
+
+        launch
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Label {
@@ -347,5 +359,15 @@ default = true
                 default: false
             }
         );
+    }
+
+    #[test]
+    fn launch_from_iterator() {
+        let launch: Launch = ["web", "worker"]
+            .iter()
+            .map(|name| ProcessBuilder::new(name.parse().unwrap(), name.to_string()).build())
+            .collect();
+
+        assert_eq!(launch.processes[0].command, "web");
     }
 }

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -365,7 +365,7 @@ default = true
     fn launch_from_iterator() {
         let launch: Launch = ["web", "worker"]
             .iter()
-            .map(|name| ProcessBuilder::new(name.parse().unwrap(), name.to_string()).build())
+            .map(|&name| ProcessBuilder::new(name.parse().unwrap(), name).build())
             .collect();
 
         assert_eq!(launch.processes[0].command, "web");

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Introduce `impl FromIterator<Process> for Launch` to make it easier to build
+  dynamic `Launch` tables. ([#401](https://github.com/heroku/libcnb.rs/pull/401))
+
 ## [0.7.0] 2022-04-12
 
 - Allow compilation of libcnb.rs buildpacks on Windows. Please note that this does not imply Windows container support, it's meant to allow running unit tests without cross-compiling. ([#368](https://github.com/heroku/libcnb.rs/pull/368))


### PR DESCRIPTION
Currently, collecting a dynamically created list of `Process`es into a `Launch` has to be done manually. Something like this:

```rust
let mut launch = Launch::new();
let procs: Vec<Process> = ["web", "worker"]
    .iter()
    .map(|name| ProcessBuilder::new(name.parse().unwrap(), name.to_string()).build())
    .collect();
for proc in procs.iter() {
    launch = launch.process(proc.clone());
}
```

With a `FromIterator`, it gets a bit easier:

```rust
let launch: Launch = ["web", "worker"]
    .iter()
    .map(|name| ProcessBuilder::new(name.parse().unwrap(), name.to_string()).build())
    .collect();
```