### PR TITLE
Explicitly check `TestConfig::app_dir` is a valid directory

### DIFF
--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Check that `TestConfig::app_dir` is a valid directory before applying `TestConfig::app_dir_preprocessor` or invoking Pack, so that a clearer error message can be displayed. ([#452](https://github.com/heroku/libcnb.rs/pull/452))
 - Add an `assert_empty!` macro, for improved UX over using `assert!` with `str::is_empty`. ([#451](https://github.com/heroku/libcnb.rs/pull/451)).
 - Fix rustdocs for `LogOutput`. ([#440](https://github.com/heroku/libcnb.rs/pull/440)).
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -136,6 +136,12 @@ impl TestRunner {
                 config.app_dir.clone()
             };
 
+            assert!(
+                normalized_app_dir_path.is_dir(),
+                "App dir is not a valid directory: {}",
+                normalized_app_dir_path.display()
+            );
+
             // Copy the app to a temporary directory if an app_dir_preprocessor is specified and run the
             // preprocessor. Skip app copying if no changes to the app will be made.
             if let Some(app_dir_preprocessor) = &config.app_dir_preprocessor {

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -256,10 +256,16 @@ fn app_dir_absolute_path() {
 
 #[test]
 #[ignore]
-// TODO: We should validate `app_dir` explicitly before passing to pack:
-// https://github.com/heroku/libcnb.rs/issues/448
-#[should_panic(expected = "pack stderr:
-ERROR: failed to build: invalid app path")]
+// The actual panic message looks like this:
+// `"App dir is not a valid directory: /.../libcnb-test/test-fixtures/non-existent-fixture"`
+// It's intentionally an absolute path to make debugging failures easier when a relative path
+// has been passed (the common case). However, since the absolute path is system/environment
+// dependent, we would need to construct the expected string dynamically in `should_panic`,
+// but cannot due to: https://github.com/rust-lang/rust/issues/88430
+// As such we test the most important part, the fact that the error message lists the non-existent
+// fixture directory path. We intentionally include the `libcnb-test/` crate directory prefix,
+// since that only appears in the absolute path, not the relative path passed to `TestConfig::new`.
+#[should_panic(expected = "libcnb-test/test-fixtures/non-existent-fixture")]
 fn app_dir_invalid_path() {
     TestRunner::default().run_test(
         TestConfig::new("heroku/builder:22", "test-fixtures/non-existent-fixture")
@@ -270,12 +276,11 @@ fn app_dir_invalid_path() {
 
 #[test]
 #[ignore]
-// TODO: We should validate `app_dir` explicitly before passing to app_dir_preprocessor:
-// https://github.com/heroku/libcnb.rs/issues/448
-#[should_panic(
-    expected = "Could not copy app to temporary location: CopyAppError(Error { kind: NotFound"
-)]
-fn app_dir_invalid_path_with_preprocessor() {
+// The actual panic message looks like this:
+// `"App dir is not a valid directory: /.../libcnb-test/test-fixtures/non-existent-fixture"`
+// See above for why we only test this substring.
+#[should_panic(expected = "libcnb-test/test-fixtures/non-existent-fixture")]
+fn app_dir_invalid_path_checked_before_applying_preprocessor() {
     TestRunner::default().run_test(
         TestConfig::new("heroku/builder:22", "test-fixtures/non-existent-fixture")
             .buildpacks(Vec::new())


### PR DESCRIPTION
Check that `TestConfig::app_dir` is a valid directory before applying `TestConfig::app_dir_preprocessor` or invoking Pack, so that a clearer error message can be displayed.

Fixes #448.
GUS-W-11389417.