### PR TITLE
Fix `libcnb_newtype!` doctest on Rust 1.62+

### DIFF
--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -21,12 +21,15 @@
 /// calls that might fail at runtime.
 ///
 /// # Usage:
-/// ```
+// This has to use compile_fail since `libcnb_newtype` is not public.
+/// ```compile_fail
+/// use crate::newtypes::libcnb_newtype;
+///
 /// libcnb_newtype!(
 ///     // The module of this crate that exports the newtype publicly. Since it might differ from
 ///     // the actual module structure, the macro needs a way to determine how to import the type
 ///     // from a user's buildpack crate.
-///     tests::doctest
+///     buildpack
 ///     /// RustDoc for the macro (optional)
 ///     buildpack_id,
 ///     /// RustDoc for the newtype itself (optional)


### PR DESCRIPTION
As of Rust 1.62, doctests that contain non-exported `macro_rules!` macros are now tested, when they were not before.

This causes `cargo test` to fail for this repository, due to the `libcnb_newtype!` doctest trying to test a private macro.

Doctests can only test things that are public, so we can to either:
1. Make `libcnb_newtype!` public.
2. Annotate the doctest with `compile_fail`, so failure is expected.
3. Remove the example from the doctest.

I've gone with option (2), since it's useful to have the example (so that people working on libcnb's codebase can use the macro more easily), however the macro is really an internal thing, so I don't think we want to export it publicly.

Fixes #410.
GUS-W-11312457.