### PR TITLE
Fix unused variable warnings in rustdocs

### DIFF
--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -111,7 +111,7 @@ impl ProcessBuilder {
     /// Adds an argument to the process.
     ///
     /// Only one argument can be passed per use. So instead of:
-    /// ```no_run
+    /// ```
     /// # use libcnb_data::process_type;
     /// # libcnb_data::launch::ProcessBuilder::new(process_type!("web"), "command")
     /// .arg("-C /path/to/repo")
@@ -120,7 +120,7 @@ impl ProcessBuilder {
     ///
     /// usage would be:
     ///
-    /// ```no_run
+    /// ```
     /// # use libcnb_data::process_type;
     /// # libcnb_data::launch::ProcessBuilder::new(process_type!("web"), "command")
     /// .arg("-C")

--- a/libcnb-proc-macros/src/lib.rs
+++ b/libcnb-proc-macros/src/lib.rs
@@ -18,7 +18,7 @@ use syn::Token;
 /// It is designed to be used within other macros to produce compile time errors when the regex
 /// doesn't match but it might work for other use-cases as well.
 ///
-/// ```no_run
+/// ```
 /// libcnb_proc_macros::verify_regex!("^A-Z+$", "foobar", println!("It did match!"), println!("It did not match!"));
 /// ```
 #[proc_macro]

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -133,7 +133,7 @@ pub(crate) enum InnerBuildResult {
 /// # Examples:
 /// ```
 /// use libcnb::build::{BuildResultBuilder, BuildResult};
-/// use libcnb::data::launch::{Launch, Process};
+/// use libcnb::data::launch::Launch;
 /// use libcnb::data::process_type;
 /// use libcnb::data::launch::ProcessBuilder;
 ///

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -34,7 +34,7 @@ pub(crate) enum InnerDetectResult {
 /// # Examples:
 /// ```
 /// use libcnb::detect::{DetectResultBuilder, DetectResult};
-/// use libcnb_data::build_plan::{BuildPlan, BuildPlanBuilder};
+/// use libcnb_data::build_plan::BuildPlanBuilder;
 ///
 /// let simple_pass: Result<DetectResult, ()> = DetectResultBuilder::pass().build();
 /// let simple_fail: Result<DetectResult, ()> = DetectResultBuilder::fail().build();

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -29,12 +29,12 @@ use std::path::Path;
 /// know the layer name or any of the logic for constructing `PATH`.
 ///
 /// # Applying the delta
-///`LayerEnv` is not a static set of environment variables, but a delta. Layers can modify existing
+/// `LayerEnv` is not a static set of environment variables, but a delta. Layers can modify existing
 /// variables by appending, prepending or setting variables only if they were not already defined. If you only need a
 /// static set of environment variables, see [`Env`].
 ///
 /// To apply a `LayerEnv` delta to a given `Env`, use [`LayerEnv::apply`] like so:
-///```
+/// ```
 /// use libcnb::layer_env::{LayerEnv, Scope, ModificationBehavior};
 /// use libcnb::Env;
 ///
@@ -61,10 +61,9 @@ use std::path::Path;
 ///
 /// libcnb supports these, including all precedence and lifecycle rules, when a `LayerEnv` is read
 /// from disk:
-///```
+/// ```
 /// use libcnb::layer_env::{LayerEnv, Scope};
 /// use tempfile::tempdir;
-/// use libcnb::Env;
 /// use std::fs;
 ///
 /// // Create a bogus layer directory
@@ -105,7 +104,7 @@ impl LayerEnv {
     /// use libcnb::Env;
     ///
     /// let layer_env = LayerEnv::new();
-    /// let mut env = Env::new();
+    /// let env = Env::new();
     ///
     /// let modified_env = layer_env.apply(Scope::Build, &env);
     /// assert_eq!(env, modified_env);
@@ -120,7 +119,7 @@ impl LayerEnv {
     /// For applying to an empty [`Env`], see [`apply_to_empty`](Self::apply_to_empty).
     ///
     /// # Example:
-    ///```
+    /// ```
     /// use libcnb::layer_env::{LayerEnv, Scope, ModificationBehavior};
     /// use libcnb::Env;
     ///
@@ -173,7 +172,6 @@ impl LayerEnv {
     /// # Example:
     /// ```
     /// use libcnb::layer_env::{LayerEnv, Scope, ModificationBehavior};
-    /// use libcnb::Env;
     ///
     /// let mut layer_env = LayerEnv::new();
     /// layer_env.insert(Scope::All, ModificationBehavior::Default, "VAR", "hello");
@@ -217,7 +215,6 @@ impl LayerEnv {
     /// # Example:
     /// ```
     /// use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
-    /// use libcnb::Env;
     ///
     /// fn something_that_needs_layer_env(layer_env: LayerEnv) {
     ///     let env = layer_env.apply_to_empty(Scope::Build);
@@ -262,10 +259,9 @@ impl LayerEnv {
     /// rely on libcnb to pass `LayerEnv` values to minimize side effects in buildpack code.
     ///
     /// # Example:
-    ///```
+    /// ```
     /// use libcnb::layer_env::{LayerEnv, Scope};
     /// use tempfile::tempdir;
-    /// use libcnb::Env;
     /// use std::fs;
     ///
     /// // Create a bogus layer directory
@@ -350,7 +346,7 @@ impl LayerEnv {
     /// layer_env.insert(Scope::Build, ModificationBehavior::Default, "FOO", "bar");
     /// layer_env.insert(Scope::All, ModificationBehavior::Append, "PATH", "some-path");
     ///
-    /// let mut temp_dir = tempdir().unwrap();
+    /// let temp_dir = tempdir().unwrap();
     /// layer_env.write_to_layer_dir(&temp_dir).unwrap();
     ///
     /// assert_eq!(fs::read_to_string(temp_dir.path().join("env.build").join("FOO.default")).unwrap(), "bar");

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -53,7 +53,7 @@ const LIBCNB_SUPPORTED_BUILDPACK_API: data::buildpack::BuildpackApi =
 /// use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 /// use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 /// use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
-/// use libcnb::{buildpack_main, data::build_plan::BuildPlan, Buildpack};
+/// use libcnb::{buildpack_main, Buildpack};
 ///
 /// pub(crate) struct MyBuildpack;
 ///

--- a/libcnb/src/platform.rs
+++ b/libcnb/src/platform.rs
@@ -22,9 +22,9 @@ where
     ///
     /// # Examples
     /// ```no_run
-    ///use libcnb::Platform;
-    ///use libcnb::generic::GenericPlatform;
-    ///let platform = GenericPlatform::from_path("/platform").unwrap();
+    /// use libcnb::Platform;
+    /// use libcnb::generic::GenericPlatform;
+    /// let platform = GenericPlatform::from_path("/platform").unwrap();
     /// ```
     fn from_path(platform_dir: impl AsRef<Path>) -> io::Result<Self>;
 }


### PR DESCRIPTION
By default rustdocs tests/docs generation doesn't show unused variable warnings, since there would be too many false positives. This means it's not possible to lint against them in CI.

However by enabling unused variable warnings in rustdocs temporarily locally, I was able to find and fix any that were not false positives.

See:
https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#showing-warnings-in-doctests

In addition, a few unnecessary `no_run` annotations have been removed, meaning those docstests are now covered by CI not only for syntax errors, but that the example successfully runs too.

GUS-W-11395978.