### PR TITLE
Only create `.libcnb-cargo/additional-bin` if there are additional binaries

### DIFF
--- a/libcnb-package/CHANGELOG.md
+++ b/libcnb-package/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Only create `.libcnb-cargo/additional-bin` if there are additional binaries to bundle ([#413](https://github.com/heroku/libcnb.rs/pull/413)).
+
 ## [0.1.1] 2022-04-12
 
 - Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).

--- a/libcnb-package/src/lib.rs
+++ b/libcnb-package/src/lib.rs
@@ -85,18 +85,21 @@ pub fn assemble_buildpack_directory(
 
     create_file_symlink("build", bin_path.join("detect"))?;
 
-    let additional_binaries_dir = destination_path
-        .as_ref()
-        .join(".libcnb-cargo")
-        .join("additional-bin");
+    if !buildpack_binaries.additional_target_binary_paths.is_empty() {
+        let additional_binaries_dir = destination_path
+            .as_ref()
+            .join(".libcnb-cargo")
+            .join("additional-bin");
 
-    fs::create_dir_all(&additional_binaries_dir)?;
+        fs::create_dir_all(&additional_binaries_dir)?;
 
-    for (binary_target_name, binary_path) in &buildpack_binaries.additional_target_binary_paths {
-        fs::copy(
-            binary_path,
-            additional_binaries_dir.join(binary_target_name),
-        )?;
+        for (binary_target_name, binary_path) in &buildpack_binaries.additional_target_binary_paths
+        {
+            fs::copy(
+                binary_path,
+                additional_binaries_dir.join(binary_target_name),
+            )?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Previously the packaged buildpack would contain an empty `.libcnb-cargo/additional-bin` directory, even if there were no additional `exec.d` binaries being bundled in the buildpack.