### PR TITLE
Make the Buildpack API version check more robust

### DIFF
--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [Unreleased]
 
-- Add `BuildpackDescriptorApiOnly` for representing only the API version of a `buildpack.toml` ([#421](https://github.com/heroku/libcnb.rs/pull/421)).
 - Add `Launch::processes` function to add multiple `Process`es to a `Launch` value at once. ([#418](https://github.com/heroku/libcnb.rs/pull/418)) 
 - `Launch::process`'s argument changed from `Process` to `Into<Process>`. ([#418](https://github.com/heroku/libcnb.rs/pull/418))
 - Update `fancy-regex` dependency from 0.8.0 to 0.10.0 ([#393](https://github.com/heroku/libcnb.rs/pull/393) and [#394](https://github.com/heroku/libcnb.rs/pull/394)).

--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -145,21 +145,6 @@ pub struct MetaBuildpackDescriptor<BM> {
     pub metadata: BM,
 }
 
-/// Partial data structure for the Buildpack descriptor (buildpack.toml) of a buildpack.
-///
-/// A representation of [buildpack.toml](https://github.com/buildpacks/spec/blob/main/buildpack.md#buildpacktoml-toml)
-/// that contains only the Buildpack API version from the `api` field.
-///
-/// For use when the Buildpack API version must be read from buildpack descriptors that might
-/// otherwise be invalid or not match the supported spec version.
-///
-/// For all other use-cases, use [`BuildpackDescriptor`], [`SingleBuildpackDescriptor`] or
-/// [`MetaBuildpackDescriptor`] instead.
-#[derive(Deserialize, Debug)]
-pub struct BuildpackDescriptorApiOnly {
-    pub api: BuildpackApi,
-}
-
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Buildpack {

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -1,12 +1,13 @@
 use crate::build::{BuildContext, InnerBuildResult};
 use crate::buildpack::Buildpack;
-use crate::data::buildpack::{BuildpackDescriptorApiOnly, StackId};
+use crate::data::buildpack::{BuildpackApi, StackId};
 use crate::detect::{DetectContext, InnerDetectResult};
 use crate::error::Error;
 use crate::platform::Platform;
 use crate::toml_file::{read_toml_file, write_toml_file};
 use crate::{exit_code, LIBCNB_SUPPORTED_BUILDPACK_API};
 use serde::de::DeserializeOwned;
+use serde::Deserialize;
 use std::env;
 use std::ffi::OsStr;
 use std::fmt::Debug;
@@ -194,6 +195,14 @@ pub fn libcnb_runtime_build<B: Buildpack>(
             Ok(exit_code::GENERIC_SUCCESS)
         }
     }
+}
+
+// A partial representation of buildpack.toml that contains only the Buildpack API version,
+// so that the version can still be read when the buildpack descriptor doesn't match the
+// supported spec version.
+#[derive(Deserialize)]
+struct BuildpackDescriptorApiOnly {
+    pub api: BuildpackApi,
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
Previously, if a `buildpack.toml` either:
1. Didn't match the specific custom buildpack type (used when custom fields are specified under `[[metadata]]`)
2. Didn't match the CNB spec

...then a generic "failed to deserialise buildpack.toml" message was shown, rather than any error about the buildpack API version not matching.

In cases where the chosen API version is actually the cause of the error (for example if a future API version makes breaking changes to the schema), then this means the underlying cause isn't mentioned.

Now, the check uses a minimal `BuildpackDescriptorApiOnly` type when deserialising `buildpack.toml`, to ensure the API version can still be determined in those cases.

The `BuildpackDescriptorApiOnly` type was used instead of a raw `toml::value::Table`, since otherwise there are a myriad of `Option`s and related to handle, from both the potential lack of `api` field and it not having a value of type string etc.

GUS-W-11324328.