### PR TITLE
Fix rustdocs for `LogOutput`

### DIFF
--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix rustdocs for `LogOutput`. ([#440](https://github.com/heroku/libcnb.rs/pull/440)).
+
 ## [0.4.0] 2022-06-24
 
 - Leverage `Into` trait for `String`/`&str` arguments in `ContainerContext` ([#412](https://github.com/heroku/libcnb.rs/pull/412)).

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -19,6 +19,7 @@ mod test_runner;
 mod util;
 
 pub use crate::container_context::*;
+pub use crate::log::*;
 pub use crate::test_config::*;
 pub use crate::test_context::*;
 pub use crate::test_runner::*;

--- a/libcnb-test/src/log.rs
+++ b/libcnb-test/src/log.rs
@@ -1,5 +1,6 @@
 use tokio_stream::{Stream, StreamExt};
 
+/// Container log output.
 #[derive(Debug, Default)]
 pub struct LogOutput {
     pub stdout_raw: Vec<u8>,


### PR DESCRIPTION
The rustdocs for `LogOutput` were previously not being shown since the module was not publicly exported, even though it was exposed via other modules.

Fixes #404.