### PR TITLE
Add LaunchBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Modify the project's `src/main.rs` file to contain the following:
 
 ```rust,no_run
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
-use libcnb::data::launch::{Launch, ProcessBuilder};
+use libcnb::data::launch::{LaunchBuilder, ProcessBuilder};
 use libcnb::data::process_type;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
@@ -153,12 +153,13 @@ impl Buildpack for HelloWorldBuildpack {
 
         BuildResultBuilder::new()
             .launch(
-                Launch::new().process(
+                LaunchBuilder::new().process(
                     ProcessBuilder::new(process_type!("web"), "echo")
                         .arg("Hello World!")
                         .default(true)
                         .build(),
-                ),
+                )
+                .build(),
             )
             .build()
     }

--- a/examples/ruby-sample/src/main.rs
+++ b/examples/ruby-sample/src/main.rs
@@ -7,7 +7,7 @@
 use crate::layers::{BundlerLayer, RubyLayer};
 use crate::util::{DownloadError, UntarError};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
-use libcnb::data::launch::{Launch, ProcessBuilder};
+use libcnb::data::launch::{LaunchBuilder, ProcessBuilder};
 use libcnb::data::{layer_name, process_type};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::GenericPlatform;
@@ -48,7 +48,7 @@ impl Buildpack for RubyBuildpack {
 
         BuildResultBuilder::new()
             .launch(
-                Launch::new()
+                LaunchBuilder::new()
                     .process(
                         ProcessBuilder::new(process_type!("web"), "bundle")
                             .args(vec!["exec", "ruby", "app.rb"])
@@ -59,7 +59,8 @@ impl Buildpack for RubyBuildpack {
                         ProcessBuilder::new(process_type!("worker"), "bundle")
                             .args(vec!["exec", "ruby", "worker.rb"])
                             .build(),
-                    ),
+                    )
+                    .build(),
             )
             .build()
     }

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Replace builder style functions from `Launch` with a dedicated `LaunchBuilder` to be more consistent with other builders in the library. Additionally, all fields of `Launch` can now be modified via the builder pattern. ([#000](https://github.com/heroku/libcnb.rs/pull/000))
+- Rename `paths` field in `launch::Slice` to `path_globs` and add docs to make it clearer that these strings are Go standard library globs. ([#000](https://github.com/heroku/libcnb.rs/pull/000))
+
 ## [0.8.0] 2022-07-14
 
 - Disable `fancy-regex` default features (such as unused unicode support) to reduce buildpack binary size. ([#439](https://github.com/heroku/libcnb.rs/pull/439))

--- a/libcnb-data/CHANGELOG.md
+++ b/libcnb-data/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [Unreleased]
 
-- Replace builder style functions from `Launch` with a dedicated `LaunchBuilder` to be more consistent with other builders in the library. Additionally, all fields of `Launch` can now be modified via the builder pattern. ([#000](https://github.com/heroku/libcnb.rs/pull/000))
-- Rename `paths` field in `launch::Slice` to `path_globs` and add docs to make it clearer that these strings are Go standard library globs. ([#000](https://github.com/heroku/libcnb.rs/pull/000))
+- Replace builder style functions from `Launch` with a dedicated `LaunchBuilder` to be more consistent with other builders in the library. Additionally, all fields of `Launch` can now be modified via the builder pattern. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
+- Rename `paths` field in `launch::Slice` to `path_globs` and add docs to make it clearer that these strings are Go standard library globs. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
 
 ## [0.8.0] 2022-07-14
 

--- a/libcnb-data/src/bom.rs
+++ b/libcnb-data/src/bom.rs
@@ -3,7 +3,7 @@ use toml;
 
 pub type Bom = Vec<Entry>;
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Entry {
     pub name: String,

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -133,15 +133,23 @@ pub(crate) enum InnerBuildResult {
 /// # Examples:
 /// ```
 /// use libcnb::build::{BuildResultBuilder, BuildResult};
-/// use libcnb::data::launch::Launch;
+/// use libcnb::data::launch::LaunchBuilder;
 /// use libcnb::data::process_type;
 /// use libcnb::data::launch::ProcessBuilder;
 ///
 /// let simple: Result<BuildResult, ()> = BuildResultBuilder::new().build();
 ///
 /// let with_launch: Result<BuildResult, ()> = BuildResultBuilder::new()
-///    .launch(Launch::new().process(ProcessBuilder::new(process_type!("type"), "command").arg("-v").build()))
-///    .build();
+///     .launch(
+///         LaunchBuilder::new()
+///             .process(
+///                 ProcessBuilder::new(process_type!("type"), "command")
+///                     .arg("-v")
+///                     .build(),
+///             )
+///             .build(),
+///     )
+///     .build();
 /// ```
 #[derive(Default)]
 #[must_use]


### PR DESCRIPTION
This PR originally started as a fix for #485. As it turns out, adding slices to `Launch` was already possible, albeit more complicated as it should be since there were no builder functions available for slices.

This PR adds a dedicated `LaunchBuilder` that allows setting all fields for `Launch`, removes the builder-style functions from `Launch` as they were inconsistent with the rest of libcnb.rs anyways. I still want to tackle #166, but this isn't the PR for that.

I also added some docs for `Slice` that clarify what `paths` actually is (and renamed it). I opted to not implement a newtype for Go standard library path globs for now as we can spend our time better in other areas. I created an issue for it as #486.

## Changelog

- Replace builder style functions from `Launch` with a dedicated `LaunchBuilder` to be more consistent with other builders in the library. Additionally, all fields of `Launch` can now be modified via the builder pattern. 
- Rename `paths` field in `launch::Slice` to `path_globs` and add docs to make it clearer that these strings are Go standard library globs.

Closes #485, [GUS-W-11486542](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-11486542)