### PR TITLE
Make changelog PR link style consistent

### DIFF
--- a/libcnb-cargo/CHANGELOG.md
+++ b/libcnb-cargo/CHANGELOG.md
@@ -2,25 +2,25 @@
 
 ## [Unreleased]
 
-- Fix the packaged buildpack size reported by `cargo libcnb package` ([#442](https://github.com/heroku/libcnb.rs/pull/442)).
+- Fix the packaged buildpack size reported by `cargo libcnb package`. ([#442](https://github.com/heroku/libcnb.rs/pull/442))
 - Reduce number of dependencies to improve installation time. ([#442](https://github.com/heroku/libcnb.rs/pull/442) and [#443](https://github.com/heroku/libcnb.rs/pull/443))
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
 
 ## [0.4.1] 2022-06-24
 
-- Update `cargo_metadata` dependency from 0.14.2 to 0.15.0 ([#423](https://github.com/heroku/libcnb.rs/pull/423)).
+- Update `cargo_metadata` dependency from `0.14.2` to `0.15.0`. ([#423](https://github.com/heroku/libcnb.rs/pull/423))
 
 ## [0.4.0] 2022-04-12
 
 - Move the packaging library parts of `libcnb-cargo` to a new `libcnb-package` crate. Consumers of the library should substitute all `libcnb-cargo` references with `libcnb-package` for equivalent functionality. ([#362](https://github.com/heroku/libcnb.rs/pull/362))
-- Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).
+- Update project URLs for the GitHub repository move to the `heroku` org. ([#388](https://github.com/heroku/libcnb.rs/pull/388))
 
 ## [0.3.0] 2022-02-28
 
 - Update cross-compile assistance on macOS to use https://github.com/messense/homebrew-macos-cross-toolchains instead of https://github.com/FiloSottile/homebrew-musl-cross. Support for the latter has not been removed, existing setups continue to work as before. ([#312](https://github.com/heroku/libcnb.rs/pull/312))
-- `libcnb-cargo` now cross-compiles and packages all binary targets of the buildpack. The main buildpack binary is either the only binary target or the target with the same name as the crate. This feature allows the usage of additional binaries for i.e. execd. ([#314](https://github.com/heroku/libcnb.rs/pull/314))
-- Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/heroku/libcnb.rs/pull/318)).
-- Upgrade CLI to Clap v3 ([#329](https://github.com/heroku/libcnb.rs/pull/329)).
+- `libcnb-cargo` now cross-compiles and packages all binary targets of the buildpack. The main buildpack binary is either the only binary target or the target with the same name as the crate. This feature allows the usage of additional binaries for i.e. `exec.d`. ([#314](https://github.com/heroku/libcnb.rs/pull/314))
+- Increase minimum supported Rust version from 1.56 to 1.58. ([#318](https://github.com/heroku/libcnb.rs/pull/318))
+- Upgrade CLI to Clap v3. ([#329](https://github.com/heroku/libcnb.rs/pull/329))
 - Update `libcnb-data` from `0.4.0` to `0.5.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#050-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
 
 ## [0.2.1] 2022-01-19
@@ -30,10 +30,10 @@
 
 ## [0.2.0] 2022-01-14
 
-- `BuildpackData`, `assemble_buildpack_directory()` and `default_buildpack_directory_name()` have been updated for the libcnb-data replacement of `BuildpackToml` with `*BuildpackDescriptor` and rename of `*buildpack_toml` to `*buildpack_descriptor` ([#248](https://github.com/heroku/libcnb.rs/pull/248) and [#254](https://github.com/heroku/libcnb.rs/pull/254)).
-- Bump external dependency versions ([#233](https://github.com/heroku/libcnb.rs/pull/233)).
-- Update `libcnb-data` from `0.3.0` to `0.4.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#040-2022-01-14) ([#276](https://github.com/heroku/libcnb.rs/pull/276)).
+- `BuildpackData`, `assemble_buildpack_directory()` and `default_buildpack_directory_name()` have been updated for the libcnb-data replacement of `BuildpackToml` with `*BuildpackDescriptor` and rename of `*buildpack_toml` to `*buildpack_descriptor`. ([#248](https://github.com/heroku/libcnb.rs/pull/248) and [#254](https://github.com/heroku/libcnb.rs/pull/254))
+- Bump external dependency versions. ([#233](https://github.com/heroku/libcnb.rs/pull/233))
+- Update `libcnb-data` from `0.3.0` to `0.4.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#040-2022-01-14). ([#276](https://github.com/heroku/libcnb.rs/pull/276))
 
 ## [0.1.0] 2021-12-08
 
-- Add a Cargo command for cross-compiling and packaging libcnb buildpacks ([#199](https://github.com/heroku/libcnb.rs/pull/199)).
+- Add a Cargo command for cross-compiling and packaging libcnb buildpacks. ([#199](https://github.com/heroku/libcnb.rs/pull/199))

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -7,39 +7,39 @@
 
 # [0.7.0] 2022-06-24
 
-- Add `Launch::processes` function to add multiple `Process`es to a `Launch` value at once. ([#418](https://github.com/heroku/libcnb.rs/pull/418)) 
+- Add `Launch::processes` function to add multiple `Process`es to a `Launch` value at once. ([#418](https://github.com/heroku/libcnb.rs/pull/418))
 - `Launch::process`'s argument changed from `Process` to `Into<Process>`. ([#418](https://github.com/heroku/libcnb.rs/pull/418))
-- Update `fancy-regex` dependency from 0.8.0 to 0.10.0 ([#393](https://github.com/heroku/libcnb.rs/pull/393) and [#394](https://github.com/heroku/libcnb.rs/pull/394)).
+- Update `fancy-regex` dependency from `0.8.0` to `0.10.0`. ([#393](https://github.com/heroku/libcnb.rs/pull/393) and [#394](https://github.com/heroku/libcnb.rs/pull/394))
 
 ## [0.6.0] 2022-04-12
 
 - Make `BuildPlan`'s `or` field public. ([#381](https://github.com/heroku/libcnb.rs/pull/381))
 - Add way to construct `Require` with metadata field and integrate with `BuildPlanBuilder`. ([#382](https://github.com/heroku/libcnb.rs/pull/382))
 - Add way to deserialize `Entry` metadata into a custom type. ([#382](https://github.com/heroku/libcnb.rs/pull/382))
-- Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).
+- Update project URLs for the GitHub repository move to the `heroku` org. ([#388](https://github.com/heroku/libcnb.rs/pull/388))
 
 ## [0.5.0] 2022-02-28
 
-- Add `#[must_use]` to `BuildPlan` and `BuildPlanBuilder` ([#288](https://github.com/heroku/libcnb.rs/pull/288)).
-- Add `exec_d` module with types representing the output of an `exec.d` program ([#324](https://github.com/heroku/libcnb.rs/pull/324)).
-- Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/heroku/libcnb.rs/pull/318)).
+- Add `#[must_use]` to `BuildPlan` and `BuildPlanBuilder`. ([#288](https://github.com/heroku/libcnb.rs/pull/288))
+- Add `exec_d` module with types representing the output of an `exec.d` program. ([#324](https://github.com/heroku/libcnb.rs/pull/324))
+- Increase minimum supported Rust version from 1.56 to 1.58. ([#318](https://github.com/heroku/libcnb.rs/pull/318))
 - Adjust newtype generated compile-time validation macros so that they don't also perform redundant validation at runtime. In cases where only compile-time validation is being performed (for example `exec.d` scripts), this results in a significant reduction in binary size. ([#331](https://github.com/heroku/libcnb.rs/pull/331))
 - Update `libcnb-proc-macros` from `0.1.1` to `0.2.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#020-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
 
 ## [0.4.0] 2022-01-14
 
-- Add `must_use` attributes to a number of pure public methods ([#232](https://github.com/heroku/libcnb.rs/pull/232)).
-- Remove builder-style methods from `LayerContentMetadata` ([#235](https://github.com/heroku/libcnb.rs/pull/235)).
-- Make `LayerContentMetadata`'s `types` field an `Option` ([#236](https://github.com/heroku/libcnb.rs/pull/236)).
-- Remove `LayerContentMetadata::Default()` ([#236](https://github.com/heroku/libcnb.rs/pull/236)).
-- Switch `Buildpack.version` from type `semver::Version` to `BuildpackVersion`, in order to validate versions more strictly against the CNB spec ([#241](https://github.com/heroku/libcnb.rs/pull/241)).
-- All libcnb-data struct types now reject unrecognised fields when deserializing ([#252](https://github.com/heroku/libcnb.rs/pull/252)).
-- `BuildpackToml` has been replaced by `BuildpackDescriptor`, which is an enum with `Single` and `Meta` variants that wrap new `SingleBuildpackDescriptor` and `MetaBuildpackDescriptor` types. The new types now reject `buildpack.toml` files where both `stacks` and `order` are present ([#248](https://github.com/heroku/libcnb.rs/pull/248)).
-- Implement `Borrow<str>` for types generated using the `libcnb_newtype!` macro (currently `BuildpackId`, `LayerName`, `ProcessType` and `StackId`), which allows them to be used with `.join()` ([#258](https://github.com/heroku/libcnb.rs/pull/258)).
-- `Launch` and `Process` can now be deserialized when optional fields are missing, and omit default values when serializing ([#243](https://github.com/heroku/libcnb.rs/pull/243) and [#265](https://github.com/heroku/libcnb.rs/pull/265)).
-- `Process::new` has been replaced by `ProcessBuilder` ([#265](https://github.com/heroku/libcnb.rs/pull/265)).
-- Bump external dependency versions ([#233](https://github.com/heroku/libcnb.rs/pull/233) and [#275](https://github.com/heroku/libcnb.rs/pull/275)).
-- Update `libcnb-proc-macros` from `0.1.0` to `0.1.1` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#011-2022-01-14) ([#276](https://github.com/heroku/libcnb.rs/pull/276)).
+- Add `must_use` attributes to a number of pure public methods. ([#232](https://github.com/heroku/libcnb.rs/pull/232))
+- Remove builder-style methods from `LayerContentMetadata`. ([#235](https://github.com/heroku/libcnb.rs/pull/235))
+- Make `LayerContentMetadata`'s `types` field an `Option`. ([#236](https://github.com/heroku/libcnb.rs/pull/236))
+- Remove `LayerContentMetadata::Default()`. ([#236](https://github.com/heroku/libcnb.rs/pull/236))
+- Switch `Buildpack.version` from type `semver::Version` to `BuildpackVersion`, in order to validate versions more strictly against the CNB spec. ([#241](https://github.com/heroku/libcnb.rs/pull/241))
+- All libcnb-data struct types now reject unrecognised fields when deserializing. ([#252](https://github.com/heroku/libcnb.rs/pull/252))
+- `BuildpackToml` has been replaced by `BuildpackDescriptor`, which is an enum with `Single` and `Meta` variants that wrap new `SingleBuildpackDescriptor` and `MetaBuildpackDescriptor` types. The new types now reject `buildpack.toml` files where both `stacks` and `order` are present. ([#248](https://github.com/heroku/libcnb.rs/pull/248))
+- Implement `Borrow<str>` for types generated using the `libcnb_newtype!` macro (currently `BuildpackId`, `LayerName`, `ProcessType` and `StackId`), which allows them to be used with `.join()`. ([#258](https://github.com/heroku/libcnb.rs/pull/258))
+- `Launch` and `Process` can now be deserialized when optional fields are missing, and omit default values when serializing. ([#243](https://github.com/heroku/libcnb.rs/pull/243) and [#265](https://github.com/heroku/libcnb.rs/pull/265))
+- `Process::new` has been replaced by `ProcessBuilder`. ([#265](https://github.com/heroku/libcnb.rs/pull/265))
+- Bump external dependency versions. ([#233](https://github.com/heroku/libcnb.rs/pull/233) and [#275](https://github.com/heroku/libcnb.rs/pull/275))
+- Update `libcnb-proc-macros` from `0.1.0` to `0.1.1` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#011-2022-01-14). ([#276](https://github.com/heroku/libcnb.rs/pull/276))
 
 ## [0.3.0] 2021-12-08
 

--- a/libcnb-package/CHANGELOG.md
+++ b/libcnb-package/CHANGELOG.md
@@ -8,13 +8,13 @@
 
 ## [0.1.2] 2022-06-24
 
-- Only create `.libcnb-cargo/additional-bin` if there are additional binaries to bundle ([#413](https://github.com/heroku/libcnb.rs/pull/413)).
-- Update `cargo_metadata` dependency from 0.14.2 to 0.15.0 ([#423](https://github.com/heroku/libcnb.rs/pull/423)).
+- Only create `.libcnb-cargo/additional-bin` if there are additional binaries to bundle. ([#413](https://github.com/heroku/libcnb.rs/pull/413))
+- Update `cargo_metadata` dependency from `0.14.2` to `0.15.0`. ([#423](https://github.com/heroku/libcnb.rs/pull/423))
 
 ## [0.1.1] 2022-04-12
 
-- Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).
+- Update project URLs for the GitHub repository move to the `heroku` org. ([#388](https://github.com/heroku/libcnb.rs/pull/388))
 
 ## [0.1.0] 2022-03-08
 
-- Initial release, containing the packaging functionality extracted from `libcnb-cargo` ([#362](https://github.com/heroku/libcnb.rs/pull/362)).
+- Initial release, containing the packaging functionality extracted from `libcnb-cargo`. ([#362](https://github.com/heroku/libcnb.rs/pull/362))

--- a/libcnb-proc-macros/CHANGELOG.md
+++ b/libcnb-proc-macros/CHANGELOG.md
@@ -8,22 +8,22 @@
 
 ## [0.2.2] 2022-06-24
 
-- Update `cargo_metadata` dependency from 0.14.2 to 0.15.0 ([#423](https://github.com/heroku/libcnb.rs/pull/423)).
-- Update `fancy-regex` dependency from 0.8.0 to 0.10.0 ([#393](https://github.com/heroku/libcnb.rs/pull/393) and [#394](https://github.com/heroku/libcnb.rs/pull/394)).
+- Update `cargo_metadata` dependency from `0.14.2` to `0.15.0`. ([#423](https://github.com/heroku/libcnb.rs/pull/423))
+- Update `fancy-regex` dependency from `0.8.0` to `0.10.0`. ([#393](https://github.com/heroku/libcnb.rs/pull/393) and [#394](https://github.com/heroku/libcnb.rs/pull/394))
 
 ## [0.2.1] 2022-04-12
 
-- Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).
+- Update project URLs for the GitHub repository move to the `heroku` org. ([#388](https://github.com/heroku/libcnb.rs/pull/388))
 
 ## [0.2.0] 2022-02-28
 
 - Add a `verify_bin_target_exists!` macro for verifying existence of binary targets in the current crate. ([#320](https://github.com/heroku/libcnb.rs/pull/320))
-- Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/heroku/libcnb.rs/pull/318)).
+- Increase minimum supported Rust version from 1.56 to 1.58. ([#318](https://github.com/heroku/libcnb.rs/pull/318))
 
 ## [0.1.1] 2022-01-14
 
-- Bump external dependency versions ([#233](https://github.com/heroku/libcnb.rs/pull/233) and [#275](https://github.com/heroku/libcnb.rs/pull/275)).
+- Bump external dependency versions. ([#233](https://github.com/heroku/libcnb.rs/pull/233) and [#275](https://github.com/heroku/libcnb.rs/pull/275))
 
 ## [0.1.0] 2021-12-08
 
-- Add a `verify_regex!` macro for compile-time string validation ([#172](https://github.com/heroku/libcnb.rs/pull/172)).
+- Add a `verify_regex!` macro for compile-time string validation. ([#172](https://github.com/heroku/libcnb.rs/pull/172))

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,61 +2,59 @@
 
 ## [Unreleased]
 
+- Add an `assert_empty!` macro, for improved UX over using `assert!` with `str::is_empty`. ([#451](https://github.com/heroku/libcnb.rs/pull/451))
 - Add `TestConfig::cargo_profile` and `CargoProfile` to support compilation of buildpacks in release mode. ([#456](https://github.com/heroku/libcnb.rs/pull/456))
 - Improve the error message shown when Pack CLI is not installed. ([#455](https://github.com/heroku/libcnb.rs/pull/455))
 - Check that `TestConfig::app_dir` is a valid directory before applying `TestConfig::app_dir_preprocessor` or invoking Pack, so that a clearer error message can be displayed. ([#452](https://github.com/heroku/libcnb.rs/pull/452))
-- Add an `assert_empty!` macro, for improved UX over using `assert!` with `str::is_empty`. ([#451](https://github.com/heroku/libcnb.rs/pull/451))
 - Fix rustdocs for `LogOutput`. ([#440](https://github.com/heroku/libcnb.rs/pull/440))
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
 
 ## [0.4.0] 2022-06-24
 
-- Leverage `Into` trait for `String`/`&str` arguments in `ContainerContext` ([#412](https://github.com/heroku/libcnb.rs/pull/412)).
-- Pass `--trust-builder` to `pack build` to ensure the builders used in tests are always trusted ([#409](https://github.com/heroku/libcnb.rs/pull/409)).
-- Add `IntegrationTest::app_dir_preprocessor`, allowing users to modify the app directory before an integration test run ([#397](https://github.com/heroku/libcnb.rs/pull/397)).
-- Update `bollard` dependency from 0.12.0 to 0.13.0 ([#419](https://github.com/heroku/libcnb.rs/pull/419)).
-- Update `cargo_metadata` dependency from 0.14.2 to 0.15.0 ([#423](https://github.com/heroku/libcnb.rs/pull/423)).
-- Add `assert_not_contains!` macro, an inverted version of `assert_contains!`. ([#424](https://github.com/heroku/libcnb.rs/pull/424)).
-- Remove `IntegrationTest::run_test`, to run a test use the new `TestRunner::run_test` function. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
-- Rename `IntegrationTest` to `TestConfig`. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
-- Rename `IntegrationTestContext` to `TestContext`. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
-- Add `Clone` implementation for `TestConfig`, allowing it to be shared across tests. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
-- Add `TestContext::run_test`, allowing you to run subsequent integration tests with the image from a previous test. These functions allow testing of subsequent builds, including caching logic and buildpack behaviour when build environment variables change, stacks are upgraded and more. ([#422](https://github.com/heroku/libcnb.rs/pull/422)).
-- Add `TestConfig::expected_pack_result`. When set to `PackResult::Failure`, it allows testing of build failure scenarios. ([#429](https://github.com/heroku/libcnb.rs/pull/429)).
-- Add `TestConfig::app_dir` which is handy in cases where `TestConfig` values are shared and only the `app_dir` needs to be different. ([#430](https://github.com/heroku/libcnb.rs/pull/430)).
-- Remove `TestContext::app_dir` to encourage the use of `TestConfig::app_dir_preprocessor`. ([#431](https://github.com/heroku/libcnb.rs/pull/431)).
-- Improve performance when no `TestConfig::app_dir_preprocessor` is configured by skipping application directory copying. ([#431](https://github.com/heroku/libcnb.rs/pull/431)).
+- Leverage `Into` trait for `String`/`&str` arguments in `ContainerContext`. ([#412](https://github.com/heroku/libcnb.rs/pull/412))
+- Pass `--trust-builder` to `pack build` to ensure the builders used in tests are always trusted. ([#409](https://github.com/heroku/libcnb.rs/pull/409))
+- Add `IntegrationTest::app_dir_preprocessor`, allowing users to modify the app directory before an integration test run. ([#397](https://github.com/heroku/libcnb.rs/pull/397))
+- Update `bollard` dependency from `0.12.0` to `0.13.0`. ([#419](https://github.com/heroku/libcnb.rs/pull/419))
+- Update `cargo_metadata` dependency from `0.14.2` to `0.15.0`. ([#423](https://github.com/heroku/libcnb.rs/pull/423))
+- Add `assert_not_contains!` macro, an inverted version of `assert_contains!`. ([#424](https://github.com/heroku/libcnb.rs/pull/424))
+- Remove `IntegrationTest::run_test`, to run a test use the new `TestRunner::run_test` function. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
+- Rename `IntegrationTest` to `TestConfig`. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
+- Rename `IntegrationTestContext` to `TestContext`. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
+- Add `Clone` implementation for `TestConfig`, allowing it to be shared across tests. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
+- Add `TestContext::run_test`, allowing you to run subsequent integration tests with the image from a previous test. These functions allow testing of subsequent builds, including caching logic and buildpack behaviour when build environment variables change, stacks are upgraded and more. ([#422](https://github.com/heroku/libcnb.rs/pull/422))
+- Add `TestConfig::expected_pack_result`. When set to `PackResult::Failure`, it allows testing of build failure scenarios. ([#429](https://github.com/heroku/libcnb.rs/pull/429))
+- Add `TestConfig::app_dir` which is handy in cases where `TestConfig` values are shared and only the `app_dir` needs to be different. ([#430](https://github.com/heroku/libcnb.rs/pull/430))
+- Remove `TestContext::app_dir` to encourage the use of `TestConfig::app_dir_preprocessor`. ([#431](https://github.com/heroku/libcnb.rs/pull/431))
+- Improve performance when no `TestConfig::app_dir_preprocessor` is configured by skipping application directory copying. ([#431](https://github.com/heroku/libcnb.rs/pull/431))
 
 ## [0.3.1] 2022-04-12
 
-- Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).
+- Update project URLs for the GitHub repository move to the `heroku` org. ([#388](https://github.com/heroku/libcnb.rs/pull/388))
 
 ## [0.3.0] 2022-03-08
 
 - Add `IntegrationTest::env` and `IntegrationTest::envs`, allowing users to set environment variables for the build process. ([#346](https://github.com/heroku/libcnb.rs/pull/346))
 - Replaced `IntegrationTestContext::start_container` with `IntegrationTestContext::prepare_container`, allowing users to configure the container before starting it. Ports can now be exposed via `PrepareContainerContext::expose_port`. ([#346](https://github.com/heroku/libcnb.rs/pull/346))
 - Added the ability to set environment variables for the container via `PrepareContainerContext::env` and `PrepareContainerContext::envs`. ([#346](https://github.com/heroku/libcnb.rs/pull/346))
-- Switch from `libcnb-cargo` to the new `libcnb-package` crate for buildpack packaging, which improves compile times due to it not including CLI-related dependencies ([#362](https://github.com/heroku/libcnb.rs/pull/362)).
-- Use `--pull-policy if-not-present` when running `pack build` ([#373](https://github.com/heroku/libcnb.rs/pull/373)).
-- Allow starting a container without using the default process type. Removed `PrepareContainerContext::start`, added `PrepareContainerContext::start_with_default_process`, `PrepareContainerContext::start_with_default_process_args`, `PrepareContainerContext::start_with_process`, `PrepareContainerContext::start_with_process_args`, `PrepareContainerContext::start_with_shell_command` ([#366](https://github.com/heroku/libcnb.rs/pull/366))
+- Switch from `libcnb-cargo` to the new `libcnb-package` crate for buildpack packaging, which improves compile times due to it not including CLI-related dependencies. ([#362](https://github.com/heroku/libcnb.rs/pull/362))
+- Use `--pull-policy if-not-present` when running `pack build`. ([#373](https://github.com/heroku/libcnb.rs/pull/373))
+- Allow starting a container without using the default process type. Removed `PrepareContainerContext::start`, added `PrepareContainerContext::start_with_default_process`, `PrepareContainerContext::start_with_default_process_args`, `PrepareContainerContext::start_with_process`, `PrepareContainerContext::start_with_process_args`, `PrepareContainerContext::start_with_shell_command`. ([#366](https://github.com/heroku/libcnb.rs/pull/366))
 - Add `ContainerContext::logs_now` and `ContainerContext::logs_wait` to access the logs of the container. Useful when used in conjunction with the new `PrepareContainerContext::start_with_shell_command` method to get the shell command output. ([#366](https://github.com/heroku/libcnb.rs/pull/366))
 - Replaced `container_context::ContainerExecResult` with `log::LogOutput` which is now also returned by `ContainerContext::logs` and `ContainerContext::logs_follow`. ([#366](https://github.com/heroku/libcnb.rs/pull/366))
-- Move support for connecting to the Docker daemon over TLS behind a new `remote-docker` feature flag, since remote Docker support is not fully implemented and pulls in many additional dependencies ([#376](https://github.com/heroku/libcnb.rs/pull/376)).
+- Move support for connecting to the Docker daemon over TLS behind a new `remote-docker` feature flag, since remote Docker support is not fully implemented and pulls in many additional dependencies. ([#376](https://github.com/heroku/libcnb.rs/pull/376))
 
 ## [0.2.0] 2022-02-28
 
-- `libcnb-test` now cross-compiles and packages all binary targets of the buildpack for an integration test. The main buildpack binary is either the only binary target or the target with the same name as the crate. This feature allows the usage of additional binaries for i.e. execd. ([#314](https://github.com/heroku/libcnb.rs/pull/314))
-- Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/heroku/libcnb.rs/pull/318)).
+- `libcnb-test` now cross-compiles and packages all binary targets of the buildpack for an integration test. The main buildpack binary is either the only binary target or the target with the same name as the crate. This feature allows the usage of additional binaries for i.e. `exec.d`. ([#314](https://github.com/heroku/libcnb.rs/pull/314))
+- Increase minimum supported Rust version from 1.56 to 1.58. ([#318](https://github.com/heroku/libcnb.rs/pull/318))
 - Add `assert_contains!` macro for easier matching of `pack` output in integration tests. ([#322](https://github.com/heroku/libcnb.rs/pull/322))
-- Fail tests early with a clearer error message, if expected cross-compilation toolchains are not found ([#347](https://github.com/heroku/libcnb.rs/pull/347)).
+- Fail tests early with a clearer error message, if expected cross-compilation toolchains are not found. ([#347](https://github.com/heroku/libcnb.rs/pull/347))
 - Update `libcnb-cargo` from `0.2.1` to `0.3.0` - see the [libcnb-cargo changelog](../libcnb-cargo/CHANGELOG.md#030-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
 
 ## [0.1.1] 2022-02-04
 
-- Use the `DOCKER_HOST` environment variable to determine the Docker connection strategy, adding support for HTTPS 
-connections in addition to local UNIX sockets. This enables using `libcnb-test` in more complex setups like on CircleCI 
-where the Docker daemon is on a remote machine. ([#305](https://github.com/heroku/libcnb.rs/pull/305))
+- Use the `DOCKER_HOST` environment variable to determine the Docker connection strategy, adding support for HTTPS connections in addition to local UNIX sockets. This enables using `libcnb-test` in more complex setups like on CircleCI where the Docker daemon is on a remote machine. ([#305](https://github.com/heroku/libcnb.rs/pull/305))
 
 ## [0.1.0] 2022-02-02
 
-- Initial release ([#277](https://github.com/heroku/libcnb.rs/pull/277)).
+- Initial release. ([#277](https://github.com/heroku/libcnb.rs/pull/277))

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -6,37 +6,37 @@
 
 ## [0.8.0] 2022-06-24
 
-- Make the "Buildpack API version mismatch" check still work when `buildpack.toml` doesn't match the spec or custom buildpack type ([#421](https://github.com/heroku/libcnb.rs/pull/421)).
-- Remove support for custom exit codes from `Buildpack::on_error`. Exit codes are part of the CNB spec and there are cases where some exit codes have special meaning to the CNB lifecycle. This put the burden on the buildpack author to not pick exit codes with special meanings, dependent on the currently executing phase. This makes `Buildpack::on_error` more consistent with the rest of the framework where we don't expose the interface between the buildpack and the CNB lifecycle directly but use abstractions for easier forward-compatibility and to prevent accidental misuse. ([#415](https://github.com/heroku/libcnb.rs/pull/415)).
-- Update `libcnb-data` (which provides the types in the `data` module) from `0.6.0` to `0.7.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#070-2022-06-24) ([#432](https://github.com/heroku/libcnb.rs/pull/432)).
+- Make the "Buildpack API version mismatch" check still work when `buildpack.toml` doesn't match the spec or custom buildpack type. ([#421](https://github.com/heroku/libcnb.rs/pull/421))
+- Remove support for custom exit codes from `Buildpack::on_error`. Exit codes are part of the CNB spec and there are cases where some exit codes have special meaning to the CNB lifecycle. This put the burden on the buildpack author to not pick exit codes with special meanings, dependent on the currently executing phase. This makes `Buildpack::on_error` more consistent with the rest of the framework where we don't expose the interface between the buildpack and the CNB lifecycle directly but use abstractions for easier forward-compatibility and to prevent accidental misuse. ([#415](https://github.com/heroku/libcnb.rs/pull/415))
+- Update `libcnb-data` (which provides the types in the `data` module) from `0.6.0` to `0.7.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#070-2022-06-24). ([#432](https://github.com/heroku/libcnb.rs/pull/432))
 
 ## [0.7.0] 2022-04-12
 
 - Allow compilation of libcnb.rs buildpacks on Windows. Please note that this does not imply Windows container support, it's meant to allow running unit tests without cross-compiling. ([#368](https://github.com/heroku/libcnb.rs/pull/368))
-- Expose `runtime::libcnb_runtime_detect`, `runtime::libcnb_runtime_build` and their related types for advanced use-cases. Buildpack authors should not use these. ([#375](https://github.com/heroku/libcnb.rs/pull/375)).
-- Only create layer `env`, `env.build` and `env.launch` directories when environment variables are being set within them ([#385](https://github.com/heroku/libcnb.rs/pull/385)).
-- Add `WriteLayerError::MissingExecDFile` error to ease debugging when an exec.d path is missing ([#387](https://github.com/heroku/libcnb.rs/pull/387)).
-- Update project URLs for the GitHub repository move to the `heroku` org ([#388](https://github.com/heroku/libcnb.rs/pull/388)).
-- Update `libcnb-data` (which provides the types in the `data` module) from `0.5.0` to `0.6.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#060-2022-04-12) ([#391](https://github.com/heroku/libcnb.rs/pull/391)).
+- Expose `runtime::libcnb_runtime_detect`, `runtime::libcnb_runtime_build` and their related types for advanced use-cases. Buildpack authors should not use these. ([#375](https://github.com/heroku/libcnb.rs/pull/375))
+- Only create layer `env`, `env.build` and `env.launch` directories when environment variables are being set within them. ([#385](https://github.com/heroku/libcnb.rs/pull/385))
+- Add `WriteLayerError::MissingExecDFile` error to ease debugging when an exec.d path is missing. ([#387](https://github.com/heroku/libcnb.rs/pull/387))
+- Update project URLs for the GitHub repository move to the `heroku` org. ([#388](https://github.com/heroku/libcnb.rs/pull/388))
+- Update `libcnb-data` (which provides the types in the `data` module) from `0.5.0` to `0.6.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#060-2022-04-12). ([#391](https://github.com/heroku/libcnb.rs/pull/391))
 
 ## [0.6.0] 2022-02-28
 
-- Add `#[must_use]` to `DetectResult`, `DetectResultBuilder`, `PassDetectResultBuilder`, `FailDetectResultBuilder`, `BuildResult` and `BuildResultBuilder` ([#288](https://github.com/heroku/libcnb.rs/pull/288)).
+- Add `#[must_use]` to `DetectResult`, `DetectResultBuilder`, `PassDetectResultBuilder`, `FailDetectResultBuilder`, `BuildResult` and `BuildResultBuilder`. ([#288](https://github.com/heroku/libcnb.rs/pull/288))
 - Add `additional_buildpack_binary_path!` macro to resolve paths to additional buildpack binaries. Only works when the buildpack is packaged with `libcnb-cargo`/`libcnb-test`. ([#320](https://github.com/heroku/libcnb.rs/pull/320))
-- Increase minimum supported Rust version from 1.56 to 1.58 ([#318](https://github.com/heroku/libcnb.rs/pull/318)).
+- Increase minimum supported Rust version from 1.56 to 1.58. ([#318](https://github.com/heroku/libcnb.rs/pull/318))
 - Add support for exec.d programs in layers. Use `LayerResultBuilder::exec_d_program` to add exec.d programs to a layer. ([#326](https://github.com/heroku/libcnb.rs/pull/326))
-- Add `libcnb::exec_d::write_exec_d_program_output` which writes `libcnb::data::exec_d::ExecDProgramOutput` in a spec conforming way. Use this to implement custom exec.d programs for your buildpack with libcnb.rs. (see [exec.d example](../examples/execd)) ([#326](https://github.com/heroku/libcnb.rs/pull/326))
+- Add `libcnb::exec_d::write_exec_d_program_output` which writes `libcnb::data::exec_d::ExecDProgramOutput` in a spec conforming way. Use this to implement custom exec.d programs for your buildpack with libcnb.rs. (see [exec.d example](../examples/execd)). ([#326](https://github.com/heroku/libcnb.rs/pull/326))
 - Update `libcnb-data` (which provides the types in the `data` module) from `0.4.0` to `0.5.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#050-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
 - Update `libcnb-proc-macros` from `0.1.1` to `0.2.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#020-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
 
 ## [0.5.0] 2022-01-14
 
-- Add `must_use` attributes to a number of pure public methods ([#232](https://github.com/heroku/libcnb.rs/pull/232)).
-- `TargetLifecycle` has been renamed to `Scope` ([#257](https://github.com/heroku/libcnb.rs/pull/257)).
-- Renamed `Buildpack::handle_error` to `Buildpack::on_error` to make it clearer that the error cannot be handled/resolved, just reacted upon ([#266](https://github.com/heroku/libcnb.rs/pull/266)).
-- Add `LayerEnv::apply_to_empty` ([#267](https://github.com/heroku/libcnb.rs/pull/267)).
-- Bump external dependency versions ([#233](https://github.com/heroku/libcnb.rs/pull/233) and [#275](https://github.com/heroku/libcnb.rs/pull/275)).
-- Update `libcnb-data` (which provides the types in the `data` module) from `0.3.0` to `0.4.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#040-2022-01-14) ([#276](https://github.com/heroku/libcnb.rs/pull/276)).
+- Add `must_use` attributes to a number of pure public methods. ([#232](https://github.com/heroku/libcnb.rs/pull/232))
+- `TargetLifecycle` has been renamed to `Scope`. ([#257](https://github.com/heroku/libcnb.rs/pull/257))
+- Renamed `Buildpack::handle_error` to `Buildpack::on_error` to make it clearer that the error cannot be handled/resolved, just reacted upon. ([#266](https://github.com/heroku/libcnb.rs/pull/266))
+- Add `LayerEnv::apply_to_empty`. ([#267](https://github.com/heroku/libcnb.rs/pull/267))
+- Bump external dependency versions. ([#233](https://github.com/heroku/libcnb.rs/pull/233) and [#275](https://github.com/heroku/libcnb.rs/pull/275))
+- Update `libcnb-data` (which provides the types in the `data` module) from `0.3.0` to `0.4.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#040-2022-01-14). ([#276](https://github.com/heroku/libcnb.rs/pull/276))
 
 ## [0.4.0] 2021-12-08
 
@@ -65,7 +65,7 @@
   implementation of implicit layer handling when no update or crate happens.
 - New trait design for `LayerLifecycle` which also was renamed to `Layer`.
 - Removed low-level layer functions from `BuildContext`. They don't fit well with the design of the library at this
-  point and are potential footguns. Implementing a `Layer` should work for all use-cases.
+  point and are potential foot-guns. Implementing a `Layer` should work for all use-cases.
 - The `stack_id` field in `BuildContext` and `DetectContext` is now of type `StackId` instead of `String`.
 - Remove `Display` trait bound from `Buildpack::Error` type.
 - Fixed file extension for delimiters when writing `LayerEnv` to disk.


### PR DESCRIPTION
Previously the changelogs were using a mixture of styles for how the link to the PR was listed (some in the same sentence, some after).

A few other markdown fixes have been made as well.