### PR TITLE
libcnb-test: Pass `--trust-builder` to `pack build`

### DIFF
--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Pass `--trust-builder` to `pack build` to ensure the builders used in tests are always trusted ([#409](https://github.com/heroku/libcnb.rs/pull/409)).
 - Add `IntegrationTest::app_dir_preprocessor`, allowing users to modify the app directory before an integration test run ([#397](https://github.com/heroku/libcnb.rs/pull/397)).
 
 ## [0.3.1] 2022-04-12


### PR DESCRIPTION
In order to:
- Normalise build log output in tests across environments - so multi-line log output assertions don't pass on one machine and fail on another (as happened in `procfile-cnb` for local vs CI), due to the untrusted-builder-only `[<stage>]` log output prefixes.
- Avoid having to add `pack config trusted-builders add ZZZZ` boilerplate to all of our CI configs.
- Speed up test execution.

This should be safe to do, since:
- `libcnb-test` doesn't publish images or pass in credentials (one of the concerns of using an untrusted builder)
- projects using `libcnb-test` will have chosen/vetted their test images (so it's a bit different from the "end user experimenting with random builders they found on the internet" case)
- by compiling/running a Rust `libcnb.rs`-using project on your local machine you are already running a bunch of untrusted code, so you either trust the author of that buildpack or you don't.

See the issue description for more details.

Fixes #407.
GUS-W-11312254.