### PR TITLE
Use `cargo add` in Quick Start Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,14 @@ $ cargo new my-buildpack
      Created binary (application) `my-buildpack` package
 ```
 
-Then, modify your project's `Cargo.toml` to include the `libcnb` dependency:
+Then, add the `libcnb` dependency to your project's `Cargo.toml`:
 
-```toml
-[package]
-name = "my-buildpack"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-libcnb = "0.8.0"
+```shell
+$ cargo add libcnb
 ```
+
+Note: If you get an error about `cargo add` not being a supported command, make sure you are
+using Rust 1.62+, or else install [cargo-edit](https://github.com/killercup/cargo-edit).
 
 Since we're writing a Cloud Native Buildpack, we also need a `buildpack.toml`. Use the template below and write it to a
 file named `buildpack.toml` in the root of your project, right next to `Cargo.toml`.


### PR DESCRIPTION
As of Rust 1.62, `cargo add` is now supported natively, and simplifies one of the steps in the quick start guide.

It also means one fewer version number string to update during releases.

See:
https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html#cargo-add