### PR TITLE
Make the `allow` of `clippy::similar_names` more tightly scoped

### DIFF
--- a/libcnb/src/layer/handling.rs
+++ b/libcnb/src/layer/handling.rs
@@ -1,3 +1,6 @@
+// This lint triggers when both layer_dir and layers_dir are present which are quite common.
+#![allow(clippy::similar_names)]
+
 use crate::build::BuildContext;
 use crate::data::layer::LayerName;
 use crate::data::layer_content_metadata::LayerContentMetadata;

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -5,8 +5,6 @@
 #![allow(clippy::missing_errors_doc)]
 // This lint is too noisy and enforces a style that reduces readability in many cases.
 #![allow(clippy::module_name_repetitions)]
-// This lint triggers when both layer_dir and layers_dir are present which are quite common.
-#![allow(clippy::similar_names)]
 
 pub mod build;
 pub mod detect;


### PR DESCRIPTION
Previously the lint was disabled for the whole `libcnb` crate, when it's only one file for which warnings are generated.

If future usages come up in other files in the future, then I would rather the lint highlight them, allowing the author of the change to decide whether they too should be excluded, or whether they should be fixed.