### PR TITLE
libcnb-cargo: Disable unused `stderrlog` features

### DIFF
--- a/libcnb-cargo/CHANGELOG.md
+++ b/libcnb-cargo/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fix the packaged buildpack size reported by `cargo libcnb package` ([#442](https://github.com/heroku/libcnb.rs/pull/442)).
+- Reduce number of dependencies to improve installation time. ([#442](https://github.com/heroku/libcnb.rs/pull/442) and [#443](https://github.com/heroku/libcnb.rs/pull/443))
 
 ## [0.4.1] 2022-06-24
 

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -24,4 +24,4 @@ clap = { version = "3.2.5", default-features = false, features = [
 libcnb-package = { version = "0.1.2", path = "../libcnb-package" }
 log = "0.4.17"
 pathdiff = "0.2.1"
-stderrlog = "0.5.1"
+stderrlog = { version = "0.5.3", default-features = false}


### PR DESCRIPTION
As of `stderrlog` v0.5.3 (https://github.com/cardoe/stderrlog-rs/pull/45), it's possible to disable the timestamps feature of `stderrlog` (which we don't use), which otherwise requires the `chrono` dependency. 

Doing so reduces the number of transitive dependencies by 5, and also removes Chrono from the dependency tree, which currently has reported CVEs so can cause security audit false positives.

GUS-W-11378865.