### PR TITLE
Symlink `libcnb/README.md` to the repo root README

### DIFF
--- a/libcnb/README.md
+++ b/libcnb/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
Since otherwise the `libcnb` crate directory is the only crate that doesn't have any README content when browsing around the repo.

The symlinking approach is what other monorepo crates use, eg:
https://github.com/serde-rs/serde/tree/master/serde