### PR TITLE
Add more tests for `ExecDProgramOutputKey`

### DIFF
--- a/libcnb-data/src/exec_d.rs
+++ b/libcnb-data/src/exec_d.rs
@@ -95,6 +95,20 @@ mod tests {
         );
 
         assert_eq!(
+            "FOO.BAR".parse::<ExecDProgramOutputKey>(),
+            Err(ExecDProgramOutputKeyError::InvalidValue(String::from(
+                "FOO.BAR"
+            )))
+        );
+
+        assert_eq!(
+            "FOO/BAR".parse::<ExecDProgramOutputKey>(),
+            Err(ExecDProgramOutputKeyError::InvalidValue(String::from(
+                "FOO/BAR"
+            )))
+        );
+
+        assert_eq!(
             "FÜCHSCHEN".parse::<ExecDProgramOutputKey>(),
             Err(ExecDProgramOutputKeyError::InvalidValue(String::from(
                 "FÜCHSCHEN"


### PR DESCRIPTION
Several of the newtype types accept the characters `.` and `/`, but these are not valid in `ExecDProgramOutputKey` values. As such, it seems worth having explicit tests for these cases.