### PR TITLE
Remove `/bin/sh` wrapping from container shell commands

### DIFF
--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `TestConfig::cargo_profile` and `CargoProfile` to support compilation of buildpacks in release mode. ([#456](https://github.com/heroku/libcnb.rs/pull/456))
 - Improve the error message shown when Pack CLI is not installed. ([#455](https://github.com/heroku/libcnb.rs/pull/455))
 - Check that `TestConfig::app_dir` is a valid directory before applying `TestConfig::app_dir_preprocessor` or invoking Pack, so that a clearer error message can be displayed. ([#452](https://github.com/heroku/libcnb.rs/pull/452))
+- `PrepareContainerContext::start_with_shell_command` and `ContainerContext::shell_exec` now use `bash` instead of `/bin/sh`. ([#464](https://github.com/heroku/libcnb.rs/pull/464))
 - Use the crate's `README.md` as the root module's rustdocs, so that all of the crate's documentation can be seen in one place on `docs.rs`. ([#460](https://github.com/heroku/libcnb.rs/pull/460))
 - Add rustdocs with code examples for all public APIs. ([#441](https://github.com/heroku/libcnb.rs/pull/441))
 - Fix rustdocs for `LogOutput`. ([#440](https://github.com/heroku/libcnb.rs/pull/440))

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -218,7 +218,7 @@ impl<'a> PrepareContainerContext<'a> {
     /// Creates and starts the container configured by this context using the given shell command.
     ///
     /// The CNB lifecycle launcher will be implicitly used. Environment variables will be set. Uses
-    /// `/bin/sh` as the shell.
+    /// `bash` as the shell.
     ///
     /// See: [CNB App Developer Guide: Run a multi-process app - User-provided shell process](https://buildpacks.io/docs/app-developer-guide/run-an-app/#user-provided-shell-process)
     ///
@@ -243,12 +243,8 @@ impl<'a> PrepareContainerContext<'a> {
         f: F,
     ) {
         self.start_internal(
-            Some(vec![String::from(CNB_LAUNCHER_PATH)]),
-            Some(vec![
-                String::from(SHELL_PATH),
-                String::from("-c"),
-                command.into(),
-            ]),
+            Some(vec![String::from(CNB_LAUNCHER_BINARY)]),
+            Some(vec![command.into()]),
             f,
         );
     }
@@ -472,7 +468,7 @@ impl<'a> ContainerContext<'a> {
                 .create_exec(
                     &self.container_name,
                     CreateExecOptions {
-                        cmd: Some(vec![CNB_LAUNCHER_PATH, SHELL_PATH, "-c", command.as_ref()]),
+                        cmd: Some(vec![CNB_LAUNCHER_BINARY, command.as_ref()]),
                         attach_stdout: Some(true),
                         ..CreateExecOptions::default()
                     },
@@ -516,5 +512,4 @@ impl<'a> Drop for ContainerContext<'a> {
     }
 }
 
-const CNB_LAUNCHER_PATH: &str = "/cnb/lifecycle/launcher";
-const SHELL_PATH: &str = "/bin/sh";
+const CNB_LAUNCHER_BINARY: &str = "launcher";

--- a/libcnb-test/test-fixtures/procfile/Procfile
+++ b/libcnb-test/test-fixtures/procfile/Procfile
@@ -1,3 +1,3 @@
-web: python3 -u -m http.server
+web: python3 -u -m http.server ${PORT:+"${PORT}"}
 worker: echo 'this is the worker process!'
 echo-args: echo


### PR DESCRIPTION
Previously `libcnb-test` wrapped the shell commands for `PrepareContainerContext::start_with_shell_command` and `ContainerContext::shell_exec` in a `/bin/sh -c '...'` invocation.

This is unnecessary, since `launcher` already runs the passed commands using bash:
https://buildpacks.io/docs/app-developer-guide/run-an-app/#user-provided-shell-process
https://buildpacks.io/docs/app-developer-guide/run-an-app/#user-provided-shell-process-with-bash-script

In addition, it's not necessary to hardcode the full launcher path, since `/cnb/lifecycle` is automatically put on `PATH` during image creation.

Now, the way the commands are invoked are consistent with how users are instructed to run processes in the upstream CNB docs.

GUS-W-11415544.