### PR TITLE
Remove unnecessary usages of public structs/functions in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
 use libcnb::{buildpack_main, Buildpack};
 
-struct HelloWorldBuildpack;
+pub(crate) struct HelloWorldBuildpack;
 
 impl Buildpack for HelloWorldBuildpack {
     // The CNB platform this buildpack targets, usually `GenericPlatform`. See the CNB spec for

--- a/examples/basics/src/main.rs
+++ b/examples/basics/src/main.rs
@@ -7,7 +7,8 @@ use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
 use libcnb::{buildpack_main, Buildpack};
 
-struct BasicBuildpack;
+pub(crate) struct BasicBuildpack;
+
 impl Buildpack for BasicBuildpack {
     type Platform = GenericPlatform;
     type Metadata = GenericMetadata;

--- a/examples/execd/src/bin/dice_roller.rs
+++ b/examples/execd/src/bin/dice_roller.rs
@@ -8,7 +8,7 @@ use libcnb::exec_d::write_exec_d_program_output;
 use std::collections::HashMap;
 use std::iter;
 
-pub fn main() {
+fn main() {
     write_exec_d_program_output(env_vars());
 }
 

--- a/examples/execd/src/layer.rs
+++ b/examples/execd/src/layer.rs
@@ -6,7 +6,7 @@ use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
 use libcnb::{additional_buildpack_binary_path, Buildpack};
 use std::path::Path;
 
-pub struct ExecDLayer;
+pub(crate) struct ExecDLayer;
 
 impl Layer for ExecDLayer {
     type Buildpack = ExecDBuildpack;

--- a/examples/execd/src/main.rs
+++ b/examples/execd/src/main.rs
@@ -13,7 +13,7 @@ use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
 use libcnb::{buildpack_main, Buildpack};
 
-pub struct ExecDBuildpack;
+pub(crate) struct ExecDBuildpack;
 
 impl Buildpack for ExecDBuildpack {
     type Platform = GenericPlatform;

--- a/examples/ruby-sample/src/layers/bundler.rs
+++ b/examples/ruby-sample/src/layers/bundler.rs
@@ -10,11 +10,11 @@ use std::path::Path;
 use std::process::Command;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct BundlerLayerMetadata {
+pub(crate) struct BundlerLayerMetadata {
     gemfile_lock_checksum: String,
 }
 
-pub struct BundlerLayer {
+pub(crate) struct BundlerLayer {
     pub ruby_env: Env,
 }
 

--- a/examples/ruby-sample/src/layers/mod.rs
+++ b/examples/ruby-sample/src/layers/mod.rs
@@ -1,5 +1,5 @@
 mod bundler;
 mod ruby;
 
-pub use bundler::*;
-pub use ruby::*;
+pub(crate) use bundler::*;
+pub(crate) use ruby::*;

--- a/examples/ruby-sample/src/layers/ruby.rs
+++ b/examples/ruby-sample/src/layers/ruby.rs
@@ -8,7 +8,7 @@ use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use std::path::Path;
 use tempfile::NamedTempFile;
 
-pub struct RubyLayer;
+pub(crate) struct RubyLayer;
 
 impl Layer for RubyLayer {
     type Buildpack = RubyBuildpack;

--- a/examples/ruby-sample/src/main.rs
+++ b/examples/ruby-sample/src/main.rs
@@ -19,7 +19,7 @@ use std::process::ExitStatus;
 mod layers;
 mod util;
 
-pub struct RubyBuildpack;
+pub(crate) struct RubyBuildpack;
 
 impl Buildpack for RubyBuildpack {
     type Platform = GenericPlatform;
@@ -67,12 +67,12 @@ impl Buildpack for RubyBuildpack {
 
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
-pub struct RubyBuildpackMetadata {
+pub(crate) struct RubyBuildpackMetadata {
     pub ruby_url: String,
 }
 
 #[derive(Debug)]
-pub enum RubyBuildpackError {
+pub(crate) enum RubyBuildpackError {
     RubyDownloadError(DownloadError),
     RubyUntarError(UntarError),
     CouldNotCreateTemporaryFile(std::io::Error),

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -55,7 +55,7 @@ const LIBCNB_SUPPORTED_BUILDPACK_API: data::buildpack::BuildpackApi =
 /// use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
 /// use libcnb::{buildpack_main, data::build_plan::BuildPlan, Buildpack};
 ///
-/// struct MyBuildpack;
+/// pub(crate) struct MyBuildpack;
 ///
 /// impl Buildpack for MyBuildpack {
 ///     type Platform = GenericPlatform;


### PR DESCRIPTION
For the common case of buildpacks being built only as a binary, and not as a library, it's not necessary to publicly export everything.

When `pub` is used, Clippy cannot warn about deadcode, since it doesn't know if the struct/function is called via a consumer of the public API.

Switching to `pub(crate)` avoids this problem.

In addition, the `basics` example has been switched from a private buildpack struct to `pub(crate)` for the reasons in #290, closing #290.