### PR TITLE
Fix ruby-sample integration test on M1 machines

### DIFF
--- a/examples/ruby-sample/tests/integration_test.rs
+++ b/examples/ruby-sample/tests/integration_test.rs
@@ -29,7 +29,7 @@ fn basic() {
             .env("PORT", TEST_PORT.to_string())
             .expose_port(TEST_PORT)
             .start_with_default_process(|container| {
-                std::thread::sleep(Duration::from_secs(1));
+                std::thread::sleep(Duration::from_secs(2));
 
                 assert_eq!(
                     call_test_fixture_service(


### PR DESCRIPTION
The test currently fails under QEMU, since it runs slowly enough that the 1 second sleep isn't enough.

Longer term we should switch to a retrying client, but for now increasing the sleep to 2 seconds is enough to make the test pass on my M1 machine.