### PR TITLE
libcnb-test: Expand integration test coverage

### DIFF
--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -24,6 +24,7 @@ tokio-stream = "0.1.9"
 
 [dev-dependencies]
 indoc = "1.0.6"
+ureq = { version = "2.5.0", default-features = false }
 
 [features]
 # Enables experimental support for connecting to a remote Docker daemon.

--- a/libcnb-test/src/container_config.rs
+++ b/libcnb-test/src/container_config.rs
@@ -128,7 +128,7 @@ impl ContainerConfig {
     ///         context.start_container(
     ///             ContainerConfig::new().env("PORT", "12345").expose_port(12345),
     ///             |container| {
-    ///                 let port_on_host = container.address_for_port(12345).unwrap();
+    ///                 let address_on_host = container.address_for_port(12345).unwrap();
     ///                 // ...
     ///             },
     ///         );

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -113,7 +113,7 @@ impl<'a> ContainerContext<'a> {
     ///         context.start_container(
     ///             ContainerConfig::new().env("PORT", "12345").expose_port(12345),
     ///             |container| {
-    ///                 let port_on_host = container.address_for_port(12345).unwrap();
+    ///                 let address_on_host = container.address_for_port(12345).unwrap();
     ///                 // ...
     ///             },
     ///         );

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -28,3 +28,5 @@ pub use crate::test_runner::*;
 // Suppress warnings due to the `unused_crate_dependencies` lint not handling integration tests well.
 #[cfg(test)]
 use indoc as _;
+#[cfg(test)]
+use ureq as _;


### PR DESCRIPTION
Adds coverage for:
- `ContainerContext::address_for_port`
- `ContainerConfig::envs` (only `env` was tested previously)
- `ContainerConfig::app_dir_preprocessor` when rebuilding

Also replaces the hardcoded sleep with a retrying HTTP client. Longer term we may want to add support for a retrying test HTTP client to `libcnb-test` behind an opt-in Cargo feature flag.

GUS-W-11451593.