### PR TITLE
Synchronous Crate Versions

### DIFF
--- a/.github/workflows/check_versions.yml
+++ b/.github/workflows/check_versions.yml
@@ -1,0 +1,18 @@
+name: Check Versions
+
+on:
+  # Only perform branch builds for `main`, to avoid duplicate builds on PRs.
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check that only one version is used across all workspace crates
+        # Exclude crates with version 0.0.0 used by examples and test buildpacks which are part of the workspace too
+        run: |
+          cargo metadata --no-deps --format-version 1 | jq -e '(.packages | map(select(.version != "0.0.0")) | group_by(.version) | length) == 1'

--- a/.github/workflows/check_versions.yml
+++ b/.github/workflows/check_versions.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check that only one version is used across all workspace crates
-        # Exclude crates with version 0.0.0 used by examples and test buildpacks which are part of the workspace too
+        # Crates that are not published to any registry (i.e. examples, test buildpacks) will not be part of this check.
         run: |
-          cargo metadata --no-deps --format-version 1 | jq -e '(.packages | map(select(.version != "0.0.0")) | group_by(.version) | length) == 1'
+          cargo metadata --no-deps --format-version 1 | jq -e '(.packages | map(select(.publish != false and .publish != [])) | group_by(.version) | length) == 1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+This is the new, unified, changelog that contains changes from across all libcnb.rs crates. Before version `0.10.0`,
+separate changelogs for each crate were used. If you need to refer to these old changelogs, find them named
+`HISTORICAL_CHANGELOG.md` in their respective crate directories.
+
+## [Unreleased]
+
+Highlight of this release is the bump to
+[Buildpack API 0.8](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.8) which brings support for SBOM to
+libcnb.rs. This is also the first release where all libcnb.rs crates are released at the same time and with the same
+version number. See the changelog below for other changes.
+
+### Changes
+
+- libcnb.rs now targets [Buildpack API 0.8](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.8). Buildpacks need to upgrade the `api` key to `0.8` in their `buildpack.toml`. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- In accordance to the CNB specification `>=0.7`, `BuildpackId` no longer permits `sbom` as a buildpack id. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Replace builder style functions from `Launch` with a dedicated `LaunchBuilder` to be more consistent with other builders in the library. Additionally, all fields of `Launch` can now be modified via the builder pattern. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
+- Rename `paths` field in `launch::Slice` to `path_globs` and add docs to make it clearer that these strings are Go standard library globs. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
+- Add explicit `DeleteLayerError` to provide more context when debugging layer handling problems. ([#488](https://github.com/heroku/libcnb.rs/pull/488))
+
+### Fixed
+
+- Fix `BuildpackApi` to use `u64` instead of `u32` for major and minor version parts. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Fix permission issues during layer handling when the layer contains read-only directories. ([#488](https://github.com/heroku/libcnb.rs/pull/488))
+
+### Added
+
+- Add `BuildResultBuilder::build_sbom`, `BuildResultBuilder::launch_sbom` and `LayerResultBuilder::sbom` to enable buildpack authors to attach SBOM data for layers and launch. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Add `sbom::SbomFormat`, describing supported SBOM formats. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Add `Buildpack::sbom_formats` field. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Add support for setting a working directory for launch processes. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Add `TestContext::download_sbom_files` to allow testing of SBOM logic. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+
+### Removed
+
+- Remove support for legacy BOM. Remove `Launch::bom`, `Build::bom`, `bom::Bom`, `bom::Entry`. ([#489](https://github.com/heroku/libcnb.rs/pull/489))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Highlight of this release is the bump to
 libcnb.rs. This is also the first release where all libcnb.rs crates are released at the same time and with the same
 version number. See the changelog below for other changes.
 
-### Changes
+### Changed
 
 - libcnb.rs now targets [Buildpack API 0.8](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.8). Buildpacks need to upgrade the `api` key to `0.8` in their `buildpack.toml`. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
 - In accordance to the CNB specification `>=0.7`, `BuildpackId` no longer permits `sbom` as a buildpack id. ([#489](https://github.com/heroku/libcnb.rs/pull/489))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,28 @@
+# Releasing
+
+All crates are released at the same time and with the same version, even if there are no changes to a crate. This makes it
+easier to gauge cross-crate compatibility.
+
+## Prepare Release
+
+1. Create a new branch for the upcoming release
+2. Set `version` in the `package` table of each `Cargo.toml` to the new version
+3. Set `version` for any repository-local dependencies of each `Cargo.toml` to the new version
+4. Update [CHANGELOG.md](./CHANGELOG.md)
+   1. Move all content under `## [Unreleased]` to a new section that follows this pattern: `## [VERSION] YYYY-MM-DD`
+   2. Add a high-level summary of changes at the beginning of the new section
+5. Commit the changes, push them and open a PR targeting `main`
+
+## Release
+
+1. After peer-review, merge the release preparation PR
+2. On you local machine, run `git switch main && git pull` to ensure you're on the `main` branch with the latest changes
+3. Create a (lightweight) Git tag for the release and push it: (i.e. for version `1.1.38`: `git tag v1.1.38 && git push origin v1.1.38`) 
+4. Use `cargo` to release all crates, make sure to release dependencies of other crates first:
+   1. `cargo publish -p libcnb-proc-macros`
+   2. `cargo publish -p libcnb-data`
+   3. `cargo publish -p libcnb-package`
+   4. `cargo publish -p libcnb-cargo`
+   5. `cargo publish -p libcnb-test`
+   6. `cargo publish -p libcnb`
+5. Create a GitHub release from the tag created earlier. Copy the contents for the release in [CHANGELOG.md](./CHANGELOG.md) for the release description.

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-cargo"
-version = "0.5.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.59"
 license = "BSD-3-Clause"
@@ -21,7 +21,7 @@ clap = { version = "3.2.11", default-features = false, features = [
   "std",
   "derive",
 ] }
-libcnb-package = { version = "0.2.0", path = "../libcnb-package" }
+libcnb-package = { version = "0.10.0", path = "../libcnb-package" }
 log = "0.4.17"
 pathdiff = "0.2.1"
 stderrlog = { version = "0.5.3", default-features = false }

--- a/libcnb-cargo/HISTORICAL_CHANGELOG.md
+++ b/libcnb-cargo/HISTORICAL_CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## [Unreleased]
+This is the historical changelog. It is no longer updated for newer versions. See [CHANGELOG.md](../CHANGELOG.md) in the
+repository root for the new unified changelog that contains changes for all libcnb.rs crates.
 
 ## [0.5.0] 2022-07-14
 
@@ -8,7 +9,7 @@
 - Reduce number of dependencies to improve installation time. ([#442](https://github.com/heroku/libcnb.rs/pull/442) and [#443](https://github.com/heroku/libcnb.rs/pull/443))
 - Use the crate's `README.md` as the root module's rustdocs, so that all of the crate's documentation can be seen in one place on `docs.rs`. ([#460](https://github.com/heroku/libcnb.rs/pull/460))
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
-- Update `libcnb-package` from `0.1.2` to `0.2.0`. Of note, buildpack binaries are now stripped when packaging to reduce buildpack size. See the [libcnb-package changelog](../libcnb-package/CHANGELOG.md#020-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
+- Update `libcnb-package` from `0.1.2` to `0.2.0`. Of note, buildpack binaries are now stripped when packaging to reduce buildpack size. See the [libcnb-package changelog](../libcnb-package/HISTORICAL_CHANGELOG.md#020-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
 
 ## [0.4.1] 2022-06-24
 
@@ -25,7 +26,7 @@
 - `libcnb-cargo` now cross-compiles and packages all binary targets of the buildpack. The main buildpack binary is either the only binary target or the target with the same name as the crate. This feature allows the usage of additional binaries for i.e. `exec.d`. ([#314](https://github.com/heroku/libcnb.rs/pull/314))
 - Increase minimum supported Rust version from 1.56 to 1.58. ([#318](https://github.com/heroku/libcnb.rs/pull/318))
 - Upgrade CLI to Clap v3. ([#329](https://github.com/heroku/libcnb.rs/pull/329))
-- Update `libcnb-data` from `0.4.0` to `0.5.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#050-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
+- Update `libcnb-data` from `0.4.0` to `0.5.0` - see the [libcnb-data changelog](../libcnb-data/HISTORICAL_CHANGELOG.md#050-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
 
 ## [0.2.1] 2022-01-19
 
@@ -36,7 +37,7 @@
 
 - `BuildpackData`, `assemble_buildpack_directory()` and `default_buildpack_directory_name()` have been updated for the libcnb-data replacement of `BuildpackToml` with `*BuildpackDescriptor` and rename of `*buildpack_toml` to `*buildpack_descriptor`. ([#248](https://github.com/heroku/libcnb.rs/pull/248) and [#254](https://github.com/heroku/libcnb.rs/pull/254))
 - Bump external dependency versions. ([#233](https://github.com/heroku/libcnb.rs/pull/233))
-- Update `libcnb-data` from `0.3.0` to `0.4.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#040-2022-01-14). ([#276](https://github.com/heroku/libcnb.rs/pull/276))
+- Update `libcnb-data` from `0.3.0` to `0.4.0` - see the [libcnb-data changelog](../libcnb-data/HISTORICAL_CHANGELOG.md#040-2022-01-14). ([#276](https://github.com/heroku/libcnb.rs/pull/276))
 
 ## [0.1.0] 2021-12-08
 

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-data"
-version = "0.8.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.59"
 license = "BSD-3-Clause"
@@ -13,7 +13,7 @@ include = ["src/**/*", "../LICENSE", "README.md"]
 
 [dependencies]
 fancy-regex = { version = "0.10.0", default-features = false }
-libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.3.0" }
+libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.10.0" }
 serde = { version = "1.0.139", features = ["derive"] }
 thiserror = "1.0.31"
 toml = "0.5.9"

--- a/libcnb-data/HISTORICAL_CHANGELOG.md
+++ b/libcnb-data/HISTORICAL_CHANGELOG.md
@@ -1,22 +1,14 @@
 # Changelog
 
-## [Unreleased]
-
-- Replace builder style functions from `Launch` with a dedicated `LaunchBuilder` to be more consistent with other builders in the library. Additionally, all fields of `Launch` can now be modified via the builder pattern. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
-- Rename `paths` field in `launch::Slice` to `path_globs` and add docs to make it clearer that these strings are Go standard library globs. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
-- Remove support for legacy BOM. Remove `Launch::bom`, `Build::bom`, `bom::Bom`, `bom::Entry`. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- Add `sbom::SbomFormat`, describing supported SBOM formats. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- Add `Buildpack::sbom_formats` field. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- In accordance to the CNB spec, `BuildpackId` no longer permits `sbom` as a buildpack id. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- Fix `BuildpackApi` to use `u64` instead of `u32` for major and minor version parts. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- Add support for setting a working directory for launch processes. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+This is the historical changelog. It is no longer updated for newer versions. See [CHANGELOG.md](../CHANGELOG.md) in the
+repository root for the new unified changelog that contains changes for all libcnb.rs crates.
 
 ## [0.8.0] 2022-07-14
 
 - Disable `fancy-regex` default features (such as unused unicode support) to reduce buildpack binary size. ([#439](https://github.com/heroku/libcnb.rs/pull/439))
 - Add a crate `README.md` and use it as the root module's rustdocs, so that all of the crate's documentation can be seen in one place on `docs.rs`. ([#458](https://github.com/heroku/libcnb.rs/pull/458) and [#460](https://github.com/heroku/libcnb.rs/pull/460))
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
-- Update `libcnb-proc-macros` from `0.2.2` to `0.3.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#030-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
+- Update `libcnb-proc-macros` from `0.2.2` to `0.3.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/HISTORICAL_CHANGELOG.md#030-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
 
 # [0.7.0] 2022-06-24
 
@@ -37,7 +29,7 @@
 - Add `exec_d` module with types representing the output of an `exec.d` program. ([#324](https://github.com/heroku/libcnb.rs/pull/324))
 - Increase minimum supported Rust version from 1.56 to 1.58. ([#318](https://github.com/heroku/libcnb.rs/pull/318))
 - Adjust newtype generated compile-time validation macros so that they don't also perform redundant validation at runtime. In cases where only compile-time validation is being performed (for example `exec.d` scripts), this results in a significant reduction in binary size. ([#331](https://github.com/heroku/libcnb.rs/pull/331))
-- Update `libcnb-proc-macros` from `0.1.1` to `0.2.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#020-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
+- Update `libcnb-proc-macros` from `0.1.1` to `0.2.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/HISTORICAL_CHANGELOG.md#020-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
 
 ## [0.4.0] 2022-01-14
 
@@ -52,7 +44,7 @@
 - `Launch` and `Process` can now be deserialized when optional fields are missing, and omit default values when serializing. ([#243](https://github.com/heroku/libcnb.rs/pull/243) and [#265](https://github.com/heroku/libcnb.rs/pull/265))
 - `Process::new` has been replaced by `ProcessBuilder`. ([#265](https://github.com/heroku/libcnb.rs/pull/265))
 - Bump external dependency versions. ([#233](https://github.com/heroku/libcnb.rs/pull/233) and [#275](https://github.com/heroku/libcnb.rs/pull/275))
-- Update `libcnb-proc-macros` from `0.1.0` to `0.1.1` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#011-2022-01-14). ([#276](https://github.com/heroku/libcnb.rs/pull/276))
+- Update `libcnb-proc-macros` from `0.1.0` to `0.1.1` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/HISTORICAL_CHANGELOG.md#011-2022-01-14). ([#276](https://github.com/heroku/libcnb.rs/pull/276))
 
 ## [0.3.0] 2021-12-08
 

--- a/libcnb-package/Cargo.toml
+++ b/libcnb-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-package"
-version = "0.2.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.59"
 license = "BSD-3-Clause"
@@ -13,6 +13,6 @@ include = ["src/**/*", "../LICENSE", "README.md"]
 
 [dependencies]
 cargo_metadata = "0.15.0"
-libcnb-data = { version = "0.8.0", path = "../libcnb-data" }
+libcnb-data = { version = "0.10.0", path = "../libcnb-data" }
 toml = "0.5.9"
 which = "4.2.5"

--- a/libcnb-package/HISTORICAL_CHANGELOG.md
+++ b/libcnb-package/HISTORICAL_CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## [Unreleased]
+This is the historical changelog. It is no longer updated for newer versions. See [CHANGELOG.md](../CHANGELOG.md) in the
+repository root for the new unified changelog that contains changes for all libcnb.rs crates.
 
 ## [0.2.0] 2022-07-14
 
@@ -8,7 +9,7 @@
 - The type of the `cargo_env` argument to `build::build_buildpack_binaries` and `build::build_binary` has changed. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
 - Use the crate's `README.md` as the root module's rustdocs, so that all of the crate's documentation can be seen in one place on `docs.rs`. ([#460](https://github.com/heroku/libcnb.rs/pull/460))
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
-- Update `libcnb-data` from `0.7.0` to `0.8.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#080-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
+- Update `libcnb-data` from `0.7.0` to `0.8.0` - see the [libcnb-data changelog](../libcnb-data/HISTORICAL_CHANGELOG.md#080-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
 
 ## [0.1.2] 2022-06-24
 

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-proc-macros"
-version = "0.3.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.59"
 license = "BSD-3-Clause"

--- a/libcnb-proc-macros/HISTORICAL_CHANGELOG.md
+++ b/libcnb-proc-macros/HISTORICAL_CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## [Unreleased]
+This is the historical changelog. It is no longer updated for newer versions. See [CHANGELOG.md](../CHANGELOG.md) in the
+repository root for the new unified changelog that contains changes for all libcnb.rs crates.
 
 ## [0.3.0] 2022-07-14
 

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb-test"
-version = "0.6.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.59"
 license = "BSD-3-Clause"
@@ -16,8 +16,8 @@ bollard = "0.13.0"
 cargo_metadata = "0.15.0"
 fastrand = "1.7.0"
 fs_extra = "1.2.0"
-libcnb-data = { version = "0.8.0", path = "../libcnb-data" }
-libcnb-package = { version = "0.2.0", path = "../libcnb-package" }
+libcnb-data = { version = "0.10.0", path = "../libcnb-data" }
+libcnb-package = { version = "0.10.0", path = "../libcnb-package" }
 serde = "1.0.139"
 tempfile = "3.3.0"
 tokio = "1.20.0"

--- a/libcnb-test/HISTORICAL_CHANGELOG.md
+++ b/libcnb-test/HISTORICAL_CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
-## [Unreleased]
-
-- Add `TestContext::download_sbom_files` to allow testing of SBOM logic. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+This is the historical changelog. It is no longer updated for newer versions. See [CHANGELOG.md](../CHANGELOG.md) in the
+repository root for the new unified changelog that contains changes for all libcnb.rs crates.
 
 ## [0.6.0] 2022-07-21
 
@@ -23,7 +22,7 @@
 - Add rustdocs with code examples for all public APIs. ([#441](https://github.com/heroku/libcnb.rs/pull/441))
 - Fix rustdocs for `LogOutput`. ([#440](https://github.com/heroku/libcnb.rs/pull/440))
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
-- Update `libcnb-package` from `0.1.2` to `0.2.0`. Of note, buildpack binaries are now stripped when packaging to reduce buildpack size, which also speeds up integration tests. See the [libcnb-package changelog](../libcnb-package/CHANGELOG.md#020-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
+- Update `libcnb-package` from `0.1.2` to `0.2.0`. Of note, buildpack binaries are now stripped when packaging to reduce buildpack size, which also speeds up integration tests. See the [libcnb-package changelog](../libcnb-package/HISTORICAL_CHANGELOG.md#020-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
 
 ## [0.4.0] 2022-06-24
 
@@ -65,7 +64,7 @@
 - Increase minimum supported Rust version from 1.56 to 1.58. ([#318](https://github.com/heroku/libcnb.rs/pull/318))
 - Add `assert_contains!` macro for easier matching of `pack` output in integration tests. ([#322](https://github.com/heroku/libcnb.rs/pull/322))
 - Fail tests early with a clearer error message, if expected cross-compilation toolchains are not found. ([#347](https://github.com/heroku/libcnb.rs/pull/347))
-- Update `libcnb-cargo` from `0.2.1` to `0.3.0` - see the [libcnb-cargo changelog](../libcnb-cargo/CHANGELOG.md#030-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
+- Update `libcnb-cargo` from `0.2.1` to `0.3.0` - see the [libcnb-cargo changelog](../libcnb-cargo/HISTORICAL_CHANGELOG.md#030-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
 
 ## [0.1.1] 2022-02-04
 

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcnb"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.59"
 license = "BSD-3-Clause"
@@ -14,8 +14,8 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 [dependencies]
 anyhow = { version = "1.0.58", optional = true }
 cyclonedx-bom = { version = "0.3.2", optional = true }
-libcnb-data = { path = "../libcnb-data", version = "0.8.0" }
-libcnb-proc-macros = { version = "0.3.0", path = "../libcnb-proc-macros" }
+libcnb-data = { version = "0.10.0", path = "../libcnb-data" }
+libcnb-proc-macros = { version = "0.10.0", path = "../libcnb-proc-macros" }
 serde = { version = "1.0.139", features = ["derive"] }
 stacker = "0.1.15"
 thiserror = "1.0.31"

--- a/libcnb/HISTORICAL_CHANGELOG.md
+++ b/libcnb/HISTORICAL_CHANGELOG.md
@@ -1,24 +1,20 @@
 # Changelog
 
-## [Unreleased]
-
-- Fix permission issues during layer handling when the layer contains read-only directories. ([#488](https://github.com/heroku/libcnb.rs/pull/488)).
-- Add explicit `DeleteLayerError` to provide more context when debugging layer handling problems. ([#488](https://github.com/heroku/libcnb.rs/pull/488)).
-- libcnb.rs now targets [Buildpack API 0.8](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.8). Buildpacks need to upgrade the `api` key to `0.8` in their `buildpack.toml`. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- Add `BuildResultBuilder::build_sbom`, `BuildResultBuilder::launch_sbom` and `LayerResultBuilder::sbom` to enable buildpack authors to attach SBOM data for layers and launch. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+This is the historical changelog. It is no longer updated for newer versions. See [CHANGELOG.md](../CHANGELOG.md) in the
+repository root for the new unified changelog that contains changes for all libcnb.rs crates.
 
 ## [0.9.0] 2022-07-14
 
 - Use the crate's `README.md` as the root module's rustdocs, so that all of the crate's documentation can be seen in one place on `docs.rs`. ([#460](https://github.com/heroku/libcnb.rs/pull/460))
 - Increase minimum supported Rust version from 1.58 to 1.59. ([#445](https://github.com/heroku/libcnb.rs/pull/445))
-- Update `libcnb-data` (which provides the types in the `data` module) from `0.7.0` to `0.8.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#080-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
-- Update `libcnb-proc-macros` from `0.2.2` to `0.3.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#030-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
+- Update `libcnb-data` (which provides the types in the `data` module) from `0.7.0` to `0.8.0` - see the [libcnb-data changelog](../libcnb-data/HISTORICAL_CHANGELOG.md#080-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
+- Update `libcnb-proc-macros` from `0.2.2` to `0.3.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/HISTORICAL_CHANGELOG.md#030-2022-07-14). ([#465](https://github.com/heroku/libcnb.rs/pull/465))
 
 ## [0.8.0] 2022-06-24
 
 - Make the "Buildpack API version mismatch" check still work when `buildpack.toml` doesn't match the spec or custom buildpack type. ([#421](https://github.com/heroku/libcnb.rs/pull/421))
 - Remove support for custom exit codes from `Buildpack::on_error`. Exit codes are part of the CNB spec and there are cases where some exit codes have special meaning to the CNB lifecycle. This put the burden on the buildpack author to not pick exit codes with special meanings, dependent on the currently executing phase. This makes `Buildpack::on_error` more consistent with the rest of the framework where we don't expose the interface between the buildpack and the CNB lifecycle directly but use abstractions for easier forward-compatibility and to prevent accidental misuse. ([#415](https://github.com/heroku/libcnb.rs/pull/415))
-- Update `libcnb-data` (which provides the types in the `data` module) from `0.6.0` to `0.7.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#070-2022-06-24). ([#432](https://github.com/heroku/libcnb.rs/pull/432))
+- Update `libcnb-data` (which provides the types in the `data` module) from `0.6.0` to `0.7.0` - see the [libcnb-data changelog](../libcnb-data/HISTORICAL_CHANGELOG.md#070-2022-06-24). ([#432](https://github.com/heroku/libcnb.rs/pull/432))
 
 ## [0.7.0] 2022-04-12
 
@@ -27,7 +23,7 @@
 - Only create layer `env`, `env.build` and `env.launch` directories when environment variables are being set within them. ([#385](https://github.com/heroku/libcnb.rs/pull/385))
 - Add `WriteLayerError::MissingExecDFile` error to ease debugging when an exec.d path is missing. ([#387](https://github.com/heroku/libcnb.rs/pull/387))
 - Update project URLs for the GitHub repository move to the `heroku` org. ([#388](https://github.com/heroku/libcnb.rs/pull/388))
-- Update `libcnb-data` (which provides the types in the `data` module) from `0.5.0` to `0.6.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#060-2022-04-12). ([#391](https://github.com/heroku/libcnb.rs/pull/391))
+- Update `libcnb-data` (which provides the types in the `data` module) from `0.5.0` to `0.6.0` - see the [libcnb-data changelog](../libcnb-data/HISTORICAL_CHANGELOG.md#060-2022-04-12). ([#391](https://github.com/heroku/libcnb.rs/pull/391))
 
 ## [0.6.0] 2022-02-28
 
@@ -36,8 +32,8 @@
 - Increase minimum supported Rust version from 1.56 to 1.58. ([#318](https://github.com/heroku/libcnb.rs/pull/318))
 - Add support for exec.d programs in layers. Use `LayerResultBuilder::exec_d_program` to add exec.d programs to a layer. ([#326](https://github.com/heroku/libcnb.rs/pull/326))
 - Add `libcnb::exec_d::write_exec_d_program_output` which writes `libcnb::data::exec_d::ExecDProgramOutput` in a spec conforming way. Use this to implement custom exec.d programs for your buildpack with libcnb.rs. (see [exec.d example](../examples/execd)). ([#326](https://github.com/heroku/libcnb.rs/pull/326))
-- Update `libcnb-data` (which provides the types in the `data` module) from `0.4.0` to `0.5.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#050-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
-- Update `libcnb-proc-macros` from `0.1.1` to `0.2.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/CHANGELOG.md#020-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
+- Update `libcnb-data` (which provides the types in the `data` module) from `0.4.0` to `0.5.0` - see the [libcnb-data changelog](../libcnb-data/HISTORICAL_CHANGELOG.md#050-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
+- Update `libcnb-proc-macros` from `0.1.1` to `0.2.0` - see the [libcnb-proc-macros changelog](../libcnb-proc-macros/HISTORICAL_CHANGELOG.md#020-2022-02-28). ([#361](https://github.com/heroku/libcnb.rs/pull/361))
 
 ## [0.5.0] 2022-01-14
 
@@ -46,14 +42,14 @@
 - Renamed `Buildpack::handle_error` to `Buildpack::on_error` to make it clearer that the error cannot be handled/resolved, just reacted upon. ([#266](https://github.com/heroku/libcnb.rs/pull/266))
 - Add `LayerEnv::apply_to_empty`. ([#267](https://github.com/heroku/libcnb.rs/pull/267))
 - Bump external dependency versions. ([#233](https://github.com/heroku/libcnb.rs/pull/233) and [#275](https://github.com/heroku/libcnb.rs/pull/275))
-- Update `libcnb-data` (which provides the types in the `data` module) from `0.3.0` to `0.4.0` - see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#040-2022-01-14). ([#276](https://github.com/heroku/libcnb.rs/pull/276))
+- Update `libcnb-data` (which provides the types in the `data` module) from `0.3.0` to `0.4.0` - see the [libcnb-data changelog](../libcnb-data/HISTORICAL_CHANGELOG.md#040-2022-01-14). ([#276](https://github.com/heroku/libcnb.rs/pull/276))
 
 ## [0.4.0] 2021-12-08
 
 - Set a minimum required Rust version of 1.56 and switch to the 2021 Rust edition.
 - libcnb now targets [Buildpack API 0.6](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.6).
 - The `data` module can now be used without the rest of the framework by depending on the `libcnb-data` crate.
-- For changes to the `data` module in this release, see the [libcnb-data changelog](../libcnb-data/CHANGELOG.md#030-2021-12-08).
+- For changes to the `data` module in this release, see the [libcnb-data changelog](../libcnb-data/HISTORICAL_CHANGELOG.md#030-2021-12-08).
 - Introduced `Buildpack` trait that needs to be implemented for each buildpack.
 - `cnb_runtime()` now requires a `Buildpack` instead of `detect` and `build` functions.
 - `ErrorHandler` has been removed. Functionality is now part of the new `Buildpack` trait.


### PR DESCRIPTION
Currently, all libcnb.rs crates use dedicated versions. This has some drawbacks:

- Hard to remember which version of which crate is the most current one.
- No indication that i.e. `libcnb-test 0.6.0` is intended to be used with `libcnb 0.9.0`, similar stories with the Cargo plugin and the `libcnb-data` crate.
- Implementing compatibility verification into the Cargo plugin and `libcnb-test` is harder since it would require a mapping file. See #358.
- Cutting a release requires copy&pasting or at least cross-linking of CHANGELOGs to include cross-crate changes. For example, if `libcnb-data` changes, almost all crates will be affected by that change implicitly and need CHANGELOG mentioning.
- When releasing, different version numbers for every crate makes it easy to make mistakes.

The idea with this PR is to release all crates at the same time and with the same version. Additionally, a unified CHANGELOG at the repository root is used, making it easier to discover all changes for users. This will avoid all of the issues mentioned before. However, this solution is not perfect either:

- We might release a new version of a crate without any changes. This is especially likely with `libcnb-proc-macros` which changes rarely and does not depend on another libcnb package. For the other crates, this is less of a problem as they all depend depend on each other and all of them on `libcnb-data`, which is the crate that changes most often.
- A unified CHANGELOG bears the question what happens with the old CHANGELOG entries. For this PR, I kept them where they were, renamed them to `HISTORICAL_CHANGELOG.md`, added a comment on top, explaining the change to a unified changelog and mentioning the historical CHANGELOGs in the new one.

In the end, I think the upsides outweigh the downsides.

Closes GUS-W-11631951, Fixes #335