### PR TITLE
Remove custom exit codes from `Buildpack::on_error`

### DIFF
--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Remove support for custom exit codes from `Buildpack::on_error`. Exit codes are part of the CNB spec and there are cases where some exit codes have special meaning to the CNB lifecycle. This put the burden on the buildpack author to not pick exit codes with special meanings, dependent on the currently executing phase. This makes `Buildpack::on_error` more consistent with the rest of the framework where we don't expose the interface between the buildpack and the CNB lifecycle directly but use abstractions for easier forward-compatibility and to prevent accidental misuse. ([#415](https://github.com/heroku/libcnb.rs/pull/415)).
+
 ## [0.7.0] 2022-04-12
 
 - Allow compilation of libcnb.rs buildpacks on Windows. Please note that this does not imply Windows container support, it's meant to allow running unit tests without cross-compiling. ([#368](https://github.com/heroku/libcnb.rs/pull/368))

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -43,10 +43,9 @@ pub trait Buildpack {
     ///
     /// The default implementation will simply print the error
     /// (using its [`Display`](std::fmt::Display) implementation) to stderr.
-    fn on_error(&self, error: crate::Error<Self::Error>) -> i32 {
+    fn on_error(&self, error: crate::Error<Self::Error>) {
         eprintln!("Unhandled error:");
         eprintln!("> {:?}", error);
         eprintln!("Buildpack will exit!");
-        100
     }
 }

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -40,7 +40,8 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
             }
         }
         Err(lib_cnb_error) => {
-            exit(buildpack.on_error(lib_cnb_error));
+            buildpack.on_error(lib_cnb_error);
+            exit(1);
         }
     }
 
@@ -92,7 +93,10 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
 
     match result {
         Ok(code) => exit(code),
-        Err(lib_cnb_error) => exit(buildpack.on_error(lib_cnb_error)),
+        Err(lib_cnb_error) => {
+            buildpack.on_error(lib_cnb_error);
+            exit(1);
+        }
     }
 }
 


### PR DESCRIPTION
Remove support for custom exit codes from `Buildpack::on_error`. Exit codes are part of the CNB spec and there are cases where some exit codes have special meaning to the CNB lifecycle. This put the burden on the buildpack author to not pick exit codes with special meanings, dependent on the currently executing phase. This makes `Buildpack::on_error` more consistent with the rest of the framework where we don't expose the interface between the buildpack and the CNB lifecycle directly but use abstractions for easier forward-compatibility and to prevent accidental misuse.

We actually made the mistake ourselves (#286) and had the default `Buildpack::on_error` implementation return `100` which means "failed detect" during detect instead of properly signalling an error.

Fixes #286 