### PR TITLE
Replace magic exit code values with constants

### DIFF
--- a/libcnb-cargo/src/exit_code.rs
+++ b/libcnb-cargo/src/exit_code.rs
@@ -1,0 +1,1 @@
+pub(crate) const UNSPECIFIED_ERROR: i32 = 1;

--- a/libcnb-cargo/src/main.rs
+++ b/libcnb-cargo/src/main.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 mod cli;
+mod exit_code;
 
 use crate::cli::{Cli, LibcnbSubcommand, PackageArgs};
 use cargo_metadata::MetadataCommand;
@@ -41,7 +42,7 @@ fn handle_libcnb_package(args: PackageArgs) {
         Ok(current_dir) => current_dir,
         Err(io_error) => {
             error!("Could not determine current directory: {io_error}");
-            std::process::exit(1);
+            std::process::exit(exit_code::UNSPECIFIED_ERROR);
         }
     };
 
@@ -60,7 +61,7 @@ fn handle_libcnb_package(args: PackageArgs) {
                 }
             }
 
-            std::process::exit(1);
+            std::process::exit(exit_code::UNSPECIFIED_ERROR);
         }
     };
 
@@ -77,7 +78,7 @@ fn handle_libcnb_package(args: PackageArgs) {
         Ok(cargo_metadata) => cargo_metadata,
         Err(error) => {
             error!("Could not obtain metadata from Cargo: {error}");
-            std::process::exit(1);
+            std::process::exit(exit_code::UNSPECIFIED_ERROR);
         }
     };
 
@@ -104,7 +105,7 @@ fn handle_libcnb_package(args: PackageArgs) {
             CrossCompileAssistance::HelpText(help_text) => {
                 error!("{help_text}");
                 info!("To disable cross-compile assistance, pass --no-cross-compile-assistance.");
-                std::process::exit(1);
+                std::process::exit(exit_code::UNSPECIFIED_ERROR);
             }
             CrossCompileAssistance::NoAssistance => {
                 warn!("Could not determine automatic cross-compile settings for target triple {target_triple}.");
@@ -151,7 +152,7 @@ fn handle_libcnb_package(args: PackageArgs) {
                 }
             }
 
-            std::process::exit(1);
+            std::process::exit(exit_code::UNSPECIFIED_ERROR);
         }
     };
 
@@ -159,7 +160,7 @@ fn handle_libcnb_package(args: PackageArgs) {
     if output_path.exists() {
         if let Err(error) = fs::remove_dir_all(&output_path) {
             error!("Could not remove buildpack directory: {error}");
-            std::process::exit(1);
+            std::process::exit(exit_code::UNSPECIFIED_ERROR);
         };
     }
 
@@ -169,7 +170,7 @@ fn handle_libcnb_package(args: PackageArgs) {
         &buildpack_binaries,
     ) {
         error!("IO error while writing buildpack directory: {io_error}");
-        std::process::exit(1);
+        std::process::exit(exit_code::UNSPECIFIED_ERROR);
     };
 
     info!(
@@ -191,6 +192,6 @@ fn setup_logging() {
         .init()
     {
         eprintln!("Unable to initialize logger: {error}");
-        std::process::exit(1);
+        std::process::exit(exit_code::UNSPECIFIED_ERROR);
     }
 }

--- a/libcnb/src/exit_code.rs
+++ b/libcnb/src/exit_code.rs
@@ -1,0 +1,12 @@
+///! libcnb exit code constants
+///
+/// Constants are prefixed with the phase they're valid for since their meaning can change between
+/// different CNB phases.
+
+pub(crate) const GENERIC_SUCCESS: i32 = 0;
+pub(crate) const GENERIC_UNSPECIFIED_ERROR: i32 = 1;
+pub(crate) const GENERIC_CNB_API_MISMATCH_ERROR: i32 = 254;
+pub(crate) const GENERIC_UNEXPECTED_EXECUTABLE_NAME_ERROR: i32 = 255;
+
+pub(crate) const DETECT_DETECTION_PASSED: i32 = 0;
+pub(crate) const DETECT_DETECTION_FAILED: i32 = 100;

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -26,6 +26,7 @@ pub mod internals;
 mod buildpack;
 mod env;
 mod error;
+mod exit_code;
 mod platform;
 mod runtime;
 mod toml_file;


### PR DESCRIPTION
Replace magic exit code values with constants.

In https://github.com/heroku/libcnb.rs/pull/415#pullrequestreview-1012086445, @edmorley brought up that we might not even want to return `i32` exit codes from `libcnb_runtime_detect` and `libcnb_runtime_build`.

Both functions are public, but really only used in _very advanced_ use-cases where `libcnb_runtime` isn't used. If we consider these functions practically private, then I don't think adding a layer of types in-between is of high-value. If we would copy their implementations directly to `libcnb_runtime` (their only internal call-site), we would not introduce additional types.

Considering these functions _are_ public, it might even be beneficial to keep their return values as-is, since this frees users of these functions to map between types to CNB compliant exit codes, removing CNB specific logic from the users code.