### PR TITLE
Disable `fancy-regex` default features

### DIFF
--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Disable `fancy-regex` default features (such as unused unicode support) to reduce buildpack binary size. ([#439](https://github.com/heroku/libcnb.rs/pull/439))
+
 # [0.7.0] 2022-06-24
 
 - Add `Launch::processes` function to add multiple `Process`es to a `Launch` value at once. ([#418](https://github.com/heroku/libcnb.rs/pull/418)) 

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
-fancy-regex = "0.10.0"
+fancy-regex = { version = "0.10.0", default-features = false }
 libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.2.2" }
 serde = { version = "1.0.137", features = ["derive"] }
 thiserror = "1.0.31"

--- a/libcnb-proc-macros/CHANGELOG.md
+++ b/libcnb-proc-macros/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Disable `fancy-regex` default features (such as unused unicode support) to reduce buildpack binary size. ([#439](https://github.com/heroku/libcnb.rs/pull/439))
 - Fix `verify_regex`'s error handling when the regex could not be compiled. ([#438](https://github.com/heroku/libcnb.rs/pull/438))
 
 ## [0.2.2] 2022-06-24

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -15,6 +15,6 @@ proc-macro = true
 
 [dependencies]
 cargo_metadata = "0.15.0"
-fancy-regex = "0.10.0"
+fancy-regex = { version = "0.10.0", default-features = false }
 quote = "1.0.20"
 syn = { version = "1.0.98", features = ["full"] }


### PR DESCRIPTION
The `fancy-regex` crate (like the `regex` crate, which it wraps), has a number of additional features enabled by default, that we do not need and cause the binary size and compilation times to be increased.

Specifically:
- We don't need unicode support in our validation regexes.
- We only use a few simple regexes against small haystack sizes, that are only invoked a handful of times (once per field in TOML files) so don't need `regex`'s advanced performance optimisations.

For more information, see:
https://docs.rs/regex/latest/regex/#crate-features

By disabling these, the release+stripped binary size of the `basics` buildpack (which is a baseline for all other buildpacks, no buildpacks can be slimmer than this) is reduced from 2.1 MB to 1.3 MB.

Whilst in absolute terms it's not a massive reduction:
- I think it's important for libcnb to be seen as a slim/lightweight framework, given people will inevitably compare it to say using bash scripts.
- This saving can add up for builders that use a micro-buildpack based strategy (where there will be many many buildpacks in the builder).
- It increases libcnb.rs' value proposition over some of the alternative Go-based CNB frameworks, whose binaries are often larger.

Note: Whilst this is marked as a breaking change, it's only breaking for consumers of the `libcnb-proc-macros` crate, not `libcnb-data`.

Fixes #365.