### PR TITLE
Support testing buildpacks compiled in release mode

### DIFF
--- a/libcnb-package/src/lib.rs
+++ b/libcnb-package/src/lib.rs
@@ -13,9 +13,14 @@ use libcnb_data::buildpack::SingleBuildpackDescriptor;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+/// The profile to use when invoking Cargo.
+///
+/// <https://doc.rust-lang.org/cargo/reference/profiles.html>
 #[derive(Copy, Clone)]
 pub enum CargoProfile {
+    /// Provides faster compilation times at the expense of runtime performance and binary size.
     Dev,
+    /// Produces assets with optimised runtime performance and binary size, at the expense of compilation time.
     Release,
 }
 

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Add `TestConfig::cargo_profile` and `CargoProfile` to support compilation of buildpacks in release mode. ([#456](https://github.com/heroku/libcnb.rs/pull/456))
 - Improve the error message shown when Pack CLI is not installed. ([#455](https://github.com/heroku/libcnb.rs/pull/455))
 - Check that `TestConfig::app_dir` is a valid directory before applying `TestConfig::app_dir_preprocessor` or invoking Pack, so that a clearer error message can be displayed. ([#452](https://github.com/heroku/libcnb.rs/pull/452))
 - Add an `assert_empty!` macro, for improved UX over using `assert!` with `str::is_empty`. ([#451](https://github.com/heroku/libcnb.rs/pull/451))

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -7,6 +7,7 @@ use tempfile::{tempdir, TempDir};
 
 /// Packages the current crate as a buildpack into a temporary directory.
 pub(crate) fn package_crate_buildpack(
+    cargo_profile: CargoProfile,
     target_triple: impl AsRef<str>,
 ) -> Result<TempDir, PackageCrateBuildpackError> {
     let cargo_manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
@@ -34,7 +35,7 @@ pub(crate) fn package_crate_buildpack(
     let buildpack_binaries = build_buildpack_binaries(
         &cargo_manifest_dir,
         &cargo_metadata,
-        CargoProfile::Dev,
+        cargo_profile,
         &cargo_env,
         target_triple.as_ref(),
     )

--- a/libcnb-test/src/test_config.rs
+++ b/libcnb-test/src/test_config.rs
@@ -2,10 +2,13 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
+pub use libcnb_package::CargoProfile;
+
 /// Configuration for a test.
 #[derive(Clone)]
 pub struct TestConfig {
     pub(crate) app_dir: PathBuf,
+    pub(crate) cargo_profile: CargoProfile,
     pub(crate) target_triple: String,
     pub(crate) builder_name: String,
     pub(crate) buildpacks: Vec<BuildpackReference>,
@@ -35,6 +38,7 @@ impl TestConfig {
     pub fn new(builder_name: impl Into<String>, app_dir: impl AsRef<Path>) -> Self {
         TestConfig {
             app_dir: PathBuf::from(app_dir.as_ref()),
+            cargo_profile: CargoProfile::Dev,
             target_triple: String::from("x86_64-unknown-linux-musl"),
             builder_name: builder_name.into(),
             buildpacks: vec![BuildpackReference::Crate],
@@ -64,6 +68,27 @@ impl TestConfig {
     /// ```
     pub fn buildpacks(&mut self, buildpacks: impl Into<Vec<BuildpackReference>>) -> &mut Self {
         self.buildpacks = buildpacks.into();
+        self
+    }
+
+    /// Sets the Cargo profile used when compiling the buildpack.
+    ///
+    /// Defaults to [`CargoProfile::Dev`].
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{CargoProfile, TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app")
+    ///         .cargo_profile(CargoProfile::Release),
+    ///     |context| {
+    ///         // ...
+    ///     },
+    /// );
+    /// ```
+    pub fn cargo_profile(&mut self, cargo_profile: CargoProfile) -> &mut Self {
+        self.cargo_profile = cargo_profile;
         self
     }
 

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -161,7 +161,7 @@ impl TestRunner {
                 .buildpacks
                 .contains(&BuildpackReference::Crate)
                 .then(|| {
-                    build::package_crate_buildpack(&config.target_triple)
+                    build::package_crate_buildpack(config.cargo_profile, &config.target_triple)
                         .expect("Could not package current crate as buildpack")
                 });
 


### PR DESCRIPTION
Previously `libcnb-test` only supported compiling the buildpack under test using Cargo's `dev` profile.

Now, `TestConfig::cargo_profile` can be used along with `CargoProfile` to instruct `libcnb-package` to compile the buildpack using Cargo's `release` mode (equivalent to `--release`).

The `TestConfig` default profile remains `CargoProfile::Dev` as before.

This:
- Allows buildpack maintainers to opt into release mode, if their buildpack's tests happen to run particularly slowly in debug mode. Whilst release builds take longer, in some cases this is vastly offset by the faster runtime performance of release builds (particularly when the compilation cache is warm).
- (As an added bonus) Could help in the future should we encounter any "release mode only" compiler related bugs, where being able to easily run integration tests in release mode would be invaluable.

An integration test has not been added, since:
- There is no easy way to determine in the test whether the buildpack was actually built in release mode or not (we don't expose the `cargo build` logs).
- The integration test would be the only one in this repo to run in release mode, so would add to the end to end time due to it having a cold compilation cache, and also bloat the CI cache (due to there being a mix of debug+release builds; something that people using release mode long-term in their own buildpack are unlikely to do).
- Most of this change has coverage via the type system + `TestConfig::cargo_profile` rustdoc example.
- The release mode is not new, and is already exercised via `libcnb-cargo`.

Fixes #386.
GUS-W-10912497.