### PR TITLE
Improve the error message shown when Pack CLI is not installed

### DIFF
--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## [Unreleased]
 
+- Improve the error message shown when Pack CLI is not installed. ([#455](https://github.com/heroku/libcnb.rs/pull/455))
 - Check that `TestConfig::app_dir` is a valid directory before applying `TestConfig::app_dir_preprocessor` or invoking Pack, so that a clearer error message can be displayed. ([#452](https://github.com/heroku/libcnb.rs/pull/452))
-- Add an `assert_empty!` macro, for improved UX over using `assert!` with `str::is_empty`. ([#451](https://github.com/heroku/libcnb.rs/pull/451)).
-- Fix rustdocs for `LogOutput`. ([#440](https://github.com/heroku/libcnb.rs/pull/440)).
+- Add an `assert_empty!` macro, for improved UX over using `assert!` with `str::is_empty`. ([#451](https://github.com/heroku/libcnb.rs/pull/451))
+- Fix rustdocs for `LogOutput`. ([#440](https://github.com/heroku/libcnb.rs/pull/440))
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
 
 ## [0.4.0] 2022-06-24


### PR DESCRIPTION
Before:

```
---- basic_build stdout ----
thread 'basic_build' panicked at 'Could not spawn external 'pack' process: Os { code: 2, kind: NotFound, message: "No such file or directory" }', /Users/emorley/src/libcnb.rs/libcnb-test/src/test_runner.rs:188:14
```

After:

```
---- basic_build stdout ----
thread 'basic_build' panicked at 'External `pack` command not found. Install Pack CLI and ensure it is on PATH: https://buildpacks.io/docs/install-pack', /Users/emorley/src/libcnb.rs/libcnb-test/src/test_runner.rs:184:21
```

No integration test has been added, since writing one would involve manipulating the `PATH` of the integration test process which would be prone to intermittent test failures given concurrent test execution occurs in threads.

In addition all panic messages that reference "pack" now do so inside backticks rather than single quotes, since the panic error message itself is inside single quotes, so it looked like the quoted section had ended prematurely.

Fixes #296.
GUS-W-11390631.