### PR TITLE
libcnb-test: Rename `Test{Runner,Context}::run_test` and `TestConfig`

### DIFF
--- a/examples/execd/tests/integration_test.rs
+++ b/examples/execd/tests/integration_test.rs
@@ -7,13 +7,13 @@
 // https://rust-lang.github.io/rust-clippy/stable/index.html
 #![warn(clippy::pedantic)]
 
-use libcnb_test::{assert_contains, assert_empty, TestConfig, TestRunner};
+use libcnb_test::{assert_contains, assert_empty, BuildConfig, TestRunner};
 
 #[test]
 #[ignore]
 fn basic() {
-    TestRunner::default().run_test(
-        TestConfig::new("heroku/builder:22", "test-fixtures/empty-app"),
+    TestRunner::default().build(
+        BuildConfig::new("heroku/builder:22", "test-fixtures/empty-app"),
         |context| {
             let log_output = context.run_shell_command("env");
             assert_empty!(log_output.stderr);

--- a/examples/ruby-sample/tests/integration_test.rs
+++ b/examples/ruby-sample/tests/integration_test.rs
@@ -8,7 +8,7 @@
 #![warn(clippy::pedantic)]
 
 use libcnb_test::{
-    assert_contains, assert_not_contains, ContainerConfig, PackResult, TestConfig, TestRunner,
+    assert_contains, assert_not_contains, BuildConfig, ContainerConfig, PackResult, TestRunner,
 };
 use std::io::{Read, Write};
 use std::net;
@@ -19,9 +19,9 @@ use std::{fs, io};
 #[test]
 #[ignore]
 fn basic() {
-    let config = TestConfig::new("heroku/buildpacks:20", "test-fixtures/simple-ruby-app");
+    let config = BuildConfig::new("heroku/buildpacks:20", "test-fixtures/simple-ruby-app");
 
-    TestRunner::default().run_test(&config, |context| {
+    TestRunner::default().build(&config, |context| {
         assert_contains!(context.pack_stdout, "---> Ruby Buildpack");
         assert_contains!(context.pack_stdout, "---> Installing bundler");
         assert_contains!(context.pack_stdout, "---> Installing gems");
@@ -49,7 +49,7 @@ fn basic() {
             "ruby 2.7.0p0"
         );
 
-        context.run_test(&config, |context| {
+        context.rebuild(&config, |context| {
             assert_not_contains!(context.pack_stdout, "---> Installing bundler");
             assert_not_contains!(context.pack_stdout, "---> Installing gems");
         });
@@ -59,8 +59,8 @@ fn basic() {
 #[test]
 #[ignore]
 fn missing_gemfile_lock() {
-    TestRunner::default().run_test(
-        TestConfig::new("heroku/buildpacks:20", "test-fixtures/simple-ruby-app")
+    TestRunner::default().build(
+        BuildConfig::new("heroku/buildpacks:20", "test-fixtures/simple-ruby-app")
             .app_dir_preprocessor(|path| fs::remove_file(path.join("Gemfile.lock")).unwrap())
             .expected_pack_result(PackResult::Failure),
         |context| {

--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Rename `TestRunner::run_test` to `TestRunner::build`, `TestConfig` to `BuildConfig` and `TestContext::run_test` to `TestContext::rebuild`. ([#470](https://github.com/heroku/libcnb.rs/pull/470))
 - Add `TestContext::start_container`, `TestContext::run_shell_command` and `ContainerConfig`. ([#469](https://github.com/heroku/libcnb.rs/pull/469))
 - Remove `TestContext::prepare_container` and `PrepareContainerContext`. To start a container use `TestContext::start_container` combined with `ContainerConfig` (or else the convenience function `TestContext::run_shell_command`) instead. ([#469](https://github.com/heroku/libcnb.rs/pull/469))
 - Fix missing logs when using `ContainerContext::logs_now`. ([#471](https://github.com/heroku/libcnb.rs/pull/471))

--- a/libcnb-test/README.md
+++ b/libcnb-test/README.md
@@ -15,14 +15,14 @@ Please use the same tag for feature requests.
 
 ```rust,no_run
 // In $CRATE_ROOT/tests/integration_test.rs
-use libcnb_test::{assert_contains, ContainerConfig, TestConfig, TestRunner};
+use libcnb_test::{assert_contains, BuildConfig, ContainerConfig, TestRunner};
 
 // In your code you'll want to mark your function as a test with `#[test]`.
 // It is removed here for compatibility with doctest so this code in the readme
 // tests for compilation.
 fn test() {
-    TestRunner::default().run_test(
-        TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    TestRunner::default().build(
+        BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
         |context| {
             assert_contains!(context.pack_stdout, "---> Maven Buildpack");
             assert_contains!(context.pack_stdout, "---> Installing Maven");

--- a/libcnb-test/src/container_config.rs
+++ b/libcnb-test/src/container_config.rs
@@ -8,10 +8,10 @@ use std::collections::HashMap;
 ///
 /// # Example
 /// ```no_run
-/// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+/// use libcnb_test::{BuildConfig, ContainerConfig, TestRunner};
 ///
-/// TestRunner::default().run_test(
-///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+/// TestRunner::default().build(
+///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
 ///     |context| {
 ///         // ...
 ///         context.start_container(
@@ -40,10 +40,10 @@ impl ContainerConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, ContainerConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
     ///         context.start_container(
@@ -66,10 +66,10 @@ impl ContainerConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, ContainerConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
     ///         context.start_container(ContainerConfig::new().entrypoint(["worker"]), |container| {
@@ -92,10 +92,10 @@ impl ContainerConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, ContainerConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
     ///         context.start_container(
@@ -119,10 +119,10 @@ impl ContainerConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, ContainerConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
     ///         context.start_container(
@@ -144,10 +144,10 @@ impl ContainerConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, ContainerConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
     ///         context.start_container(
@@ -170,10 +170,10 @@ impl ContainerConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, ContainerConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
     ///         context.start_container(

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -24,10 +24,10 @@ impl<'a> ContainerContext<'a> {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{assert_contains, assert_empty, ContainerConfig, TestConfig, TestRunner};
+    /// use libcnb_test::{assert_contains, assert_empty, BuildConfig, ContainerConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
     ///         context.start_container(ContainerConfig::new(), |container| {
@@ -58,10 +58,10 @@ impl<'a> ContainerContext<'a> {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{assert_contains, assert_empty, ContainerConfig, TestConfig, TestRunner};
+    /// use libcnb_test::{assert_contains, assert_empty, BuildConfig, ContainerConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
     ///         context.start_container(ContainerConfig::new(), |container| {
@@ -104,10 +104,10 @@ impl<'a> ContainerContext<'a> {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{ContainerConfig, TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, ContainerConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
     ///         context.start_container(
@@ -144,10 +144,10 @@ impl<'a> ContainerContext<'a> {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{assert_contains, ContainerConfig, TestConfig, TestRunner};
+    /// use libcnb_test::{assert_contains, BuildConfig, ContainerConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
     ///         context.start_container(ContainerConfig::new(), |container| {

--- a/libcnb-test/src/test_config.rs
+++ b/libcnb-test/src/test_config.rs
@@ -6,7 +6,7 @@ pub use libcnb_package::CargoProfile;
 
 /// Configuration for a test.
 #[derive(Clone)]
-pub struct TestConfig {
+pub struct BuildConfig {
     pub(crate) app_dir: PathBuf,
     pub(crate) cargo_profile: CargoProfile,
     pub(crate) target_triple: String,
@@ -17,7 +17,7 @@ pub struct TestConfig {
     pub(crate) expected_pack_result: PackResult,
 }
 
-impl TestConfig {
+impl BuildConfig {
     /// Creates a new test configuration.
     ///
     /// If the `app_dir` parameter is a relative path, it is treated as relative to the Cargo
@@ -26,17 +26,17 @@ impl TestConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app"),
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
     ///     },
     /// );
     /// ```
     pub fn new(builder_name: impl Into<String>, app_dir: impl AsRef<Path>) -> Self {
-        TestConfig {
+        Self {
             app_dir: PathBuf::from(app_dir.as_ref()),
             cargo_profile: CargoProfile::Dev,
             target_triple: String::from("x86_64-unknown-linux-musl"),
@@ -54,10 +54,10 @@ impl TestConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{BuildpackReference, TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, BuildpackReference, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app").buildpacks(vec![
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app").buildpacks(vec![
     ///         BuildpackReference::Other(String::from("heroku/another-buildpack")),
     ///         BuildpackReference::Crate,
     ///     ]),
@@ -77,10 +77,10 @@ impl TestConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{CargoProfile, TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, CargoProfile, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app")
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app")
     ///         .cargo_profile(CargoProfile::Release),
     ///     |context| {
     ///         // ...
@@ -98,10 +98,10 @@ impl TestConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app")
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app")
     ///         .target_triple("x86_64-unknown-linux-musl"),
     ///     |context| {
     ///         // ...
@@ -120,10 +120,10 @@ impl TestConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app")
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app")
     ///         .env("ENV_VAR_ONE", "VALUE ONE")
     ///         .env("ENV_VAR_TWO", "SOME OTHER VALUE"),
     ///     |context| {
@@ -143,10 +143,10 @@ impl TestConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app").envs(vec![
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app").envs(vec![
     ///         ("ENV_VAR_ONE", "VALUE ONE"),
     ///         ("ENV_VAR_TWO", "SOME OTHER VALUE"),
     ///     ]),
@@ -176,10 +176,10 @@ impl TestConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app").app_dir_preprocessor(|app_dir| {
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app").app_dir_preprocessor(|app_dir| {
     ///         std::fs::remove_file(app_dir.join("Procfile")).unwrap();
     ///     }),
     ///     |context| {
@@ -194,19 +194,19 @@ impl TestConfig {
 
     /// Sets the app directory.
     ///
-    /// The app directory is normally set in the [`TestConfig::new`] call, but when sharing test
+    /// The app directory is normally set in the [`BuildConfig::new`] call, but when sharing test
     /// configuration, it might be necessary to change the app directory but keep everything else
     /// the same.
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, TestRunner};
     ///
-    /// fn default_config() -> TestConfig {
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app")
+    /// fn default_config() -> BuildConfig {
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app")
     /// }
     ///
-    /// TestRunner::default().run_test(
+    /// TestRunner::default().build(
     ///     default_config().app_dir("test-fixtures/a-different-app"),
     ///     |context| {
     ///         // ...
@@ -228,10 +228,10 @@ impl TestConfig {
     ///
     /// # Example
     /// ```no_run
-    /// use libcnb_test::{PackResult, TestConfig, TestRunner};
+    /// use libcnb_test::{BuildConfig, PackResult, TestRunner};
     ///
-    /// TestRunner::default().run_test(
-    ///     TestConfig::new("heroku/builder:22", "test-fixtures/app")
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app")
     ///         .expected_pack_result(PackResult::Failure),
     ///     |context| {
     ///         // ...


### PR DESCRIPTION
Performs the following renames:
- `TestRunner::run_test` -> `TestRunner::build`
- `TestConfig` -> `BuildConfig`
- `TestContext::run_test` -> `TestContext::rebuild`

Whilst there were arguments for using `run_test` at the top level (such as the closure being the whole test, not just the build):
- using `run_test` again for the rebuild case didn't fit as well
- it obscures the fact that inside the closure is initially only the result of the build, and not anything else (until containers are started etc).

Similarly, the rename of `TestConfig` to `BuildConfig` should make it clearer that options there (such as `BuildConfig.env`) only apply  to the build, and don't also apply to the started containers.

GUS-W-11415596.