### PR TITLE
Make `Buildpack::on_error` phase aware and fix `Buildpack::on_error` default implementation

### DIFF
--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- `Buildpack::on_error` now gets passed a `libcnb::BuildpackPhase` value. This allows error handling based on the currently executing phase. This is particularly useful since the CNB specification assigns different meanings for exit codes based on the current phase. ([#414](https://github.com/heroku/libcnb.rs/pull/414)).
+- The default `Buildpack::on_error` implementation now uses exit code `1` instead of `100`. The previously used exit code signalled a failed detect instead of an error during the detect phase. ([#414](https://github.com/heroku/libcnb.rs/pull/414)).
+
 ## [0.7.0] 2022-04-12
 
 - Allow compilation of libcnb.rs buildpacks on Windows. Please note that this does not imply Windows container support, it's meant to allow running unit tests without cross-compiling. ([#368](https://github.com/heroku/libcnb.rs/pull/368))

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -42,7 +42,7 @@ pub trait Buildpack {
     /// collect and send metrics about occurring errors to a central system.
     ///
     /// The default implementation will simply print the error
-    /// (using its [`Display`](std::fmt::Display) implementation) to stderr.
+    /// (using its [`Display`](std::fmt::Display) implementation) to stderr and exits with code 1.
     fn on_error(
         &self,
         #[allow(unused_variables)] phase: BuildpackPhase,
@@ -51,6 +51,6 @@ pub trait Buildpack {
         eprintln!("Unhandled error:");
         eprintln!("> {:?}", error);
         eprintln!("Buildpack will exit!");
-        100
+        1
     }
 }

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -1,6 +1,6 @@
 use crate::build::{BuildContext, BuildResult};
 use crate::detect::{DetectContext, DetectResult};
-use crate::Platform;
+use crate::{BuildpackPhase, Platform};
 use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 
@@ -43,7 +43,11 @@ pub trait Buildpack {
     ///
     /// The default implementation will simply print the error
     /// (using its [`Display`](std::fmt::Display) implementation) to stderr.
-    fn on_error(&self, error: crate::Error<Self::Error>) -> i32 {
+    fn on_error(
+        &self,
+        #[allow(unused_variables)] phase: BuildpackPhase,
+        error: crate::Error<Self::Error>,
+    ) -> i32 {
         eprintln!("Unhandled error:");
         eprintln!("> {:?}", error);
         eprintln!("Buildpack will exit!");

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -125,6 +125,14 @@ macro_rules! additional_buildpack_binary_path {
     };
 }
 
+/// Cloud Native Buildpacks phase
+pub enum BuildpackPhase {
+    /// See: <https://github.com/buildpacks/spec/blob/main/buildpack.md#phase-1-detection>
+    Detect,
+    /// See: <https://github.com/buildpacks/spec/blob/main/buildpack.md#phase-3-build>
+    Build,
+}
+
 // This runs the README.md as a doctest, ensuring the code examples in it are valid.
 // It will not be part of the final crate.
 #[cfg(doctest)]


### PR DESCRIPTION
`Buildpack::on_error` now gets passed a `libcnb::BuildpackPhase` value. This allows error handling based on the currently executing phase. This is particularly useful since the CNB specification assigns different meanings for exit codes based on the current phase. 

The default `Buildpack::on_error` implementation now uses exit code `1` instead of `100`. The previously used exit code signalled a failed detect instead of an error during the detect phase. See #286 for details.

Fixes #286 