### PR TITLE
Prevent libcnb-data badges from showing up in `data` rustdocs

### DIFF
--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -29,11 +29,13 @@ mod util;
 pub use buildpack::Buildpack;
 pub use env::*;
 pub use error::*;
-#[doc(inline)]
-pub use libcnb_data as data;
 pub use platform::*;
 pub use runtime::*;
 pub use toml_file::*;
+
+/// Provides types for CNB data formats. Is a re-export of the `libcnb-data` crate.
+#[doc(inline)]
+pub use libcnb_data as data;
 
 const LIBCNB_SUPPORTED_BUILDPACK_API: data::buildpack::BuildpackApi =
     data::buildpack::BuildpackApi { major: 0, minor: 6 };


### PR DESCRIPTION
Previously the rustdocs for the `libcnb::data` module entry (which is a re-export of the `libcnb-data` crate) were auto-generated, and resulted in:

```
## Modules
build   Provides build phase specific types and helpers.
data    libcnb-data  Docs Latest Version MSRV 
...
```

(where the "Docs Latest Version MSRV" are broken badge links from `libcnb-data`'s README)

See:
https://docs.rs/libcnb/0.9.0/libcnb/index.html#modules

Now the content from the libcnb-data README is overridden, which results in:

```
## Modules
build   Provides build phase specific types and helpers.
data    Provides types for CNB data formats. Is a re-export of the `libcnb-data` crate.
...
```

Follow-up to #460.