### PR TITLE
Allow running subsequent integration test builds

### DIFF
--- a/examples/execd/tests/integration_test.rs
+++ b/examples/execd/tests/integration_test.rs
@@ -7,20 +7,23 @@
 // https://rust-lang.github.io/rust-clippy/stable/index.html
 #![warn(clippy::pedantic)]
 
-use libcnb_test::{assert_contains, IntegrationTest};
+use libcnb_test::{assert_contains, TestConfig, TestRunner};
 
 #[test]
 #[ignore]
 fn basic() {
-    IntegrationTest::new("heroku/builder:22", "test-fixtures/empty-app").run_test(|context| {
-        context
-            .prepare_container()
-            .start_with_shell_command("env", |container| {
-                let env_stdout = container.logs_wait().stdout;
+    TestRunner::default().run_test(
+        TestConfig::new("heroku/builder:22", "test-fixtures/empty-app"),
+        |context| {
+            context
+                .prepare_container()
+                .start_with_shell_command("env", |container| {
+                    let env_stdout = container.logs_wait().stdout;
 
-                assert_contains!(env_stdout, "ROLL_1D6=");
-                assert_contains!(env_stdout, "ROLL_4D6=");
-                assert_contains!(env_stdout, "ROLL_1D20=");
-            });
-    });
+                    assert_contains!(env_stdout, "ROLL_1D6=");
+                    assert_contains!(env_stdout, "ROLL_4D6=");
+                    assert_contains!(env_stdout, "ROLL_1D20=");
+                });
+        },
+    );
 }

--- a/examples/ruby-sample/tests/integration_test.rs
+++ b/examples/ruby-sample/tests/integration_test.rs
@@ -7,8 +7,7 @@
 // https://rust-lang.github.io/rust-clippy/stable/index.html
 #![warn(clippy::pedantic)]
 
-use libcnb_test::assert_contains;
-use libcnb_test::IntegrationTest;
+use libcnb_test::{assert_contains, assert_not_contains, TestConfig, TestRunner};
 use std::io;
 use std::io::{Read, Write};
 use std::net;
@@ -18,7 +17,8 @@ use std::time::Duration;
 #[test]
 #[ignore]
 fn basic() {
-    IntegrationTest::new("heroku/buildpacks:20", "test-fixtures/simple-ruby-app").run_test(
+    TestRunner::default().run_test(
+        TestConfig::new("heroku/buildpacks:20", "test-fixtures/simple-ruby-app"),
         |context| {
             assert_contains!(context.pack_stdout, "---> Ruby Buildpack");
             assert_contains!(context.pack_stdout, "---> Installing bundler");
@@ -45,6 +45,14 @@ fn basic() {
                         "ruby 2.7.0p0"
                     );
                 });
+
+            context.run_test(
+                TestConfig::new("heroku/buildpacks:20", "test-fixtures/simple-ruby-app"),
+                |context| {
+                    assert_not_contains!(context.pack_stdout, "---> Installing bundler");
+                    assert_not_contains!(context.pack_stdout, "---> Installing gems");
+                },
+            );
         },
     );
 }

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Rename `IntegrationTest` to `TestConfig`. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
 - Rename `IntegrationTestContext` to `TestContext`. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
 - Add `Clone` implementation for `TestConfig`, allowing it to be shared across tests. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
-- Add `TestContext::run_test` and `TestContext::run_test_inherit_config`, allowing you to run subsequent integration tests with the image from a previous test. These functions allow testing of subsequent builds, including caching logic and buildpack behaviour when build environment variables change, stacks are upgraded and more. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
+- Add `TestContext::run_test`, allowing you to run subsequent integration tests with the image from a previous test. These functions allow testing of subsequent builds, including caching logic and buildpack behaviour when build environment variables change, stacks are upgraded and more. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
 
 ## [0.3.1] 2022-04-12
 

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ## [Unreleased]
 
-- Leverage `Into` trait for `String`/`&str` arguments in `ContainerContext` ([#412](https://github.com/heroku/libcnb.rs/pull/412)).
-- Pass `--trust-builder` to `pack build` to ensure the builders used in tests are always trusted ([#409](https://github.com/heroku/libcnb.rs/pull/409)).
-- Add `IntegrationTest::app_dir_preprocessor`, allowing users to modify the app directory before an integration test run ([#397](https://github.com/heroku/libcnb.rs/pull/397)).
-- Update `bollard` dependency from 0.12.0 to 0.13.0 ([#419](https://github.com/heroku/libcnb.rs/pull/419)).
-- Update `cargo_metadata` dependency from 0.14.2 to 0.15.0 ([#423](https://github.com/heroku/libcnb.rs/pull/423)).
+- Leverage `Into` trait for `String`/`&str` arguments in `ContainerContext` ([#412](https://github.com/heroku/libcnb.rs/pull/412))
+- Pass `--trust-builder` to `pack build` to ensure the builders used in tests are always trusted ([#409](https://github.com/heroku/libcnb.rs/pull/409))
+- Add `IntegrationTest::app_dir_preprocessor`, allowing users to modify the app directory before an integration test run ([#397](https://github.com/heroku/libcnb.rs/pull/397))
+- Update `bollard` dependency from 0.12.0 to 0.13.0 ([#419](https://github.com/heroku/libcnb.rs/pull/419))
+- Update `cargo_metadata` dependency from 0.14.2 to 0.15.0 ([#423](https://github.com/heroku/libcnb.rs/pull/423))
 - Add `assert_not_contains!` macro, an inverted version of `assert_contains!`. ([#424](https://github.com/heroku/libcnb.rs/pull/424))
+- Remove `IntegrationTest::run_test`, to run a test use the new `TestRunner::run_test` function. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
+- Rename `IntegrationTest` to `TestConfig`. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
+- Rename `IntegrationTestContext` to `TestContext`. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
+- Add `Clone` implementation for `TestConfig`, allowing it to be shared across tests. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
+- Add `TestContext::run_test` and `TestContext::run_test_inherit_config`, allowing you to run subsequent integration tests with the image from a previous test. These functions allow testing of subsequent builds, including caching logic and buildpack behaviour when build environment variables change, stacks are upgraded and more. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
+
 
 ## [0.3.1] 2022-04-12
 

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,18 +2,17 @@
 
 ## [Unreleased]
 
-- Leverage `Into` trait for `String`/`&str` arguments in `ContainerContext` ([#412](https://github.com/heroku/libcnb.rs/pull/412))
-- Pass `--trust-builder` to `pack build` to ensure the builders used in tests are always trusted ([#409](https://github.com/heroku/libcnb.rs/pull/409))
-- Add `IntegrationTest::app_dir_preprocessor`, allowing users to modify the app directory before an integration test run ([#397](https://github.com/heroku/libcnb.rs/pull/397))
-- Update `bollard` dependency from 0.12.0 to 0.13.0 ([#419](https://github.com/heroku/libcnb.rs/pull/419))
-- Update `cargo_metadata` dependency from 0.14.2 to 0.15.0 ([#423](https://github.com/heroku/libcnb.rs/pull/423))
-- Add `assert_not_contains!` macro, an inverted version of `assert_contains!`. ([#424](https://github.com/heroku/libcnb.rs/pull/424))
-- Remove `IntegrationTest::run_test`, to run a test use the new `TestRunner::run_test` function. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
-- Rename `IntegrationTest` to `TestConfig`. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
-- Rename `IntegrationTestContext` to `TestContext`. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
-- Add `Clone` implementation for `TestConfig`, allowing it to be shared across tests. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
-- Add `TestContext::run_test` and `TestContext::run_test_inherit_config`, allowing you to run subsequent integration tests with the image from a previous test. These functions allow testing of subsequent builds, including caching logic and buildpack behaviour when build environment variables change, stacks are upgraded and more. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
-
+- Leverage `Into` trait for `String`/`&str` arguments in `ContainerContext` ([#412](https://github.com/heroku/libcnb.rs/pull/412)).
+- Pass `--trust-builder` to `pack build` to ensure the builders used in tests are always trusted ([#409](https://github.com/heroku/libcnb.rs/pull/409)).
+- Add `IntegrationTest::app_dir_preprocessor`, allowing users to modify the app directory before an integration test run ([#397](https://github.com/heroku/libcnb.rs/pull/397)).
+- Update `bollard` dependency from 0.12.0 to 0.13.0 ([#419](https://github.com/heroku/libcnb.rs/pull/419)).
+- Update `cargo_metadata` dependency from 0.14.2 to 0.15.0 ([#423](https://github.com/heroku/libcnb.rs/pull/423)).
+- Add `assert_not_contains!` macro, an inverted version of `assert_contains!`. ([#424](https://github.com/heroku/libcnb.rs/pull/424)).
+- Remove `IntegrationTest::run_test`, to run a test use the new `TestRunner::run_test` function. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
+- Rename `IntegrationTest` to `TestConfig`. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
+- Rename `IntegrationTestContext` to `TestContext`. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
+- Add `Clone` implementation for `TestConfig`, allowing it to be shared across tests. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
+- Add `TestContext::run_test` and `TestContext::run_test_inherit_config`, allowing you to run subsequent integration tests with the image from a previous test. These functions allow testing of subsequent builds, including caching logic and buildpack behaviour when build environment variables change, stacks are upgraded and more. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
 
 ## [0.3.1] 2022-04-12
 

--- a/libcnb-test/README.md
+++ b/libcnb-test/README.md
@@ -15,35 +15,36 @@ Please use the same tag for feature requests.
 
 ```rust,no_run
 // In $CRATE_ROOT/tests/integration_test.rs
-use libcnb_test::{IntegrationTest, BuildpackReference, assert_contains};
+use libcnb_test::{assert_contains, BuildpackReference, TestRunner, TestConfig};
 
 #[test]
 fn test() {
-    IntegrationTest::new("heroku/builder:22", "test-fixtures/app")
-        .buildpacks(vec![
-            BuildpackReference::Other(String::from("heroku/openjdk")),
-            BuildpackReference::Crate,
-        ])
-        .run_test(|context| {
+    TestRunner::default().run_test(
+        TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+        |context| {
             assert_contains!(context.pack_stdout, "---> Maven Buildpack");
             assert_contains!(context.pack_stdout, "---> Installing Maven");
             assert_contains!(context.pack_stdout, "---> Running mvn package");
 
-            context.prepare_container().expose_port(12345).start(|container| {
-                assert_eq!(
-                    call_test_fixture_service(
-                        container.address_for_port(12345).unwrap(),
-                        "Hagbard Celine"
-                    )
-                    .unwrap(),
-                    "enileC drabgaH"
-                );
-            });
-        });
+            context
+                .prepare_container()
+                .expose_port(12345)
+                .start_with_default_process(|container| {
+                    assert_eq!(
+                        call_test_fixture_service(
+                            container.address_for_port(12345).unwrap(),
+                            "Hagbard Celine"
+                        )
+                        .unwrap(),
+                        "enileC drabgaH"
+                    );
+                });
+        },
+    );
 }
 
 fn call_test_fixture_service(addr: std::net::SocketAddr, payload: &str) -> Result<String, ()> {
-   unimplemented!()
+    unimplemented!()
 }
 ```
 

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -13,336 +13,38 @@ mod container_port_mapping;
 mod log;
 mod macros;
 mod pack;
+mod test_config;
+mod test_runner;
 mod util;
 
 pub use crate::container_context::{ContainerContext, PrepareContainerContext};
 use crate::pack::{PackBuildCommand, PullPolicy};
+pub use crate::test_config::*;
+pub use crate::test_runner::*;
 use bollard::image::RemoveImageOptions;
-use bollard::Docker;
-use std::collections::HashMap;
-use std::env;
-use std::env::VarError;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::borrow::Borrow;
+use std::path::PathBuf;
 
-/// Main type for libcnb integration tests.
-///
-/// # Dependencies
-/// Integration tests require external tools to be available on the host to run:
-/// - [pack](https://buildpacks.io/docs/tools/pack/)
-/// - [Docker](https://www.docker.com/)
-///
-/// # Example
-/// ```no_run
-/// use libcnb_test::{IntegrationTest, BuildpackReference, assert_contains};
-///
-/// # fn call_test_fixture_service(addr: std::net::SocketAddr, payload: &str) -> Result<String, ()> {
-/// #    unimplemented!()
-/// # }
-/// IntegrationTest::new("heroku/builder:22", "test-fixtures/app")
-///     .buildpacks(vec![
-///         BuildpackReference::Other(String::from("heroku/openjdk")),
-///         BuildpackReference::Crate,
-///     ])
-///     .run_test(|context| {
-///         assert_contains!(context.pack_stdout, "---> Maven Buildpack");
-///         assert_contains!(context.pack_stdout, "---> Installing Maven");
-///         assert_contains!(context.pack_stdout, "---> Running mvn package");
-///
-///         context.prepare_container().expose_port(12345).start_with_default_process(|container| {
-///             assert_eq!(
-///                 call_test_fixture_service(
-///                     container.address_for_port(12345).unwrap(),
-///                     "Hagbard Celine"
-///                 )
-///                 .unwrap(),
-///                 "enileC drabgaH"
-///             );
-///         });
-///     });
-/// ```
-pub struct IntegrationTest {
-    app_dir: PathBuf,
-    target_triple: String,
-    builder_name: String,
-    buildpacks: Vec<BuildpackReference>,
-    env: HashMap<String, String>,
-    app_dir_preprocessor: Option<Box<dyn Fn(PathBuf)>>,
-    docker: Docker,
-    tokio_runtime: tokio::runtime::Runtime,
-}
-
-/// References a Cloud Native Buildpack
-#[derive(Eq, PartialEq, Debug)]
-pub enum BuildpackReference {
-    /// References the buildpack in the Rust Crate currently being tested
-    Crate,
-    /// References another buildpack by id, local directory or tarball
-    Other(String),
-}
-
-impl IntegrationTest {
-    /// Creates a new integration test.
-    ///
-    /// If the `app_dir` parameter is a relative path, it is treated as relative to the Cargo
-    /// manifest directory ([`CARGO_MANIFEST_DIR`](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates)),
-    /// i.e. the package's root directory.
-    ///
-    /// # Panics
-    /// - When the connection to Docker failed
-    /// - When the internal Tokio runtime could not be created
-    pub fn new(builder_name: impl Into<String>, app_dir: impl AsRef<Path>) -> Self {
-        let tokio_runtime =
-            tokio::runtime::Runtime::new().expect("Could not create internal Tokio runtime");
-
-        let docker = match env::var("DOCKER_HOST") {
-            #[cfg(target_family = "unix")]
-            Ok(docker_host) if docker_host.starts_with("unix://") => {
-                Docker::connect_with_unix_defaults()
-            }
-            Ok(docker_host)
-                if docker_host.starts_with("tcp://") || docker_host.starts_with("https://") =>
-            {
-                #[cfg(not(feature = "remote-docker"))]
-                panic!("Cannot connect to DOCKER_HOST '{docker_host}' since it requires TLS. Please use a local Docker daemon instead (recommended), or else enable the experimental `remote-docker` feature.");
-                #[cfg(feature = "remote-docker")]
-                Docker::connect_with_ssl_defaults()
-            }
-            Ok(docker_host) => panic!("Cannot connect to unsupported DOCKER_HOST '{docker_host}'"),
-            Err(VarError::NotPresent) => Docker::connect_with_local_defaults(),
-            Err(VarError::NotUnicode(_)) => {
-                panic!("DOCKER_HOST environment variable is not unicode encoded!")
-            }
-        }
-        .expect("Could not connect to local Docker daemon");
-
-        IntegrationTest {
-            app_dir: PathBuf::from(app_dir.as_ref()),
-            target_triple: String::from("x86_64-unknown-linux-musl"),
-            builder_name: builder_name.into(),
-            buildpacks: vec![BuildpackReference::Crate],
-            env: HashMap::new(),
-            app_dir_preprocessor: None,
-            docker,
-            tokio_runtime,
-        }
-    }
-
-    /// Sets the buildpacks order.
-    ///
-    /// Defaults to [`BuildpackReference::Crate`].
-    pub fn buildpacks(&mut self, buildpacks: impl Into<Vec<BuildpackReference>>) -> &mut Self {
-        self.buildpacks = buildpacks.into();
-        self
-    }
-
-    /// Sets the target triple.
-    ///
-    /// Defaults to `x86_64-unknown-linux-musl`.
-    pub fn target_triple(&mut self, target_triple: impl Into<String>) -> &mut Self {
-        self.target_triple = target_triple.into();
-        self
-    }
-
-    /// Inserts or updates an environment variable mapping for the build process.
-    ///
-    /// Note: This does not set this environment variable for running containers, it's only
-    /// available during the build.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use libcnb_test::IntegrationTest;
-    ///
-    /// IntegrationTest::new("heroku/builder:22", "test-fixtures/app")
-    ///     .env("ENV_VAR_ONE", "VALUE ONE")
-    ///     .env("ENV_VAR_TWO", "SOME OTHER VALUE")
-    ///     .run_test(|context| {
-    ///         // ...
-    ///     })
-    /// ```
-    pub fn env(&mut self, k: impl Into<String>, v: impl Into<String>) -> &mut Self {
-        self.env.insert(k.into(), v.into());
-        self
-    }
-
-    /// Adds or updates multiple environment variable mappings for the build process.
-    ///
-    /// Note: This does not set environment variables for running containers, they're only
-    /// available during the build.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use libcnb_test::IntegrationTest;
-    ///
-    /// IntegrationTest::new("heroku/builder:22", "test-fixtures/app")
-    ///     .envs(vec![("ENV_VAR_ONE", "VALUE ONE"), ("ENV_VAR_TWO", "SOME OTHER VALUE")])
-    ///     .run_test(|context| {
-    ///         // ...
-    ///     })
-    /// ```
-    pub fn envs<K: Into<String>, V: Into<String>, I: IntoIterator<Item = (K, V)>>(
-        &mut self,
-        envs: I,
-    ) -> &mut Self {
-        envs.into_iter().for_each(|(key, value)| {
-            self.env(key.into(), value.into());
-        });
-
-        self
-    }
-
-    /// Sets an app directory preprocessor function.
-    ///
-    /// It will be run after the app directory has been copied for the current integration test run,
-    /// the changes will not affect other integration test runs.
-    ///
-    /// Generally, we suggest using dedicated test fixtures. However, in some cases it is more
-    /// economical to slightly modify a fixture programmatically before a test instead.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use libcnb_test::IntegrationTest;
-    ///
-    /// IntegrationTest::new("heroku/builder:22", "test-fixtures/app")
-    ///     .app_dir_preprocessor(|app_dir| {
-    ///         std::fs::remove_file(app_dir.join("Procfile")).unwrap()
-    ///     })
-    ///     .run_test(|context| {
-    ///         // ...
-    ///     })
-    /// ```
-    pub fn app_dir_preprocessor<F: 'static + Fn(PathBuf)>(&mut self, f: F) -> &mut Self {
-        self.app_dir_preprocessor = Some(Box::new(f));
-        self
-    }
-
-    /// Starts a new integration test run.
-    ///
-    /// This function will copy the application to a temporary directory, cross-compiles this crate,
-    /// packages it as a buildpack and then invokes [pack](https://buildpacks.io/docs/tools/pack/)
-    /// to build a new Docker image with the buildpacks specified by this integration test instance.
-    ///
-    /// Since this function is supposed to only be used in integration tests, failures are not
-    /// signalled via [`Result`](Result) values. Instead, this function panics whenever an unexpected error
-    /// occurred to simplify testing code.
-    ///
-    /// # Panics
-    /// - When the app could not be copied
-    /// - When this crate could not be packed as a buildpack
-    /// - When the "pack" command unexpectedly fails
-    ///
-    /// # Example
-    /// ```no_run
-    /// use libcnb_test::{IntegrationTest, assert_contains};
-    ///
-    /// IntegrationTest::new("heroku/builder:22", "test-fixtures/app")
-    ///     .run_test(|context| {
-    ///         assert_contains!(context.pack_stdout, "---> Ruby Buildpack");
-    ///         assert_contains!(context.pack_stdout, "---> Installing bundler");
-    ///         assert_contains!(context.pack_stdout, "---> Installing gems");
-    ///     })
-    /// ```
-    pub fn run_test<F: FnOnce(IntegrationTestContext)>(&mut self, f: F) {
-        let app_dir = if self.app_dir.is_relative() {
-            env::var("CARGO_MANIFEST_DIR")
-                .map(PathBuf::from)
-                .expect("Could not determine Cargo manifest directory")
-                .join(&self.app_dir)
-        } else {
-            self.app_dir.clone()
-        };
-
-        let temp_app_dir =
-            app::copy_app(&app_dir).expect("Could not copy app to temporary location");
-
-        if let Some(app_dir_preprocessor) = &self.app_dir_preprocessor {
-            (app_dir_preprocessor)(PathBuf::from(temp_app_dir.path()));
-        }
-
-        let temp_crate_buildpack_dir = if self.buildpacks.contains(&BuildpackReference::Crate) {
-            Some(
-                build::package_crate_buildpack(&self.target_triple)
-                    .expect("Could not package current crate as buildpack"),
-            )
-        } else {
-            None
-        };
-
-        let image_name = util::random_docker_identifier();
-
-        let mut pack_command = PackBuildCommand::new(
-            &self.builder_name,
-            temp_app_dir.path(),
-            &image_name,
-            // Prevent redundant image-pulling, which slows tests and risks hitting registry rate limits.
-            PullPolicy::IfNotPresent,
-        );
-
-        self.env.iter().for_each(|(key, value)| {
-            pack_command.env(key, value);
-        });
-
-        for buildpack in &self.buildpacks {
-            match buildpack {
-                BuildpackReference::Crate => {
-                    pack_command.buildpack(temp_crate_buildpack_dir.as_ref()
-                        .expect("Test references crate buildpack, but crate wasn't packaged as a buildpack. This is an internal libcnb-test error, please report any occurrences."))
-                }
-                BuildpackReference::Other(id) => pack_command.buildpack(id.clone()),
-            };
-        }
-
-        let output = Command::from(pack_command)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("Could not spawn external 'pack' process")
-            .wait_with_output()
-            .expect("Error while waiting on external 'pack' process");
-
-        let integration_test_context = IntegrationTestContext {
-            pack_stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-            pack_stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-            image_name,
-            app_dir: PathBuf::from(temp_app_dir.path()),
-            integration_test: self,
-        };
-
-        if output.status.success() {
-            f(integration_test_context);
-        } else {
-            panic!(
-                "pack command failed with exit-code {}!\n\npack stdout:\n{}\n\npack stderr:\n{}",
-                output
-                    .status
-                    .code()
-                    .map_or(String::from("<unknown>"), |exit_code| exit_code.to_string()),
-                integration_test_context.pack_stdout,
-                integration_test_context.pack_stderr
-            )
-        }
-    }
-}
-
-/// Context for a currently executing integration test.
-pub struct IntegrationTestContext<'a> {
+/// Context for a currently executing test.
+pub struct TestContext<'a> {
     /// Standard output of `pack`, interpreted as an UTF-8 string.
     pub pack_stdout: String,
     /// Standard error of `pack`, interpreted as an UTF-8 string.
     pub pack_stderr: String,
-    /// The name of the image this integration test created.
-    pub image_name: String,
     /// The directory of the app this integration test uses.
     ///
-    /// This is a copy of the `app_dir` directory passed to [`IntegrationTest::new`] and unique to
+    /// This is a copy of the `app_dir` directory passed to [`TestConfig::new`] and unique to
     /// this integration test run. It is safe to modify the directory contents inside the test.
     pub app_dir: PathBuf,
+    /// The configuration used for this integration test.
+    pub config: TestConfig,
 
-    integration_test: &'a IntegrationTest,
+    image_name: String,
+    runner: &'a TestRunner,
 }
 
-impl<'a> IntegrationTestContext<'a> {
-    /// Prepares a new container with the image from the integration test.
+impl<'a> TestContext<'a> {
+    /// Prepares a new container with the image from the test.
     ///
     /// This will not create nor run the container immediately. Use the returned
     /// `PrepareContainerContext` to configure the container, then call
@@ -352,34 +54,90 @@ impl<'a> IntegrationTestContext<'a> {
     /// # Example:
     ///
     /// ```no_run
-    /// use libcnb_test::IntegrationTest;
+    /// use libcnb_test::{TestConfig, TestRunner};
     ///
-    /// IntegrationTest::new("heroku/builder:22", "test-fixtures/empty-app").run_test(|context| {
-    ///     context.prepare_container().start_with_default_process(|container| {
-    ///         // ...
-    ///     });
-    /// });
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/empty-app"),
+    ///     |context| {
+    ///         context
+    ///             .prepare_container()
+    ///             .start_with_default_process(|container| {
+    ///                 // ...
+    ///             });
+    ///     },
+    /// );
     /// ```
     #[must_use]
     pub fn prepare_container(&self) -> PrepareContainerContext {
         PrepareContainerContext::new(self)
     }
+
+    /// Starts a subsequent integration test run.
+    ///
+    /// This function behaves exactly like [`TestRunner::run_test`], but it will reuse the OCI image
+    /// from the previous test, causing the CNB lifecycle to restore cached layers. It will use the
+    /// same [`TestRunner`] as the previous test run.
+    ///
+    /// This function allows testing of subsequent builds, including caching logic and buildpack
+    /// behaviour when build environment variables change, stacks are upgraded and more.
+    ///
+    /// Note that this function will consume the current context. This is because the image will
+    /// be changed by the subsequent test, invalidating the context. Running a subsequent test must
+    /// therefore be the last operation. You can nest subsequent runs if required.
+    ///
+    /// # Panics
+    /// - When the app could not be copied
+    /// - When this crate could not be packaged as a buildpack
+    /// - When the `pack` command unexpectedly fails
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{assert_contains, TestRunner, TestConfig};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         assert_contains!(context.pack_stdout, "---> Ruby Buildpack");
+    ///         assert_contains!(context.pack_stdout, "---> Installing bundler");
+    ///         assert_contains!(context.pack_stdout, "---> Installing gems");
+    ///     },
+    /// )
+    /// ```
+    pub fn run_test<C: Borrow<TestConfig>, F: FnOnce(TestContext)>(self, config: C, f: F) {
+        self.runner
+            .run_test_internal(self.image_name.clone(), config, f);
+    }
+
+    /// Starts a subsequent integration test run with inherited configuration.
+    ///
+    /// This function is the same as [`TestContext::run_test`] but automatically inherits the
+    /// configuration from the previous test run. See [`TestContext::run_test`] for details.
+    ///
+    /// # Panics
+    /// - When the app could not be copied
+    /// - When this crate could not be packaged as a buildpack
+    /// - When the `pack` command unexpectedly fails
+    pub fn run_test_inherit_config<F: FnOnce(TestContext)>(self, f: F) {
+        self.runner
+            .run_test_internal(self.image_name.clone(), self.config.clone(), f);
+    }
 }
 
-impl<'a> Drop for IntegrationTestContext<'a> {
+impl<'a> Drop for TestContext<'a> {
     fn drop(&mut self) {
         // We do not care if image removal succeeded or not. Panicking here would result in
         // SIGILL since this function might be called in a Tokio runtime.
-        let _image_delete_result = self.integration_test.tokio_runtime.block_on(
-            self.integration_test.docker.remove_image(
-                &self.image_name,
-                Some(RemoveImageOptions {
-                    force: true,
-                    ..RemoveImageOptions::default()
-                }),
-                None,
-            ),
-        );
+        let _image_delete_result =
+            self.runner
+                .tokio_runtime
+                .block_on(self.runner.docker.remove_image(
+                    &self.image_name,
+                    Some(RemoveImageOptions {
+                        force: true,
+                        ..RemoveImageOptions::default()
+                    }),
+                    None,
+                ));
     }
 }
 

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -107,20 +107,6 @@ impl<'a> TestContext<'a> {
         self.runner
             .run_test_internal(self.image_name.clone(), config, f);
     }
-
-    /// Starts a subsequent integration test run with inherited configuration.
-    ///
-    /// This function is the same as [`TestContext::run_test`] but automatically inherits the
-    /// configuration from the previous test run. See [`TestContext::run_test`] for details.
-    ///
-    /// # Panics
-    /// - When the app could not be copied
-    /// - When this crate could not be packaged as a buildpack
-    /// - When the `pack` command unexpectedly fails
-    pub fn run_test_inherit_config<F: FnOnce(TestContext)>(self, f: F) {
-        self.runner
-            .run_test_internal(self.image_name.clone(), self.config.clone(), f);
-    }
 }
 
 impl<'a> Drop for TestContext<'a> {

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -75,7 +75,7 @@ impl<'a> TestContext<'a> {
     /// Starts a subsequent integration test run.
     ///
     /// This function behaves exactly like [`TestRunner::run_test`], but it will reuse the OCI image
-    /// from the previous test, causing the CNB lifecycle to restore cached layers. It will use the
+    /// from the previous test, causing the CNB lifecycle to restore any cached layers. It will use the
     /// same [`TestRunner`] as the previous test run.
     ///
     /// This function allows testing of subsequent builds, including caching logic and buildpack

--- a/libcnb-test/src/test_config.rs
+++ b/libcnb-test/src/test_config.rs
@@ -38,7 +38,7 @@ impl TestConfig {
         self
     }
 
-    /// Sets the target triple.
+    /// Sets the target triple used when compiling the buildpack.
     ///
     /// Defaults to `x86_64-unknown-linux-musl`.
     pub fn target_triple(&mut self, target_triple: impl Into<String>) -> &mut Self {

--- a/libcnb-test/src/test_config.rs
+++ b/libcnb-test/src/test_config.rs
@@ -1,0 +1,136 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+/// Configuration for a test.
+#[derive(Clone)]
+pub struct TestConfig {
+    pub(crate) app_dir: PathBuf,
+    pub(crate) target_triple: String,
+    pub(crate) builder_name: String,
+    pub(crate) buildpacks: Vec<BuildpackReference>,
+    pub(crate) env: HashMap<String, String>,
+    pub(crate) app_dir_preprocessor: Option<Rc<dyn Fn(PathBuf)>>,
+}
+
+impl TestConfig {
+    /// Creates a new test configuration.
+    ///
+    /// If the `app_dir` parameter is a relative path, it is treated as relative to the Cargo
+    /// manifest directory ([`CARGO_MANIFEST_DIR`](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates)),
+    /// i.e. the package's root directory.
+    pub fn new(builder_name: impl Into<String>, app_dir: impl AsRef<Path>) -> Self {
+        TestConfig {
+            app_dir: PathBuf::from(app_dir.as_ref()),
+            target_triple: String::from("x86_64-unknown-linux-musl"),
+            builder_name: builder_name.into(),
+            buildpacks: vec![BuildpackReference::Crate],
+            env: HashMap::new(),
+            app_dir_preprocessor: None,
+        }
+    }
+
+    /// Sets the buildpacks order.
+    ///
+    /// Defaults to [`BuildpackReference::Crate`].
+    pub fn buildpacks(&mut self, buildpacks: impl Into<Vec<BuildpackReference>>) -> &mut Self {
+        self.buildpacks = buildpacks.into();
+        self
+    }
+
+    /// Sets the target triple.
+    ///
+    /// Defaults to `x86_64-unknown-linux-musl`.
+    pub fn target_triple(&mut self, target_triple: impl Into<String>) -> &mut Self {
+        self.target_triple = target_triple.into();
+        self
+    }
+
+    /// Inserts or updates an environment variable mapping for the build process.
+    ///
+    /// Note: This does not set this environment variable for running containers, it's only
+    /// available during the build.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app")
+    ///         .env("ENV_VAR_ONE", "VALUE ONE")
+    ///         .env("ENV_VAR_TWO", "SOME OTHER VALUE"),
+    ///     |context| {
+    ///         // ...
+    ///     },
+    /// )
+    /// ```
+    pub fn env(&mut self, k: impl Into<String>, v: impl Into<String>) -> &mut Self {
+        self.env.insert(k.into(), v.into());
+        self
+    }
+
+    /// Adds or updates multiple environment variable mappings for the build process.
+    ///
+    /// Note: This does not set environment variables for running containers, they're only
+    /// available during the build.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app").envs(vec![
+    ///         ("ENV_VAR_ONE", "VALUE ONE"),
+    ///         ("ENV_VAR_TWO", "SOME OTHER VALUE"),
+    ///     ]),
+    ///     |context| {
+    ///         // ...
+    ///     },
+    /// );
+    /// ```
+    pub fn envs<K: Into<String>, V: Into<String>, I: IntoIterator<Item = (K, V)>>(
+        &mut self,
+        envs: I,
+    ) -> &mut Self {
+        envs.into_iter().for_each(|(key, value)| {
+            self.env(key.into(), value.into());
+        });
+
+        self
+    }
+
+    /// Sets an app directory preprocessor function.
+    ///
+    /// It will be run after the app directory has been copied for the current integration test run,
+    /// the changes will not affect other integration test runs.
+    ///
+    /// Generally, we suggest using dedicated test fixtures. However, in some cases it is more
+    /// economical to slightly modify a fixture programmatically before a test instead.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app").app_dir_preprocessor(
+    ///         |app_dir| std::fs::remove_file(app_dir.join("Procfile")).unwrap(),
+    ///     ),
+    ///     |context| {
+    ///         // ...
+    ///     },
+    /// );
+    /// ```
+    pub fn app_dir_preprocessor<F: 'static + Fn(PathBuf)>(&mut self, f: F) -> &mut Self {
+        self.app_dir_preprocessor = Some(Rc::new(f));
+        self
+    }
+}
+
+/// References a Cloud Native Buildpack
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum BuildpackReference {
+    /// References the buildpack in the Rust Crate currently being tested
+    Crate,
+    /// References another buildpack by id, local directory or tarball
+    Other(String),
+}

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -97,7 +97,7 @@ impl TestRunner {
 
     /// Starts a new integration test run.
     ///
-    /// This function will copy the application to a temporary directory, cross-compiles this crate,
+    /// This function copies the application to a temporary directory, cross-compiles this crate,
     /// packages it as a buildpack and then invokes [pack](https://buildpacks.io/docs/tools/pack/)
     /// to build a new Docker image with the buildpacks specified by the passed [`TestConfig`].
     ///

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -151,14 +151,14 @@ impl TestRunner {
             (app_dir_preprocessor)(PathBuf::from(temp_app_dir.path()));
         }
 
-        let temp_crate_buildpack_dir = if config.buildpacks.contains(&BuildpackReference::Crate) {
-            Some(
-                build::package_crate_buildpack(&config.target_triple)
-                    .expect("Could not package current crate as buildpack"),
-            )
-        } else {
-            None
-        };
+        let temp_crate_buildpack_dir =
+            config
+                .buildpacks
+                .contains(&BuildpackReference::Crate)
+                .then(|| {
+                    build::package_crate_buildpack(&config.target_triple)
+                        .expect("Could not package current crate as buildpack")
+                });
 
         let mut pack_command = PackBuildCommand::new(
             &config.builder_name,

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -1,0 +1,216 @@
+use crate::{
+    app, build, util, BuildpackReference, PackBuildCommand, PullPolicy, TestConfig, TestContext,
+};
+use bollard::Docker;
+use std::borrow::Borrow;
+use std::env;
+use std::env::VarError;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+/// Runner for libcnb integration tests.
+///
+/// # Dependencies
+/// Integration tests require external tools to be available on the host to run:
+/// - [pack](https://buildpacks.io/docs/tools/pack/)
+/// - [Docker](https://www.docker.com/)
+///
+/// # Example
+/// ```no_run
+/// use libcnb_test::{TestConfig, BuildpackReference, assert_contains, TestRunner};
+///
+/// # fn call_test_fixture_service(addr: std::net::SocketAddr, payload: &str) -> Result<String, ()> {
+/// #    unimplemented!()
+/// # }
+/// TestRunner::default().run_test(
+///     TestConfig::new("heroku/builder:22", "test-fixtures/app").buildpacks(vec![
+///         BuildpackReference::Other(String::from("heroku/openjdk")),
+///         BuildpackReference::Crate,
+///     ]),
+///     |context| {
+///         assert_contains!(context.pack_stdout, "---> Maven Buildpack");
+///         assert_contains!(context.pack_stdout, "---> Installing Maven");
+///         assert_contains!(context.pack_stdout, "---> Running mvn package");
+///
+///         context
+///             .prepare_container()
+///             .expose_port(12345)
+///             .start_with_default_process(|container| {
+///                 assert_eq!(
+///                     call_test_fixture_service(
+///                         container.address_for_port(12345).unwrap(),
+///                         "Hagbard Celine"
+///                     )
+///                     .unwrap(),
+///                     "enileC drabgaH"
+///                 );
+///             });
+///     },
+/// );
+/// ```
+pub struct TestRunner {
+    pub(crate) docker: Docker,
+    pub(crate) tokio_runtime: tokio::runtime::Runtime,
+}
+
+impl Default for TestRunner {
+    fn default() -> Self {
+        let tokio_runtime =
+            tokio::runtime::Runtime::new().expect("Could not create internal Tokio runtime");
+
+        let docker = match env::var("DOCKER_HOST") {
+            #[cfg(target_family = "unix")]
+            Ok(docker_host) if docker_host.starts_with("unix://") => {
+                Docker::connect_with_unix_defaults()
+            }
+            Ok(docker_host)
+            if docker_host.starts_with("tcp://") || docker_host.starts_with("https://") =>
+                {
+                    #[cfg(not(feature = "remote-docker"))]
+                    panic!("Cannot connect to DOCKER_HOST '{docker_host}' since it requires TLS. Please use a local Docker daemon instead (recommended), or else enable the experimental `remote-docker` feature.");
+                    #[cfg(feature = "remote-docker")]
+                    Docker::connect_with_ssl_defaults()
+                }
+            Ok(docker_host) => panic!("Cannot connect to unsupported DOCKER_HOST '{docker_host}'"),
+            Err(VarError::NotPresent) => Docker::connect_with_local_defaults(),
+            Err(VarError::NotUnicode(_)) => {
+                panic!("DOCKER_HOST environment variable is not unicode encoded!")
+            }
+        }
+            .expect("Could not connect to local Docker daemon");
+
+        TestRunner::new(tokio_runtime, docker)
+    }
+}
+
+impl TestRunner {
+    /// Creates a new runner that uses the given Tokio runtime and Docker connection.
+    ///
+    /// This function is meant for advanced use-cases where fine control over the Tokio runtime
+    /// and/or Docker connection is required. For the common use-cases, use `Runner::default`.
+    pub fn new(tokio_runtime: tokio::runtime::Runtime, docker: Docker) -> Self {
+        TestRunner {
+            docker,
+            tokio_runtime,
+        }
+    }
+
+    /// Starts a new integration test run.
+    ///
+    /// This function will copy the application to a temporary directory, cross-compiles this crate,
+    /// packages it as a buildpack and then invokes [pack](https://buildpacks.io/docs/tools/pack/)
+    /// to build a new Docker image with the buildpacks specified by the passed [`TestConfig`].
+    ///
+    /// Since this function is supposed to only be used in integration tests, failures are not
+    /// signalled via [`Result`](Result) values. Instead, this function panics whenever an unexpected error
+    /// occurred to simplify testing code.
+    ///
+    /// # Panics
+    /// - When the app could not be copied
+    /// - When this crate could not be packaged as a buildpack
+    /// - When the `pack` command unexpectedly fails
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{assert_contains, TestRunner, TestConfig};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         assert_contains!(context.pack_stdout, "---> Ruby Buildpack");
+    ///         assert_contains!(context.pack_stdout, "---> Installing bundler");
+    ///         assert_contains!(context.pack_stdout, "---> Installing gems");
+    ///     },
+    /// )
+    /// ```
+    pub fn run_test<C: Borrow<TestConfig>, F: FnOnce(TestContext)>(&self, config: C, f: F) {
+        self.run_test_internal(util::random_docker_identifier(), config, f);
+    }
+
+    pub(crate) fn run_test_internal<C: Borrow<TestConfig>, F: FnOnce(TestContext)>(
+        &self,
+        image_name: String,
+        config: C,
+        f: F,
+    ) {
+        let config = config.borrow();
+
+        let app_dir = if config.app_dir.is_relative() {
+            env::var("CARGO_MANIFEST_DIR")
+                .map(PathBuf::from)
+                .expect("Could not determine Cargo manifest directory")
+                .join(&config.app_dir)
+        } else {
+            config.app_dir.clone()
+        };
+
+        let temp_app_dir =
+            app::copy_app(&app_dir).expect("Could not copy app to temporary location");
+
+        if let Some(app_dir_preprocessor) = &config.app_dir_preprocessor {
+            (app_dir_preprocessor)(PathBuf::from(temp_app_dir.path()));
+        }
+
+        let temp_crate_buildpack_dir = if config.buildpacks.contains(&BuildpackReference::Crate) {
+            Some(
+                build::package_crate_buildpack(&config.target_triple)
+                    .expect("Could not package current crate as buildpack"),
+            )
+        } else {
+            None
+        };
+
+        let mut pack_command = PackBuildCommand::new(
+            &config.builder_name,
+            temp_app_dir.path(),
+            &image_name,
+            // Prevent redundant image-pulling, which slows tests and risks hitting registry rate limits.
+            PullPolicy::IfNotPresent,
+        );
+
+        config.env.iter().for_each(|(key, value)| {
+            pack_command.env(key, value);
+        });
+
+        for buildpack in &config.buildpacks {
+            match buildpack {
+                BuildpackReference::Crate => {
+                    pack_command.buildpack(temp_crate_buildpack_dir.as_ref()
+                        .expect("Test references crate buildpack, but crate wasn't packaged as a buildpack. This is an internal libcnb-test error, please report any occurrences."))
+                }
+                BuildpackReference::Other(id) => pack_command.buildpack(id.clone()),
+            };
+        }
+
+        let output = Command::from(pack_command)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("Could not spawn external 'pack' process")
+            .wait_with_output()
+            .expect("Error while waiting on external 'pack' process");
+
+        let test_context = TestContext {
+            pack_stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            pack_stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            app_dir: PathBuf::from(temp_app_dir.path()),
+            image_name,
+            config: config.clone(),
+            runner: self,
+        };
+
+        if output.status.success() {
+            f(test_context);
+        } else {
+            panic!(
+                "pack command failed with exit-code {}!\n\npack stdout:\n{}\n\npack stderr:\n{}",
+                output
+                    .status
+                    .code()
+                    .map_or(String::from("<unknown>"), |exit_code| exit_code.to_string()),
+                test_context.pack_stdout,
+                test_context.pack_stderr
+            )
+        }
+    }
+}

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -7,7 +7,7 @@
 // https://rust-lang.github.io/rust-clippy/stable/index.html
 #![warn(clippy::pedantic)]
 
-use libcnb_test::{BuildpackReference, IntegrationTest};
+use libcnb_test::{BuildpackReference, TestConfig, TestRunner};
 use tempfile::tempdir;
 
 #[test]
@@ -22,7 +22,10 @@ ERROR: failed to build: failed to fetch builder image 'index.docker.io/libcnb/vo
 ")]
 fn panic_on_unsuccessful_pack_run() {
     let temp_app_dir = tempdir().unwrap();
-    IntegrationTest::new("libcnb/void-builder:doesntexist", temp_app_dir.path())
-        .buildpacks(vec![BuildpackReference::Other(String::from("libcnb/void"))])
-        .run_test(|_| {});
+
+    TestRunner::default().run_test(
+        TestConfig::new("libcnb/void-builder:doesntexist", temp_app_dir.path())
+            .buildpacks(vec![BuildpackReference::Other(String::from("libcnb/void"))]),
+        |_| {},
+    );
 }


### PR DESCRIPTION
To achieve a consistent API, breaking changes had to be made to allow sharing of `TestConfig` (formerly `IntegrationTest`) for both initial and subsequent test runs. The biggest change is the addition of `TestRunner` which is now the way to run tests.

Even though it's a breaking change, migration to this new API should be simple. See examples in this PR for an idea of required changes.

## Changelog

- Remove `IntegrationTest::run_test`, to run a test use the new `TestRunner::run_test` function.
- Rename `IntegrationTest` to `TestConfig`.
- Rename `IntegrationTestContext` to `TestContext`.
- Add `Clone` implementation for `TestConfig`, allowing it to be shared across tests.
- Add `TestContext::run_test` and `TestContext::run_test_inherit_config`, allowing you to run subsequent integration tests with the image from a previous test. These functions allow testing of subsequent builds, including caching logic and buildpack behaviour when build environment variables change, stacks are upgraded and more.

## Examples

```rust
#[test]
fn basic() {
    TestRunner::default().run_test(
        TestConfig::new("heroku/buildpacks:20", "test-fixtures/simple-ruby-app"),
        |context| {
            assert_contains!(context.pack_stdout, "---> Ruby Buildpack");
            assert_contains!(context.pack_stdout, "---> Installing bundler");
            assert_contains!(context.pack_stdout, "---> Installing gems");

            context.run_test_inherit_config(|context| {
                assert_not_contains!(context.pack_stdout, "---> Installing bundler");
                assert_not_contains!(context.pack_stdout, "---> Installing gems");
            });
        },
    );
}

#[test]
fn clear_bundler_cache() {
    let base_config = TestConfig::new("heroku/buildpacks:20", "test-fixtures/simple-ruby-app");

    TestRunner::default().run_test(&base_config, |context| {
        assert_contains!(context.pack_stdout, "---> Ruby Buildpack");
        assert_contains!(context.pack_stdout, "---> Installing bundler");
        assert_contains!(context.pack_stdout, "---> Installing gems");

        context.run_test(
            // Subsequent tests can be run using a different config, allowing testing of stack
            // changes, different environment variables, etc. Since TestConfig is now Clone,
            // configuration can be easily shared.
            base_config.clone().env("CLEAR_BUNDLER_CACHE", "true"),
            |context| {
                assert_contains!(context.pack_stdout, "---> Installing bundler");
                assert_contains!(context.pack_stdout, "---> Installing gems");
            },
        );
    });
}
```

Closes #278, [GUS-W-10539929](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-10539929)