### PR TITLE
Fix `verify_regex` proc macro's error handling

### DIFF
--- a/libcnb-proc-macros/CHANGELOG.md
+++ b/libcnb-proc-macros/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix `verify_regex`'s error handling when the regex could not be compiled. ([#438](https://github.com/heroku/libcnb.rs/pull/438))
+
 ## [0.2.2] 2022-06-24
 
 - Update `cargo_metadata` dependency from 0.14.2 to 0.15.0 ([#423](https://github.com/heroku/libcnb.rs/pull/423)).

--- a/libcnb-proc-macros/src/lib.rs
+++ b/libcnb-proc-macros/src/lib.rs
@@ -37,11 +37,11 @@ pub fn verify_regex(input: TokenStream) -> TokenStream {
 
             quote! { #expression }
         }
-        Err(_) => {
-            quote! {
-                compile_error!(concat!("Could not compile regular expression: ", #(verify_regex_input.regex)));
-            }
-        }
+        Err(err) => syn::Error::new(
+            input.regex.span(),
+            format!("Could not compile regular expression: {err}"),
+        )
+        .to_compile_error(),
     };
 
     token_stream.into()


### PR DESCRIPTION
Previously if an error was encountered whilst parsing the regex, a confusing internal macro error was emitted (see #437 for output).

Now the actual regex error is output, eg:

```
error: Could not compile regular expression: Opening parenthesis without closing parenthesis
  --> examples/ruby-sample/src/main.rs:40:47
   |
40 |         let ruby_layer = context.handle_layer(layer_name!("ruby"), RubyLayer)?;
   |                                               ^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `layer_name` (in Nightly builds, run with -Z macro-backtrace for more info)
```

See:
https://docs.rs/syn/latest/syn/struct.Error.html
https://stackoverflow.com/a/54394014

Fixes #437.
GUS-W-11375177.