### PR TITLE
libcnb-test: Don't set a time window for `logs_now()`

### DIFF
--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `TestContext::start_container`, `TestContext::run_shell_command` and `ContainerConfig`. ([#469](https://github.com/heroku/libcnb.rs/pull/469))
 - Remove `TestContext::prepare_container` and `PrepareContainerContext`. To start a container use `TestContext::start_container` combined with `ContainerConfig` (or else the convenience function `TestContext::run_shell_command`) instead. ([#469](https://github.com/heroku/libcnb.rs/pull/469))
+- Fix missing logs when using `ContainerContext::logs_now`. ([#471](https://github.com/heroku/libcnb.rs/pull/471))
 
 ## [0.5.0] 2022-07-14
 

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -5,7 +5,6 @@ use bollard::container::RemoveContainerOptions;
 use bollard::exec::{CreateExecOptions, StartExecResults};
 use serde::Serialize;
 use std::net::SocketAddr;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Context of a launched container.
 pub struct ContainerContext<'a> {
@@ -41,16 +40,9 @@ impl<'a> ContainerContext<'a> {
     /// ```
     #[must_use]
     pub fn logs_now(&self) -> LogOutput {
-        // Bollard forces us to cast to i64
-        #[allow(clippy::cast_possible_wrap)]
         self.logs_internal(bollard::container::LogsOptions {
             stdout: true,
             stderr: true,
-            since: 0,
-            until: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("System time is before UNIX epoch")
-                .as_secs() as i64,
             tail: "all",
             ..bollard::container::LogsOptions::default()
         })


### PR DESCRIPTION
Previously `ContainerContext::logs_now` set the `since` and `until` options in the logs request sent to the Docker daemon.

Not only are these options unnecessary (since the default is to return all logs), but in fact setting the values explicitly was resulting in logs intermittently not being returned in some cases. I believe this may be due to races between the `SystemTime::now()` call and the time associated with the log lines in the daemon.

Now, we rely on the default values for `since` and `until`:
https://docs.rs/bollard/latest/bollard/container/struct.LogsOptions.html
https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerLogs

GUS-W-11451448.