### PR TITLE
Fix rustdocs `include_str!` for libcnb

### DIFF
--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../README.md")]
+#![doc = include_str!("../README.md")]
 #![warn(clippy::pedantic)]
 #![warn(unused_crate_dependencies)]
 // Most of libcnb's public API returns user-provided errors, making error docs redundant.
@@ -119,9 +119,3 @@ macro_rules! additional_buildpack_binary_path {
         )
     };
 }
-
-// This runs the README.md as a doctest, ensuring the code examples in it are valid.
-// It will not be part of the final crate.
-#[cfg(doctest)]
-#[doc = include_str!("../../README.md")]
-pub struct ReadmeDoctests;


### PR DESCRIPTION
Followup to #460.

Previously it was referencing the repo root file, which doesn't exist when the package is published (since at that point it's no longer in a monorepo).

Now, the package root `README.md` is used instead, which is a symlink to the repo root `README.md` in the monorepo, and when the package is published is the resolved README from:
https://github.com/heroku/libcnb.rs/blob/3c9637e238d23d3fec402f27c81fa8a13b1a5a6d/libcnb/Cargo.toml#L11-L12

The redundant doctest readme include has also been removed.

GUS-W-11395978.