### PR TITLE
Add more docs for libcnb-test

### DIFF
--- a/libcnb-test/README.md
+++ b/libcnb-test/README.md
@@ -15,10 +15,10 @@ Please use the same tag for feature requests.
 
 ```rust,no_run
 // In $CRATE_ROOT/tests/integration_test.rs
-use libcnb_test::{assert_contains, BuildpackReference, TestRunner, TestConfig};
+use libcnb_test::{assert_contains, TestConfig, TestRunner};
 
 // In your code you'll want to mark your function as a test with `#[test]`.
-// It is removed here for compatability with doctest so this code in the readme
+// It is removed here for compatibility with doctest so this code in the readme
 // tests for compilation.
 fn test() {
     TestRunner::default().run_test(

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -10,6 +10,10 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// Context for preparing a container.
+///
+/// Created by [`TestContext::prepare_container`] and is used to configure the
+/// container before running it.
 pub struct PrepareContainerContext<'a> {
     test_context: &'a TestContext<'a>,
     exposed_ports: Vec<u16>,
@@ -45,10 +49,11 @@ impl<'a> PrepareContainerContext<'a> {
     ///     |context| {
     ///         context
     ///             .prepare_container()
-    ///             .envs(vec![("FOO", "FOO_VALUE"), ("BAR", "BAR_VALUE")])
+    ///             .env("FOO", "FOO_VALUE")
+    ///             .env("BAR", "BAR_VALUE")
     ///             .start_with_default_process(|container| {
     ///                 // ...
-    ///             })
+    ///             });
     ///     },
     /// );
     /// ```
@@ -71,7 +76,7 @@ impl<'a> PrepareContainerContext<'a> {
     ///             .envs(vec![("FOO", "FOO_VALUE"), ("BAR", "BAR_VALUE")])
     ///             .start_with_default_process(|container| {
     ///                 // ...
-    ///             })
+    ///             });
     ///     },
     /// );
     /// ```
@@ -91,9 +96,21 @@ impl<'a> PrepareContainerContext<'a> {
     ///
     /// See: [CNB App Developer Guide: Run a multi-process app - Default process type](https://buildpacks.io/docs/app-developer-guide/run-an-app/#default-process-type)
     ///
-    /// # Panics
-    /// - When the container could not be created
-    /// - When the container could not be started
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         context
+    ///             .prepare_container()
+    ///             .start_with_default_process(|container| {
+    ///                 // ...
+    ///             });
+    ///     },
+    /// );
+    /// ```
     pub fn start_with_default_process<F: FnOnce(ContainerContext)>(&self, f: F) {
         self.start_internal(None, None, f);
     }
@@ -103,9 +120,22 @@ impl<'a> PrepareContainerContext<'a> {
     ///
     /// See: [CNB App Developer Guide: Run a multi-process app - Default process type with additional arguments](https://buildpacks.io/docs/app-developer-guide/run-an-app/#default-process-type-with-additional-arguments)
     ///
-    /// # Panics
-    /// - When the container could not be created
-    /// - When the container could not be started
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         context.prepare_container().start_with_default_process_args(
+    ///             ["--version"],
+    ///             |container| {
+    ///                 // ...
+    ///             },
+    ///         );
+    ///     },
+    /// );
+    /// ```
     pub fn start_with_default_process_args<
         F: FnOnce(ContainerContext),
         A: IntoIterator<Item = I>,
@@ -122,9 +152,21 @@ impl<'a> PrepareContainerContext<'a> {
     ///
     /// See: [CNB App Developer Guide: Run a multi-process app - Non-default process-type](https://buildpacks.io/docs/app-developer-guide/run-an-app/#non-default-process-type)
     ///
-    /// # Panics
-    /// - When the container could not be created
-    /// - When the container could not be started
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         context
+    ///             .prepare_container()
+    ///             .start_with_process("worker", |container| {
+    ///                 // ...
+    ///             });
+    ///     },
+    /// );
+    /// ```
     pub fn start_with_process<F: FnOnce(ContainerContext), P: Into<String>>(
         &self,
         process: P,
@@ -138,9 +180,23 @@ impl<'a> PrepareContainerContext<'a> {
     ///
     /// See: [CNB App Developer Guide: Run a multi-process app - Non-default process-type with additional arguments](https://buildpacks.io/docs/app-developer-guide/run-an-app/#non-default-process-type-with-additional-arguments)
     ///
-    /// # Panics
-    /// - When the container could not be created
-    /// - When the container could not be started
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         context.prepare_container().start_with_process_args(
+    ///             "worker",
+    ///             ["--config", "foo.toml"],
+    ///             |container| {
+    ///                 // ...
+    ///             },
+    ///         );
+    ///     },
+    /// );
+    /// ```
     pub fn start_with_process_args<
         F: FnOnce(ContainerContext),
         A: IntoIterator<Item = I>,
@@ -166,9 +222,21 @@ impl<'a> PrepareContainerContext<'a> {
     ///
     /// See: [CNB App Developer Guide: Run a multi-process app - User-provided shell process](https://buildpacks.io/docs/app-developer-guide/run-an-app/#user-provided-shell-process)
     ///
-    /// # Panics
-    /// - When the container could not be created
-    /// - When the container could not be started
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         context
+    ///             .prepare_container()
+    ///             .start_with_shell_command("env", |container| {
+    ///                 // ...
+    ///             });
+    ///     },
+    /// );
+    /// ```
     pub fn start_with_shell_command<F: FnOnce(ContainerContext), C: Into<String>>(
         &self,
         command: C,
@@ -227,7 +295,9 @@ impl<'a> PrepareContainerContext<'a> {
     }
 }
 
+/// Context of a launched container.
 pub struct ContainerContext<'a> {
+    /// The randomly generated name of this container.
     pub container_name: String,
     pub(crate) test_context: &'a TestContext<'a>,
 }
@@ -241,8 +311,22 @@ impl<'a> ContainerContext<'a> {
     ///
     /// See: [`logs_wait`](Self::logs_wait) for a blocking alternative.
     ///
-    /// # Panics
-    /// - When the log output could not be consumed/read.
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{assert_contains, TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         // ...
+    ///         context
+    ///             .prepare_container()
+    ///             .start_with_default_process(|container| {
+    ///                 assert_contains!(container.logs_now().stdout, "Expected output");
+    ///             });
+    ///     },
+    /// );
+    /// ```
     #[must_use]
     pub fn logs_now(&self) -> LogOutput {
         // Bollard forces us to cast to i64
@@ -268,8 +352,22 @@ impl<'a> ContainerContext<'a> {
     ///
     /// See: [`logs_now`](Self::logs_now) for a non-blocking alternative.
     ///
-    /// # Panics
-    /// - When the log output could not be consumed/read.
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{assert_contains, TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         // ...
+    ///         context
+    ///             .prepare_container()
+    ///             .start_with_default_process(|container| {
+    ///                 assert_contains!(container.logs_wait().stdout, "Expected output");
+    ///             });
+    ///     },
+    /// );
+    /// ```
     #[must_use]
     pub fn logs_wait(&self) -> LogOutput {
         self.logs_internal(bollard::container::LogsOptions {
@@ -298,7 +396,35 @@ impl<'a> ContainerContext<'a> {
             .expect("Could not consume container log output")
     }
 
-    /// # Panics
+    /// Returns the local address of an exposed container port.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{TestConfig, TestRunner};
+    ///
+    /// # fn call_test_fixture_service(addr: std::net::SocketAddr, payload: &str) -> Result<String, ()> {
+    /// #    unimplemented!()
+    /// # }
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         // ...
+    ///         context
+    ///             .prepare_container()
+    ///             .expose_port(12345)
+    ///             .start_with_default_process(|container| {
+    ///                 assert_eq!(
+    ///                     call_test_fixture_service(
+    ///                         container.address_for_port(12345).unwrap(),
+    ///                         "Hagbard Celine"
+    ///                     )
+    ///                     .unwrap(),
+    ///                     "enileC drabgaH"
+    ///                 );
+    ///             });
+    ///     },
+    /// );
+    /// ```
     #[must_use]
     pub fn address_for_port(&self, port: u16) -> Option<SocketAddr> {
         self.test_context.runner.tokio_runtime.block_on(async {
@@ -307,12 +433,12 @@ impl<'a> ContainerContext<'a> {
                 .docker
                 .inspect_container(&self.container_name, None)
                 .await
-                .unwrap()
+                .expect("Could not inspect container")
                 .network_settings
                 .and_then(|network_settings| network_settings.ports)
                 .and_then(|ports| {
                     container_port_mapping::parse_port_map(&ports)
-                        .unwrap()
+                        .expect("Could not parse container port mapping")
                         .get(&port)
                         .copied()
                 })
@@ -321,7 +447,22 @@ impl<'a> ContainerContext<'a> {
 
     /// Executes a shell command inside an already running container.
     ///
-    /// # Panics
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{assert_contains, TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         // ...
+    ///         context
+    ///             .prepare_container()
+    ///             .start_with_default_process(|container| {
+    ///                 assert_contains!(container.shell_exec("ps").stdout, "gunicorn");
+    ///             });
+    ///     },
+    /// );
+    /// ```
     pub fn shell_exec(&self, command: impl AsRef<str>) -> LogOutput {
         self.test_context.runner.tokio_runtime.block_on(async {
             let create_exec_result = self
@@ -337,7 +478,7 @@ impl<'a> ContainerContext<'a> {
                     },
                 )
                 .await
-                .unwrap();
+                .expect("Could not create container exec instance");
 
             let start_exec_result = self
                 .test_context
@@ -345,7 +486,7 @@ impl<'a> ContainerContext<'a> {
                 .docker
                 .start_exec(&create_exec_result.id, None)
                 .await
-                .unwrap();
+                .expect("Could not start container exec instance");
 
             match start_exec_result {
                 StartExecResults::Attached { output, .. } => {

--- a/libcnb-test/src/test_config.rs
+++ b/libcnb-test/src/test_config.rs
@@ -20,6 +20,18 @@ impl TestConfig {
     /// If the `app_dir` parameter is a relative path, it is treated as relative to the Cargo
     /// manifest directory ([`CARGO_MANIFEST_DIR`](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates)),
     /// i.e. the package's root directory.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         // ...
+    ///     },
+    /// );
+    /// ```
     pub fn new(builder_name: impl Into<String>, app_dir: impl AsRef<Path>) -> Self {
         TestConfig {
             app_dir: PathBuf::from(app_dir.as_ref()),
@@ -35,6 +47,21 @@ impl TestConfig {
     /// Sets the buildpacks order.
     ///
     /// Defaults to [`BuildpackReference::Crate`].
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{BuildpackReference, TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app").buildpacks(vec![
+    ///         BuildpackReference::Other(String::from("heroku/another-buildpack")),
+    ///         BuildpackReference::Crate,
+    ///     ]),
+    ///     |context| {
+    ///         // ...
+    ///     },
+    /// );
+    /// ```
     pub fn buildpacks(&mut self, buildpacks: impl Into<Vec<BuildpackReference>>) -> &mut Self {
         self.buildpacks = buildpacks.into();
         self
@@ -43,6 +70,19 @@ impl TestConfig {
     /// Sets the target triple used when compiling the buildpack.
     ///
     /// Defaults to `x86_64-unknown-linux-musl`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app")
+    ///         .target_triple("x86_64-unknown-linux-musl"),
+    ///     |context| {
+    ///         // ...
+    ///     },
+    /// );
+    /// ```
     pub fn target_triple(&mut self, target_triple: impl Into<String>) -> &mut Self {
         self.target_triple = target_triple.into();
         self
@@ -64,7 +104,7 @@ impl TestConfig {
     ///     |context| {
     ///         // ...
     ///     },
-    /// )
+    /// );
     /// ```
     pub fn env(&mut self, k: impl Into<String>, v: impl Into<String>) -> &mut Self {
         self.env.insert(k.into(), v.into());
@@ -114,9 +154,9 @@ impl TestConfig {
     /// use libcnb_test::{TestConfig, TestRunner};
     ///
     /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app").app_dir_preprocessor(
-    ///         |app_dir| std::fs::remove_file(app_dir.join("Procfile")).unwrap(),
-    ///     ),
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app").app_dir_preprocessor(|app_dir| {
+    ///         std::fs::remove_file(app_dir.join("Procfile")).unwrap();
+    ///     }),
     ///     |context| {
     ///         // ...
     ///     },
@@ -132,6 +172,22 @@ impl TestConfig {
     /// The app directory is normally set in the [`TestConfig::new`] call, but when sharing test
     /// configuration, it might be necessary to change the app directory but keep everything else
     /// the same.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{TestConfig, TestRunner};
+    ///
+    /// fn default_config() -> TestConfig {
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app")
+    /// }
+    ///
+    /// TestRunner::default().run_test(
+    ///     default_config().app_dir("test-fixtures/a-different-app"),
+    ///     |context| {
+    ///         // ...
+    ///     },
+    /// );
+    /// ```
     pub fn app_dir<P: Into<PathBuf>>(&mut self, path: P) -> &mut Self {
         self.app_dir = path.into();
         self
@@ -143,19 +199,32 @@ impl TestConfig {
     /// error output. When passed [`PackResult::Failure`], the test will fail if the pack build
     /// succeeds and vice-versa.
     ///
-    /// Defaults to [`PackResult::Success`]
+    /// Defaults to [`PackResult::Success`].
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{PackResult, TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app")
+    ///         .expected_pack_result(PackResult::Failure),
+    ///     |context| {
+    ///         // ...
+    ///     },
+    /// );
+    /// ```
     pub fn expected_pack_result(&mut self, pack_result: PackResult) -> &mut Self {
         self.expected_pack_result = pack_result;
         self
     }
 }
 
-/// References a Cloud Native Buildpack
+/// References a Cloud Native Buildpack.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum BuildpackReference {
-    /// References the buildpack in the Rust Crate currently being tested
+    /// References the buildpack in the Rust Crate currently being tested.
     Crate,
-    /// References another buildpack by id, local directory or tarball
+    /// References another buildpack by id, local directory or tarball.
     Other(String),
 }
 

--- a/libcnb-test/src/test_context.rs
+++ b/libcnb-test/src/test_context.rs
@@ -29,7 +29,7 @@ impl<'a> TestContext<'a> {
     /// use libcnb_test::{TestConfig, TestRunner};
     ///
     /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/empty-app"),
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         context
     ///             .prepare_container()
@@ -56,11 +56,6 @@ impl<'a> TestContext<'a> {
     /// Note that this function will consume the current context. This is because the image will
     /// be changed by the subsequent test, invalidating the context. Running a subsequent test must
     /// therefore be the last operation. You can nest subsequent runs if required.
-    ///
-    /// # Panics
-    /// - When the app could not be copied
-    /// - When this crate could not be packaged as a buildpack
-    /// - When the `pack` command unexpectedly fails
     ///
     /// # Example
     /// ```no_run

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -16,16 +16,13 @@ use std::process::{Command, Stdio};
 ///
 /// # Example
 /// ```no_run
-/// use libcnb_test::{TestConfig, BuildpackReference, assert_contains, TestRunner};
+/// use libcnb_test::{assert_contains, TestConfig, TestRunner};
 ///
 /// # fn call_test_fixture_service(addr: std::net::SocketAddr, payload: &str) -> Result<String, ()> {
 /// #    unimplemented!()
 /// # }
 /// TestRunner::default().run_test(
-///     TestConfig::new("heroku/builder:22", "test-fixtures/app").buildpacks(vec![
-///         BuildpackReference::Other(String::from("heroku/openjdk")),
-///         BuildpackReference::Crate,
-///     ]),
+///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
 ///     |context| {
 ///         assert_contains!(context.pack_stdout, "---> Maven Buildpack");
 ///         assert_contains!(context.pack_stdout, "---> Installing Maven");
@@ -96,18 +93,13 @@ impl TestRunner {
 
     /// Starts a new integration test run.
     ///
-    /// This function copies the application to a temporary directory, cross-compiles this crate,
-    /// packages it as a buildpack and then invokes [pack](https://buildpacks.io/docs/tools/pack/)
+    /// This function copies the application to a temporary directory (if necessary), cross-compiles the current
+    /// crate, packages it as a buildpack and then invokes [pack](https://buildpacks.io/docs/tools/pack/)
     /// to build a new Docker image with the buildpacks specified by the passed [`TestConfig`].
     ///
     /// Since this function is supposed to only be used in integration tests, failures are not
     /// signalled via [`Result`](Result) values. Instead, this function panics whenever an unexpected error
     /// occurred to simplify testing code.
-    ///
-    /// # Panics
-    /// - When the app could not be copied
-    /// - When this crate could not be packaged as a buildpack
-    /// - When the `pack` command unexpectedly fails
     ///
     /// # Example
     /// ```no_run


### PR DESCRIPTION
All public structs and methods are now documented and missing examples have been added. Some existing examples with mis-formatted code have also been fixed.

Some last remaining `.unwrap()` usages have been switched to `.expect()`, since it (a) gives better error messages, (b) means the `clippy::missing_panics_doc` lint no longer insists on the `# Panics` rustdocs section (which is redundant for `libcnb-test`, since we state upfront that failures mean panics, given that's how tests indicate failures).

Closes #406.