### PR TITLE
Fix `Buildpack::on_error` rustdoc

### DIFF
--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -42,7 +42,7 @@ pub trait Buildpack {
     /// collect and send metrics about occurring errors to a central system.
     ///
     /// The default implementation will simply print the error
-    /// (using its [`Display`](std::fmt::Display) implementation) to stderr.
+    /// (using its [`Debug`](std::fmt::Debug) implementation) to stderr.
     fn on_error(&self, error: crate::Error<Self::Error>) {
         eprintln!("Unhandled error:");
         eprintln!("> {:?}", error);


### PR DESCRIPTION
Originally reported by @edmorley here: https://github.com/heroku/libcnb.rs/pull/415#discussion_r901536265