### PR TITLE
Add changelog entries for recent dependency upgrades

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -11,8 +11,7 @@ jobs:
       !contains(github.event.pull_request.body, '[skip changelog]') &&
       !contains(github.event.pull_request.body, '[changelog skip]') &&
       !contains(github.event.pull_request.body, '[skip ci]') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip changelog') &&
-      !contains(github.event.pull_request.labels.*.name, 'dependencies')
+      !contains(github.event.pull_request.labels.*.name, 'skip changelog')
     steps:
       - uses: actions/checkout@v3
       - name: Check that CHANGELOG is touched

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `Launch::processes` function to add multiple `Process`es to a `Launch` value at once. ([#418](https://github.com/heroku/libcnb.rs/pull/418)) 
 - `Launch::process`'s argument changed from `Process` to `Into<Process>`. ([#418](https://github.com/heroku/libcnb.rs/pull/418))
+- Update `fancy-regex` dependency from 0.8.0 to 0.10.0 ([#393](https://github.com/heroku/libcnb.rs/pull/393) and [#394](https://github.com/heroku/libcnb.rs/pull/394)).
 
 ## [0.6.0] 2022-04-12
 

--- a/libcnb-proc-macros/CHANGELOG.md
+++ b/libcnb-proc-macros/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Update `fancy-regex` dependency from 0.8.0 to 0.10.0 ([#393](https://github.com/heroku/libcnb.rs/pull/393) and [#394](https://github.com/heroku/libcnb.rs/pull/394)).
+
 ## [0.2.1] 2022-04-12
 
 - Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Leverage `Into` trait for `String`/`&str` arguments in `ContainerContext` ([#412](https://github.com/heroku/libcnb.rs/pull/412)).
 - Pass `--trust-builder` to `pack build` to ensure the builders used in tests are always trusted ([#409](https://github.com/heroku/libcnb.rs/pull/409)).
 - Add `IntegrationTest::app_dir_preprocessor`, allowing users to modify the app directory before an integration test run ([#397](https://github.com/heroku/libcnb.rs/pull/397)).
+- Update `bollard` dependency from 0.12.0 to 0.13.0 ([#419](https://github.com/heroku/libcnb.rs/pull/419)).
 
 ## [0.3.1] 2022-04-12
 


### PR DESCRIPTION
Whilst it's unlikely, there is a chance that dependency upgrades could cause unforeseen breakage for consumers of libcnb, in which case a mention of them in the changelog would make it easier for users to debug.

Also, without a changelog entry, it's easy to not realise that there are unreleased changes for a package that are waiting on a release to be performed.

As such, in addition to adding the recent `fancy-regex` and `bollard` upgrades to the respective changelogs, I've removed the Dependabot PR exemption from the check-changelog task, to encourage addition of changelog entries in the future. 

This shouldn't be too much hassle in practice, since this repository is for a library (and not an end application), so does not commit its `Cargo.lock`. As such, Dependabot PRs are only for major version upgrades of top-level dependencies (and not every patch/minor release), and so are relatively rare.

The `skip changelog` label can still be used in cases where a changelog entry isn't warranted (for example updates to the GitHub Actions dependencies, or updates to `[dev-dependencies]` (of which this repo has very few).