### PR TITLE
Add `Launch::processes`

### DIFF
--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Add `Launch::processes` function to add multiple `Process`es to a `Launch` value at once. ([#418](https://github.com/heroku/libcnb.rs/pull/418)) 
+- `Launch::process`'s argument changed from `Process` to `Into<Process>`. ([#418](https://github.com/heroku/libcnb.rs/pull/418))
+
 ## [0.6.0] 2022-04-12
 
 - Make `BuildPlan`'s `or` field public. ([#381](https://github.com/heroku/libcnb.rs/pull/381))


### PR DESCRIPTION
Adds the ability to add multiple processes to a `Launch`. This can be useful when processes are created programatically and need to be added. This came out of https://github.com/heroku/libcnb.rs/pull/401, where I proposed the solution in this PR as an alternative: https://github.com/heroku/libcnb.rs/pull/401#issuecomment-1160150599.

I don't think we'll merge #401, but even if we would, both the function in this PR and the `FromIterator` implementation from #401 can co-exist.

Minor improvements also included in this PR:

- Add rudimentary RustDoc for `Launch::process`
- Make `Launch::process` argument generic (`Into<Process>`)
- Add rudimentary unit tests for `Launch::process` and `Launch::processes`