### PR TITLE
Consolidate default options for `PackBuildCommand`

### DIFF
--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -57,7 +57,6 @@ impl PackBuildCommand {
         builder: impl Into<String>,
         path: impl Into<PathBuf>,
         image_name: impl Into<String>,
-        pull_policy: PullPolicy,
     ) -> PackBuildCommand {
         PackBuildCommand {
             builder: builder.into(),
@@ -65,7 +64,8 @@ impl PackBuildCommand {
             env: BTreeMap::new(),
             image_name: image_name.into(),
             path: path.into(),
-            pull_policy,
+            // Prevent redundant image-pulling, which slows tests and risks hitting registry rate limits.
+            pull_policy: PullPolicy::IfNotPresent,
             trust_builder: true,
             verbose: false,
         }

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -1,4 +1,4 @@
-use crate::pack::{PackBuildCommand, PullPolicy};
+use crate::pack::PackBuildCommand;
 use crate::{app, build, util, BuildpackReference, PackResult, TestConfig, TestContext};
 use bollard::Docker;
 use std::borrow::Borrow;
@@ -159,13 +159,7 @@ impl TestRunner {
                         .expect("Could not package current crate as buildpack")
                 });
 
-        let mut pack_command = PackBuildCommand::new(
-            &config.builder_name,
-            &app_dir,
-            &image_name,
-            // Prevent redundant image-pulling, which slows tests and risks hitting registry rate limits.
-            PullPolicy::IfNotPresent,
-        );
+        let mut pack_command = PackBuildCommand::new(&config.builder_name, &app_dir, &image_name);
 
         config.env.iter().for_each(|(key, value)| {
             pack_command.env(key, value);


### PR DESCRIPTION
`PackBuildCommand::new` already contained a number of default options (such as `trust_builder: true` and `verbose: false`), with the exception of the chosen `PullPolicy`, which was the only option specified at the call site.

Now all default options are consolidated in `PackBuildCommand::new`.