### PR TITLE
Compile README tests as a part of doctest

### DIFF
--- a/libcnb-test/README.md
+++ b/libcnb-test/README.md
@@ -17,7 +17,9 @@ Please use the same tag for feature requests.
 // In $CRATE_ROOT/tests/integration_test.rs
 use libcnb_test::{assert_contains, BuildpackReference, TestRunner, TestConfig};
 
-#[test]
+// In your code you'll want to mark your function as a test with `#[test]`.
+// It is removed here for compatability with doctest so this code in the readme
+// tests for compilation.
 fn test() {
     TestRunner::default().run_test(
         TestConfig::new("heroku/builder:22", "test-fixtures/app"),

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -25,6 +25,6 @@ pub use crate::test_runner::*;
 
 // This runs the README.md as a doctest, ensuring the code examples in it are valid.
 // It will not be part of the final crate.
-#[cfg(doctest)]
 #[doc = include_str!("../README.md")]
+#[cfg(doctest)]
 pub struct ReadmeDoctests;


### PR DESCRIPTION

In https://github.com/heroku/libcnb.rs/pull/366#issuecomment-1151577355 I left feedback that stated the README was broken. I found we actually DO have doctests on it but even if you add a non-existent method in there it still passes. Why? Because the method has the `#[test]` line on it so it only compiles on the test environment and doctest does not use the test environment.

I removed the config declaration and added a comment explaining why.

In `lib.rs` I moved the ordering to match https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html but I don't think it has an impact.