### PR TITLE
Bump versions for new release

### DIFF
--- a/examples/ruby-sample/Cargo.toml
+++ b/examples/ruby-sample/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 [dependencies]
 flate2 = "1.0.24"
 libcnb = { path = "../../libcnb" }
-serde = "1.0.137"
+serde = "1.0.139"
 sha2 = "0.10.2"
 tar = "0.4.38"
 tempfile = "3.3.0"
-ureq = "2.4.0"
+ureq = "2.5.0"
 
 [dev-dependencies]
 libcnb-test = { path = "../../libcnb-test" }

--- a/libcnb-cargo/CHANGELOG.md
+++ b/libcnb-cargo/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [Unreleased]
 
+## [0.5.0] 2022-07-14
+
 - Fix the packaged buildpack size reported by `cargo libcnb package`. ([#442](https://github.com/heroku/libcnb.rs/pull/442))
 - Reduce number of dependencies to improve installation time. ([#442](https://github.com/heroku/libcnb.rs/pull/442) and [#443](https://github.com/heroku/libcnb.rs/pull/443))
 - Use the crate's `README.md` as the root module's rustdocs, so that all of the crate's documentation can be seen in one place on `docs.rs`. ([#460](https://github.com/heroku/libcnb.rs/pull/460))
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
+- Update `libcnb-package` from `0.1.2` to `0.2.0`. Of note, buildpack binaries are now stripped when packaging to reduce buildpack size. See the [libcnb-package changelog](../libcnb-package/CHANGELOG.md#020-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
 
 ## [0.4.1] 2022-06-24
 

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-cargo"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.59"
 license = "BSD-3-Clause"
@@ -17,11 +17,11 @@ path = "src/main.rs"
 
 [dependencies]
 cargo_metadata = "0.15.0"
-clap = { version = "3.2.5", default-features = false, features = [
+clap = { version = "3.2.11", default-features = false, features = [
   "std",
   "derive",
 ] }
-libcnb-package = { version = "0.1.2", path = "../libcnb-package" }
+libcnb-package = { version = "0.2.0", path = "../libcnb-package" }
 log = "0.4.17"
 pathdiff = "0.2.1"
-stderrlog = { version = "0.5.3", default-features = false}
+stderrlog = { version = "0.5.3", default-features = false }

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.0] 2022-07-14
+
 - Disable `fancy-regex` default features (such as unused unicode support) to reduce buildpack binary size. ([#439](https://github.com/heroku/libcnb.rs/pull/439))
 - Add a crate `README.md` and use it as the root module's rustdocs, so that all of the crate's documentation can be seen in one place on `docs.rs`. ([#458](https://github.com/heroku/libcnb.rs/pull/458) and [#460](https://github.com/heroku/libcnb.rs/pull/460))
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
+- Update `libcnb-proc-macros` from `0.2.2` to `0.3.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#030-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
 
 # [0.7.0] 2022-06-24
 

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-data"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.59"
 license = "BSD-3-Clause"
@@ -13,10 +13,10 @@ include = ["src/**/*", "../LICENSE", "README.md"]
 
 [dependencies]
 fancy-regex = { version = "0.10.0", default-features = false }
-libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.2.2" }
-serde = { version = "1.0.137", features = ["derive"] }
+libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.3.0" }
+serde = { version = "1.0.139", features = ["derive"] }
 thiserror = "1.0.31"
 toml = "0.5.9"
 
 [dev-dependencies]
-serde_test = "1.0.137"
+serde_test = "1.0.139"

--- a/libcnb-package/CHANGELOG.md
+++ b/libcnb-package/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [Unreleased]
 
+## [0.2.0] 2022-07-14
+
 - Strip buildpack binaries when packaging, to reduce buildpack size. This not only reduces the size of production builder images, but also speeds up workflows that involve non-release builds (such as integration tests). ([#445](https://github.com/heroku/libcnb.rs/pull/445))
 - The type of the `cargo_env` argument to `build::build_buildpack_binaries` and `build::build_binary` has changed. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
 - Use the crate's `README.md` as the root module's rustdocs, so that all of the crate's documentation can be seen in one place on `docs.rs`. ([#460](https://github.com/heroku/libcnb.rs/pull/460))
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
+- Update `libcnb-data` from `0.7.0` to `0.8.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#080-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
 
 ## [0.1.2] 2022-06-24
 

--- a/libcnb-package/Cargo.toml
+++ b/libcnb-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-package"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.59"
 license = "BSD-3-Clause"
@@ -13,6 +13,6 @@ include = ["src/**/*", "../LICENSE", "README.md"]
 
 [dependencies]
 cargo_metadata = "0.15.0"
-libcnb-data = { version = "0.7.0", path = "../libcnb-data" }
+libcnb-data = { version = "0.8.0", path = "../libcnb-data" }
 toml = "0.5.9"
 which = "4.2.5"

--- a/libcnb-proc-macros/CHANGELOG.md
+++ b/libcnb-proc-macros/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.3.0] 2022-07-14
+
 - Disable `fancy-regex` default features (such as unused unicode support) to reduce buildpack binary size. ([#439](https://github.com/heroku/libcnb.rs/pull/439))
 - Fix `verify_regex`'s error handling when the regex could not be compiled. ([#438](https://github.com/heroku/libcnb.rs/pull/438))
 - Add a crate `README.md` and use it as the root module's rustdocs, so that all of the crate's documentation can be seen in one place on `docs.rs`. ([#458](https://github.com/heroku/libcnb.rs/pull/458) and [#460](https://github.com/heroku/libcnb.rs/pull/460))

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-proc-macros"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.59"
 license = "BSD-3-Clause"

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.0] 2022-07-14
+
 - Add an `assert_empty!` macro, for improved UX over using `assert!` with `str::is_empty`. ([#451](https://github.com/heroku/libcnb.rs/pull/451))
 - Add `TestConfig::cargo_profile` and `CargoProfile` to support compilation of buildpacks in release mode. ([#456](https://github.com/heroku/libcnb.rs/pull/456))
 - Improve the error message shown when Pack CLI is not installed. ([#455](https://github.com/heroku/libcnb.rs/pull/455))
@@ -11,6 +13,7 @@
 - Add rustdocs with code examples for all public APIs. ([#441](https://github.com/heroku/libcnb.rs/pull/441))
 - Fix rustdocs for `LogOutput`. ([#440](https://github.com/heroku/libcnb.rs/pull/440))
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
+- Update `libcnb-package` from `0.1.2` to `0.2.0`. Of note, buildpack binaries are now stripped when packaging to reduce buildpack size, which also speeds up integration tests. See the [libcnb-package changelog](../libcnb-package/CHANGELOG.md#020-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
 
 ## [0.4.0] 2022-06-24
 

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-test"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.59"
 license = "BSD-3-Clause"
@@ -16,10 +16,10 @@ bollard = "0.13.0"
 cargo_metadata = "0.15.0"
 fastrand = "1.7.0"
 fs_extra = "1.2.0"
-libcnb-package = { version = "0.1.2", path = "../libcnb-package" }
-serde = "1.0.137"
+libcnb-package = { version = "0.2.0", path = "../libcnb-package" }
+serde = "1.0.139"
 tempfile = "3.3.0"
-tokio = "1.19.2"
+tokio = "1.20.0"
 tokio-stream = "0.1.9"
 
 [dev-dependencies]

--- a/libcnb/CHANGELOG.md
+++ b/libcnb/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.0] 2022-07-14
+
 - Use the crate's `README.md` as the root module's rustdocs, so that all of the crate's documentation can be seen in one place on `docs.rs`. ([#460](https://github.com/heroku/libcnb.rs/pull/460))
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
+- Update `libcnb-data` (which provides the types in the `data` module) from `0.7.0` to `0.8.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#080-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
+- Update `libcnb-proc-macros` from `0.2.2` to `0.3.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#030-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
 
 ## [0.8.0] 2022-06-24
 

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.59"
 license = "BSD-3-Clause"
@@ -13,9 +13,9 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
 anyhow = { version = "1.0.58", optional = true }
-libcnb-data = { path = "../libcnb-data", version = "0.7.0" }
-libcnb-proc-macros = { version = "0.2.2", path = "../libcnb-proc-macros" }
-serde = { version = "1.0.137", features = ["derive"] }
+libcnb-data = { path = "../libcnb-data", version = "0.8.0" }
+libcnb-proc-macros = { version = "0.3.0", path = "../libcnb-proc-macros" }
+serde = { version = "1.0.139", features = ["derive"] }
 thiserror = "1.0.31"
 toml = "0.5.9"
 


### PR DESCRIPTION
Created using the playbook in #335.

Changes:
https://github.com/heroku/libcnb.rs/compare/libcnb/v0.8.0...aca4eeba577dc9d1df76ff70010a742b88b83259

GUS-W-11428161.