### PR TITLE
Leverage `Into` trait for `String`/`&str` arguments in `ContainerContext`

### DIFF
--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Leverage `Into` trait for `String`/`&str` arguments in `ContainerContext` ([#412](https://github.com/heroku/libcnb.rs/pull/412)).
 - Pass `--trust-builder` to `pack build` to ensure the builders used in tests are always trusted ([#409](https://github.com/heroku/libcnb.rs/pull/409)).
 - Add `IntegrationTest::app_dir_preprocessor`, allowing users to modify the app directory before an integration test run ([#397](https://github.com/heroku/libcnb.rs/pull/397)).
 

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -119,8 +119,12 @@ impl<'a> PrepareContainerContext<'a> {
     /// # Panics
     /// - When the container could not be created
     /// - When the container could not be started
-    pub fn start_with_process<F: FnOnce(ContainerContext)>(&self, process: String, f: F) {
-        self.start_internal(Some(vec![process]), None, f);
+    pub fn start_with_process<F: FnOnce(ContainerContext), P: Into<String>>(
+        &self,
+        process: P,
+        f: F,
+    ) {
+        self.start_internal(Some(vec![process.into()]), None, f);
     }
 
     /// Creates and starts the container configured by this context using the given CNB process
@@ -135,14 +139,15 @@ impl<'a> PrepareContainerContext<'a> {
         F: FnOnce(ContainerContext),
         A: IntoIterator<Item = I>,
         I: Into<String>,
+        P: Into<String>,
     >(
         &self,
-        process: String,
+        process: P,
         args: A,
         f: F,
     ) {
         self.start_internal(
-            Some(vec![process]),
+            Some(vec![process.into()]),
             Some(args.into_iter().map(I::into).collect()),
             f,
         );
@@ -158,13 +163,17 @@ impl<'a> PrepareContainerContext<'a> {
     /// # Panics
     /// - When the container could not be created
     /// - When the container could not be started
-    pub fn start_with_shell_command<F: FnOnce(ContainerContext)>(&self, command: &str, f: F) {
+    pub fn start_with_shell_command<F: FnOnce(ContainerContext), C: Into<String>>(
+        &self,
+        command: C,
+        f: F,
+    ) {
         self.start_internal(
             Some(vec![String::from(CNB_LAUNCHER_PATH)]),
             Some(vec![
                 String::from(SHELL_PATH),
                 String::from("-c"),
-                String::from(command),
+                command.into(),
             ]),
             f,
         );


### PR DESCRIPTION
Functions in `ContainerContext` used concrete string types in some places that could easily replaced with a generic `Into<String>`. In most cases, conversion to `String` was happening anyway. This change just exposes this via the API, allowing the user to pass in anything that can be turned into a `String`, improving DX.

Fixes #405 