### PR TITLE
libcnb-test: Refactor the API for starting containers

### DIFF
--- a/examples/execd/tests/integration_test.rs
+++ b/examples/execd/tests/integration_test.rs
@@ -7,7 +7,7 @@
 // https://rust-lang.github.io/rust-clippy/stable/index.html
 #![warn(clippy::pedantic)]
 
-use libcnb_test::{assert_contains, TestConfig, TestRunner};
+use libcnb_test::{assert_contains, assert_empty, TestConfig, TestRunner};
 
 #[test]
 #[ignore]
@@ -15,15 +15,11 @@ fn basic() {
     TestRunner::default().run_test(
         TestConfig::new("heroku/builder:22", "test-fixtures/empty-app"),
         |context| {
-            context
-                .prepare_container()
-                .start_with_shell_command("env", |container| {
-                    let env_stdout = container.logs_wait().stdout;
-
-                    assert_contains!(env_stdout, "ROLL_1D6=");
-                    assert_contains!(env_stdout, "ROLL_4D6=");
-                    assert_contains!(env_stdout, "ROLL_1D20=");
-                });
+            let log_output = context.run_shell_command("env");
+            assert_empty!(log_output.stderr);
+            assert_contains!(log_output.stdout, "ROLL_1D6=");
+            assert_contains!(log_output.stdout, "ROLL_4D6=");
+            assert_contains!(log_output.stdout, "ROLL_1D20=");
         },
     );
 }

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Add `TestContext::start_container`, `TestContext::run_shell_command` and `ContainerConfig`. ([#469](https://github.com/heroku/libcnb.rs/pull/469))
+- Remove `TestContext::prepare_container` and `PrepareContainerContext`. To start a container use `TestContext::start_container` combined with `ContainerConfig` (or else the convenience function `TestContext::run_shell_command`) instead. ([#469](https://github.com/heroku/libcnb.rs/pull/469))
+
 ## [0.5.0] 2022-07-14
 
 - Add an `assert_empty!` macro, for improved UX over using `assert!` with `str::is_empty`. ([#451](https://github.com/heroku/libcnb.rs/pull/451))

--- a/libcnb-test/README.md
+++ b/libcnb-test/README.md
@@ -15,7 +15,7 @@ Please use the same tag for feature requests.
 
 ```rust,no_run
 // In $CRATE_ROOT/tests/integration_test.rs
-use libcnb_test::{assert_contains, TestConfig, TestRunner};
+use libcnb_test::{assert_contains, ContainerConfig, TestConfig, TestRunner};
 
 // In your code you'll want to mark your function as a test with `#[test]`.
 // It is removed here for compatibility with doctest so this code in the readme
@@ -28,10 +28,11 @@ fn test() {
             assert_contains!(context.pack_stdout, "---> Installing Maven");
             assert_contains!(context.pack_stdout, "---> Running mvn package");
 
-            context
-                .prepare_container()
-                .expose_port(12345)
-                .start_with_default_process(|container| {
+            context.start_container(
+                ContainerConfig::new()
+                    .env("PORT", "12345")
+                    .expose_port(12345),
+                |container| {
                     assert_eq!(
                         call_test_fixture_service(
                             container.address_for_port(12345).unwrap(),
@@ -40,7 +41,8 @@ fn test() {
                         .unwrap(),
                         "enileC drabgaH"
                     );
-                });
+                },
+            );
         },
     );
 }

--- a/libcnb-test/src/container_config.rs
+++ b/libcnb-test/src/container_config.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+
+/// Config used when starting a container.
+///
+/// By default the container will run the CNB default process-type, however this can be
+/// overridden using [`ContainerConfig::entrypoint`] and [`ContainerConfig::command`].
+/// See: [CNB App Developer Guide: Run a multi-process app](https://buildpacks.io/docs/app-developer-guide/run-an-app/#run-a-multi-process-app)
+///
+/// # Example
+/// ```no_run
+/// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+///
+/// TestRunner::default().run_test(
+///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+///     |context| {
+///         // ...
+///         context.start_container(
+///             ContainerConfig::new().env("PORT", "12345").expose_port(12345),
+///             |container| {
+///                 // ...
+///             },
+///         );
+///     },
+/// );
+/// ```
+#[derive(Default)]
+pub struct ContainerConfig {
+    pub(crate) entrypoint: Option<Vec<String>>,
+    pub(crate) command: Option<Vec<String>>,
+    pub(crate) env: HashMap<String, String>,
+    pub(crate) exposed_ports: Vec<u16>,
+}
+
+impl ContainerConfig {
+    /// Creates an empty [`ContainerConfig`] instance.
+    ///
+    /// By default the container will run the CNB default process-type, however this can be
+    /// overridden using [`ContainerConfig::entrypoint`] and [`ContainerConfig::command`].
+    /// See: [CNB App Developer Guide: Run a multi-process app](https://buildpacks.io/docs/app-developer-guide/run-an-app/#run-a-multi-process-app)
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         // ...
+    ///         context.start_container(
+    ///             ContainerConfig::new().env("PORT", "12345").expose_port(12345),
+    ///             |container| {
+    ///                 // ...
+    ///             },
+    ///         );
+    ///     },
+    /// );
+    /// ```
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the image's `entrypoint` (which is the CNB default process-type).
+    ///
+    /// See: [CNB App Developer Guide: Run a multi-process app](https://buildpacks.io/docs/app-developer-guide/run-an-app/#run-a-multi-process-app)
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         // ...
+    ///         context.start_container(ContainerConfig::new().entrypoint(["worker"]), |container| {
+    ///             // ...
+    ///         });
+    ///     },
+    /// );
+    /// ```
+    pub fn entrypoint<I: IntoIterator<Item = S>, S: Into<String>>(
+        &mut self,
+        entrypoint: I,
+    ) -> &mut Self {
+        self.entrypoint = Some(entrypoint.into_iter().map(S::into).collect());
+        self
+    }
+
+    /// Set the container's `command` (CNB images have no default command).
+    ///
+    /// See: [CNB App Developer Guide: Run a multi-process app](https://buildpacks.io/docs/app-developer-guide/run-an-app/#run-a-multi-process-app)
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         // ...
+    ///         context.start_container(
+    ///             ContainerConfig::new().command(["--additional-arg1", "--additional-arg2"]),
+    ///             |container| {
+    ///                 // ...
+    ///             },
+    ///         );
+    ///     },
+    /// );
+    /// ```
+    pub fn command<I: IntoIterator<Item = S>, S: Into<String>>(&mut self, command: I) -> &mut Self {
+        self.command = Some(command.into_iter().map(S::into).collect());
+        self
+    }
+
+    /// Exposes a given port of the container to the host machine.
+    ///
+    /// The given port is mapped to a random port on the host machine. Use
+    /// [`crate::ContainerContext::address_for_port`] to obtain the local port for a mapped port.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         // ...
+    ///         context.start_container(
+    ///             ContainerConfig::new().env("PORT", "12345").expose_port(12345),
+    ///             |container| {
+    ///                 let port_on_host = container.address_for_port(12345).unwrap();
+    ///                 // ...
+    ///             },
+    ///         );
+    ///     },
+    /// );
+    /// ```
+    pub fn expose_port(&mut self, port: u16) -> &mut Self {
+        self.exposed_ports.push(port);
+        self
+    }
+
+    /// Inserts or updates an environment variable mapping for the container.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         // ...
+    ///         context.start_container(
+    ///             ContainerConfig::new()
+    ///                 .env("PORT", "5678")
+    ///                 .env("DEBUG", "true"),
+    ///             |container| {
+    ///                 // ...
+    ///             },
+    ///         );
+    ///     },
+    /// );
+    /// ```
+    pub fn env(&mut self, key: impl Into<String>, value: impl Into<String>) -> &mut Self {
+        self.env.insert(key.into(), value.into());
+        self
+    }
+
+    /// Adds or updates multiple environment variable mappings for the container.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+    ///
+    /// TestRunner::default().run_test(
+    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    ///     |context| {
+    ///         // ...
+    ///         context.start_container(
+    ///             ContainerConfig::new().envs(vec![("PORT", "5678"), ("DEBUG", "true")]),
+    ///             |container| {
+    ///                 // ...
+    ///             },
+    ///         );
+    ///     },
+    /// );
+    /// ```
+    pub fn envs<K: Into<String>, V: Into<String>, I: IntoIterator<Item = (K, V)>>(
+        &mut self,
+        envs: I,
+    ) -> &mut Self {
+        envs.into_iter().for_each(|(key, value)| {
+            self.env(key.into(), value.into());
+        });
+
+        self
+    }
+}

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -31,7 +31,7 @@ impl<'a> ContainerContext<'a> {
     ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
-    ///         context.start_container(&ContainerConfig::new(), |container| {
+    ///         context.start_container(ContainerConfig::new(), |container| {
     ///             let log_output_until_now = container.logs_now();
     ///             assert_empty!(log_output_until_now.stderr);
     ///             assert_contains!(log_output_until_now.stdout, "Expected output");
@@ -72,7 +72,7 @@ impl<'a> ContainerContext<'a> {
     ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
-    ///         context.start_container(&ContainerConfig::new(), |container| {
+    ///         context.start_container(ContainerConfig::new(), |container| {
     ///             let all_log_output = container.logs_wait();
     ///             assert_empty!(all_log_output.stderr);
     ///             assert_contains!(all_log_output.stdout, "Expected output");
@@ -158,7 +158,7 @@ impl<'a> ContainerContext<'a> {
     ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
-    ///         context.start_container(&ContainerConfig::new(), |container| {
+    ///         context.start_container(ContainerConfig::new(), |container| {
     ///             let log_output = container.shell_exec("ps");
     ///             assert_contains!(log_output.stdout, "gunicorn");
     ///         });

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -1,295 +1,11 @@
 use crate::log::LogOutput;
 use crate::{container_port_mapping, util};
 use crate::{log, TestContext};
-use bollard::container::{
-    Config, CreateContainerOptions, RemoveContainerOptions, StartContainerOptions,
-};
+use bollard::container::RemoveContainerOptions;
 use bollard::exec::{CreateExecOptions, StartExecResults};
 use serde::Serialize;
-use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::time::{SystemTime, UNIX_EPOCH};
-
-/// Context for preparing a container.
-///
-/// Created by [`TestContext::prepare_container`] and is used to configure the
-/// container before running it.
-pub struct PrepareContainerContext<'a> {
-    test_context: &'a TestContext<'a>,
-    exposed_ports: Vec<u16>,
-    env: HashMap<String, String>,
-}
-
-impl<'a> PrepareContainerContext<'a> {
-    pub(crate) fn new(test_context: &'a TestContext) -> Self {
-        Self {
-            test_context,
-            exposed_ports: Vec::new(),
-            env: HashMap::new(),
-        }
-    }
-
-    /// Exposes a given port of the container to the host machine.
-    ///
-    /// The given port is mapped to a random port on the host machine. Use
-    /// [`ContainerContext::address_for_port`] to obtain the local port for a mapped port.
-    pub fn expose_port(&mut self, port: u16) -> &mut Self {
-        self.exposed_ports.push(port);
-        self
-    }
-
-    /// Inserts or updates an environment variable mapping for the container.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
-    ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
-    ///     |context| {
-    ///         context
-    ///             .prepare_container()
-    ///             .env("FOO", "FOO_VALUE")
-    ///             .env("BAR", "BAR_VALUE")
-    ///             .start_with_default_process(|container| {
-    ///                 // ...
-    ///             });
-    ///     },
-    /// );
-    /// ```
-    pub fn env(&mut self, key: impl Into<String>, value: impl Into<String>) -> &mut Self {
-        self.env.insert(key.into(), value.into());
-        self
-    }
-
-    /// Adds or updates multiple environment variable mappings for the container.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
-    ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
-    ///     |context| {
-    ///         context
-    ///             .prepare_container()
-    ///             .envs(vec![("FOO", "FOO_VALUE"), ("BAR", "BAR_VALUE")])
-    ///             .start_with_default_process(|container| {
-    ///                 // ...
-    ///             });
-    ///     },
-    /// );
-    /// ```
-    pub fn envs<K: Into<String>, V: Into<String>, I: IntoIterator<Item = (K, V)>>(
-        &mut self,
-        envs: I,
-    ) -> &mut Self {
-        envs.into_iter().for_each(|(key, value)| {
-            self.env(key.into(), value.into());
-        });
-
-        self
-    }
-
-    /// Creates and starts the container configured by this context using the image's default
-    /// CNB process.
-    ///
-    /// See: [CNB App Developer Guide: Run a multi-process app - Default process type](https://buildpacks.io/docs/app-developer-guide/run-an-app/#default-process-type)
-    ///
-    /// # Example
-    /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
-    ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
-    ///     |context| {
-    ///         context
-    ///             .prepare_container()
-    ///             .start_with_default_process(|container| {
-    ///                 // ...
-    ///             });
-    ///     },
-    /// );
-    /// ```
-    pub fn start_with_default_process<F: FnOnce(ContainerContext)>(&self, f: F) {
-        self.start_internal(None, None, f);
-    }
-
-    /// Creates and starts the container configured by this context using the image's default
-    /// CNB process and given arguments.
-    ///
-    /// See: [CNB App Developer Guide: Run a multi-process app - Default process type with additional arguments](https://buildpacks.io/docs/app-developer-guide/run-an-app/#default-process-type-with-additional-arguments)
-    ///
-    /// # Example
-    /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
-    ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
-    ///     |context| {
-    ///         context.prepare_container().start_with_default_process_args(
-    ///             ["--version"],
-    ///             |container| {
-    ///                 // ...
-    ///             },
-    ///         );
-    ///     },
-    /// );
-    /// ```
-    pub fn start_with_default_process_args<
-        F: FnOnce(ContainerContext),
-        A: IntoIterator<Item = I>,
-        I: Into<String>,
-    >(
-        &self,
-        args: A,
-        f: F,
-    ) {
-        self.start_internal(None, Some(args.into_iter().map(I::into).collect()), f);
-    }
-
-    /// Creates and starts the container configured by this context using the given CNB process.
-    ///
-    /// See: [CNB App Developer Guide: Run a multi-process app - Non-default process-type](https://buildpacks.io/docs/app-developer-guide/run-an-app/#non-default-process-type)
-    ///
-    /// # Example
-    /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
-    ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
-    ///     |context| {
-    ///         context
-    ///             .prepare_container()
-    ///             .start_with_process("worker", |container| {
-    ///                 // ...
-    ///             });
-    ///     },
-    /// );
-    /// ```
-    pub fn start_with_process<F: FnOnce(ContainerContext), P: Into<String>>(
-        &self,
-        process: P,
-        f: F,
-    ) {
-        self.start_internal(Some(vec![process.into()]), None, f);
-    }
-
-    /// Creates and starts the container configured by this context using the given CNB process
-    /// and arguments.
-    ///
-    /// See: [CNB App Developer Guide: Run a multi-process app - Non-default process-type with additional arguments](https://buildpacks.io/docs/app-developer-guide/run-an-app/#non-default-process-type-with-additional-arguments)
-    ///
-    /// # Example
-    /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
-    ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
-    ///     |context| {
-    ///         context.prepare_container().start_with_process_args(
-    ///             "worker",
-    ///             ["--config", "foo.toml"],
-    ///             |container| {
-    ///                 // ...
-    ///             },
-    ///         );
-    ///     },
-    /// );
-    /// ```
-    pub fn start_with_process_args<
-        F: FnOnce(ContainerContext),
-        A: IntoIterator<Item = I>,
-        I: Into<String>,
-        P: Into<String>,
-    >(
-        &self,
-        process: P,
-        args: A,
-        f: F,
-    ) {
-        self.start_internal(
-            Some(vec![process.into()]),
-            Some(args.into_iter().map(I::into).collect()),
-            f,
-        );
-    }
-
-    /// Creates and starts the container configured by this context using the given shell command.
-    ///
-    /// The CNB lifecycle launcher will be implicitly used. Environment variables will be set. Uses
-    /// `bash` as the shell.
-    ///
-    /// See: [CNB App Developer Guide: Run a multi-process app - User-provided shell process](https://buildpacks.io/docs/app-developer-guide/run-an-app/#user-provided-shell-process)
-    ///
-    /// # Example
-    /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
-    ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
-    ///     |context| {
-    ///         context
-    ///             .prepare_container()
-    ///             .start_with_shell_command("env", |container| {
-    ///                 // ...
-    ///             });
-    ///     },
-    /// );
-    /// ```
-    pub fn start_with_shell_command<F: FnOnce(ContainerContext), C: Into<String>>(
-        &self,
-        command: C,
-        f: F,
-    ) {
-        self.start_internal(
-            Some(vec![String::from(CNB_LAUNCHER_BINARY)]),
-            Some(vec![command.into()]),
-            f,
-        );
-    }
-
-    fn start_internal<F: FnOnce(ContainerContext)>(
-        &self,
-        entrypoint: Option<Vec<String>>,
-        cmd: Option<Vec<String>>,
-        f: F,
-    ) {
-        let container_name = util::random_docker_identifier();
-
-        self.test_context.runner.tokio_runtime.block_on(async {
-            self.test_context
-                .runner
-                .docker
-                .create_container(
-                    Some(CreateContainerOptions {
-                        name: container_name.clone(),
-                    }),
-                    Config {
-                        image: Some(self.test_context.image_name.clone()),
-                        env: Some(self.env.iter().map(|(k, v)| format!("{k}={v}")).collect()),
-                        entrypoint,
-                        cmd,
-                        ..container_port_mapping::port_mapped_container_config(&self.exposed_ports)
-                    },
-                )
-                .await
-                .expect("Could not create container");
-
-            self.test_context
-                .runner
-                .docker
-                .start_container(&container_name, None::<StartContainerOptions<String>>)
-                .await
-                .expect("Could not start container");
-        });
-
-        f(ContainerContext {
-            container_name,
-            test_context: self.test_context,
-        });
-    }
-}
 
 /// Context of a launched container.
 pub struct ContainerContext<'a> {
@@ -309,17 +25,17 @@ impl<'a> ContainerContext<'a> {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{assert_contains, TestConfig, TestRunner};
+    /// use libcnb_test::{assert_contains, assert_empty, ContainerConfig, TestConfig, TestRunner};
     ///
     /// TestRunner::default().run_test(
     ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
-    ///         context
-    ///             .prepare_container()
-    ///             .start_with_default_process(|container| {
-    ///                 assert_contains!(container.logs_now().stdout, "Expected output");
-    ///             });
+    ///         context.start_container(&ContainerConfig::new(), |container| {
+    ///             let log_output_until_now = container.logs_now();
+    ///             assert_empty!(log_output_until_now.stderr);
+    ///             assert_contains!(log_output_until_now.stdout, "Expected output");
+    ///         });
     ///     },
     /// );
     /// ```
@@ -350,17 +66,17 @@ impl<'a> ContainerContext<'a> {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{assert_contains, TestConfig, TestRunner};
+    /// use libcnb_test::{assert_contains, assert_empty, ContainerConfig, TestConfig, TestRunner};
     ///
     /// TestRunner::default().run_test(
     ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
-    ///         context
-    ///             .prepare_container()
-    ///             .start_with_default_process(|container| {
-    ///                 assert_contains!(container.logs_wait().stdout, "Expected output");
-    ///             });
+    ///         context.start_container(&ContainerConfig::new(), |container| {
+    ///             let all_log_output = container.logs_wait();
+    ///             assert_empty!(all_log_output.stderr);
+    ///             assert_contains!(all_log_output.stdout, "Expected output");
+    ///         });
     ///     },
     /// );
     /// ```
@@ -396,28 +112,19 @@ impl<'a> ContainerContext<'a> {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
+    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
     ///
-    /// # fn call_test_fixture_service(addr: std::net::SocketAddr, payload: &str) -> Result<String, ()> {
-    /// #    unimplemented!()
-    /// # }
     /// TestRunner::default().run_test(
     ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
-    ///         context
-    ///             .prepare_container()
-    ///             .expose_port(12345)
-    ///             .start_with_default_process(|container| {
-    ///                 assert_eq!(
-    ///                     call_test_fixture_service(
-    ///                         container.address_for_port(12345).unwrap(),
-    ///                         "Hagbard Celine"
-    ///                     )
-    ///                     .unwrap(),
-    ///                     "enileC drabgaH"
-    ///                 );
-    ///             });
+    ///         context.start_container(
+    ///             ContainerConfig::new().env("PORT", "12345").expose_port(12345),
+    ///             |container| {
+    ///                 let port_on_host = container.address_for_port(12345).unwrap();
+    ///                 // ...
+    ///             },
+    ///         );
     ///     },
     /// );
     /// ```
@@ -445,17 +152,16 @@ impl<'a> ContainerContext<'a> {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{assert_contains, TestConfig, TestRunner};
+    /// use libcnb_test::{assert_contains, ContainerConfig, TestConfig, TestRunner};
     ///
     /// TestRunner::default().run_test(
     ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
-    ///         context
-    ///             .prepare_container()
-    ///             .start_with_default_process(|container| {
-    ///                 assert_contains!(container.shell_exec("ps").stdout, "gunicorn");
-    ///             });
+    ///         context.start_container(&ContainerConfig::new(), |container| {
+    ///             let log_output = container.shell_exec("ps");
+    ///             assert_contains!(log_output.stdout, "gunicorn");
+    ///         });
     ///     },
     /// );
     /// ```
@@ -468,7 +174,7 @@ impl<'a> ContainerContext<'a> {
                 .create_exec(
                     &self.container_name,
                     CreateExecOptions {
-                        cmd: Some(vec![CNB_LAUNCHER_BINARY, command.as_ref()]),
+                        cmd: Some(vec![util::CNB_LAUNCHER_BINARY, command.as_ref()]),
                         attach_stdout: Some(true),
                         ..CreateExecOptions::default()
                     },
@@ -511,5 +217,3 @@ impl<'a> Drop for ContainerContext<'a> {
         );
     }
 }
-
-const CNB_LAUNCHER_BINARY: &str = "launcher";

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod app;
 mod build;
+mod container_config;
 mod container_context;
 mod container_port_mapping;
 mod log;
@@ -17,6 +18,7 @@ mod test_context;
 mod test_runner;
 mod util;
 
+pub use crate::container_config::*;
 pub use crate::container_context::*;
 pub use crate::log::*;
 pub use crate::test_config::*;

--- a/libcnb-test/src/test_context.rs
+++ b/libcnb-test/src/test_context.rs
@@ -111,9 +111,9 @@ impl<'a> TestContext<'a> {
         });
     }
 
-    /// Run the provided shell script.
+    /// Run the provided shell command.
     ///
-    /// The CNB launcher will run the provided script using `bash`.
+    /// The CNB launcher will run the provided command using `bash`.
     ///
     /// Note: This method will block until the container stops.
     ///
@@ -131,7 +131,7 @@ impl<'a> TestContext<'a> {
     /// );
     /// ```
     ///
-    /// This is a convenience function for running shell scripts inside the image, and is equivalent to:
+    /// This is a convenience function for running shell commands inside the image, and is equivalent to:
     /// ```no_run
     /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
     ///

--- a/libcnb-test/src/test_context.rs
+++ b/libcnb-test/src/test_context.rs
@@ -34,7 +34,7 @@ impl<'a> TestContext<'a> {
     ///     |context| {
     ///         // Start the container using the default process-type:
     ///         // https://buildpacks.io/docs/app-developer-guide/run-an-app/#default-process-type
-    ///         context.start_container(&ContainerConfig::new(), |container| {
+    ///         context.start_container(ContainerConfig::new(), |container| {
     ///             // ...
     ///         });
     ///
@@ -70,7 +70,12 @@ impl<'a> TestContext<'a> {
     ///     },
     /// );
     /// ```
-    pub fn start_container<F: FnOnce(ContainerContext)>(&self, config: &ContainerConfig, f: F) {
+    pub fn start_container<C: Borrow<ContainerConfig>, F: FnOnce(ContainerContext)>(
+        &self,
+        config: C,
+        f: F,
+    ) {
+        let config = config.borrow();
         let container_name = util::random_docker_identifier();
 
         self.runner.tokio_runtime.block_on(async {

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -16,7 +16,7 @@ use std::{env, io};
 ///
 /// # Example
 /// ```no_run
-/// use libcnb_test::{assert_contains, TestConfig, TestRunner};
+/// use libcnb_test::{assert_contains, ContainerConfig, TestConfig, TestRunner};
 ///
 /// # fn call_test_fixture_service(addr: std::net::SocketAddr, payload: &str) -> Result<String, ()> {
 /// #    unimplemented!()
@@ -28,10 +28,11 @@ use std::{env, io};
 ///         assert_contains!(context.pack_stdout, "---> Installing Maven");
 ///         assert_contains!(context.pack_stdout, "---> Running mvn package");
 ///
-///         context
-///             .prepare_container()
-///             .expose_port(12345)
-///             .start_with_default_process(|container| {
+///         context.start_container(
+///             ContainerConfig::new()
+///                 .env("PORT", "12345")
+///                 .expose_port(12345),
+///             |container| {
 ///                 assert_eq!(
 ///                     call_test_fixture_service(
 ///                         container.address_for_port(12345).unwrap(),
@@ -40,7 +41,8 @@ use std::{env, io};
 ///                     .unwrap(),
 ///                     "enileC drabgaH"
 ///                 );
-///             });
+///             },
+///         );
 ///     },
 /// );
 /// ```

--- a/libcnb-test/src/util.rs
+++ b/libcnb-test/src/util.rs
@@ -13,3 +13,5 @@ pub(crate) fn random_docker_identifier() -> String {
             .collect::<String>()
     )
 }
+
+pub(crate) const CNB_LAUNCHER_BINARY: &str = "launcher";

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -202,7 +202,7 @@ fn app_dir_preprocessor() {
                 fs::write(app_dir.join("Procfile"), "list-files: find . | sort").unwrap();
             }),
         |context| {
-            context.start_container(&ContainerConfig::new(), |container| {
+            context.start_container(ContainerConfig::new(), |container| {
                 let log_output = container.logs_wait();
                 assert_contains!(
                     log_output.stdout,


### PR DESCRIPTION
Previously container configuration was specified using a builder-style API, which was inconsistent with the API for `TestRunner::run_test`, and also slightly confusing at first glance (eg: for `TestContext::prepare_container` what does it mean to "prepare" a container?)

Now, a new `TestContext::start_container` takes a `ContainerConfig` argument along with the closure, similar to `TestRunner::run_test` and `TestConfig`.

In addition, a new convenience function for running a shell script (a common use-case) has been added (`TestContext::run_shell_command`) which handles more of the boilerplate than `PrepareContainerContext::start_with_shell_command` used to. In the future, this function will also check the exit status of the container (#446).

GUS-W-11415596.