### PR TITLE
Release libcnb-test 0.6.0

### DIFF
--- a/libcnb-test/CHANGELOG.md
+++ b/libcnb-test/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.6.0] 2022-07-21
+
 - Overhaul the crate README/docs, to improve the learning/onboarding UX. ([#478](https://github.com/heroku/libcnb.rs/pull/478))
 - Rename `TestRunner::run_test` to `TestRunner::build`, `TestConfig` to `BuildConfig` and `TestContext::run_test` to `TestContext::rebuild`. ([#470](https://github.com/heroku/libcnb.rs/pull/470))
 - Add `TestContext::start_container`, `TestContext::run_shell_command` and `ContainerConfig`. ([#469](https://github.com/heroku/libcnb.rs/pull/469))

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-test"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.59"
 license = "BSD-3-Clause"


### PR DESCRIPTION
https://github.com/heroku/libcnb.rs/compare/libcnb-test/v0.5.0...e4a364436c044840261e3093b4a7491e738b6f08

GUS-W-11469147.