### PR TITLE
Bump MSRV to 1.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ## [Unreleased]
 
-- Bump Minimum Supported Rust Version (MSRV) to `1.60` ([#000](https://github.com/heroku/libcnb.rs/pull/000))
+- Bump Minimum Supported Rust Version (MSRV) to `1.60` ([#496](https://github.com/heroku/libcnb.rs/pull/496))
 
 ## [0.10.0] 2022-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ## [Unreleased]
 
+- Bump Minimum Supported Rust Version (MSRV) to `1.60` ([#000](https://github.com/heroku/libcnb.rs/pull/000))
+
 ## [0.10.0] 2022-08-31
 
 Highlight of this release is the bump to

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [docs.rs]: https://docs.rs/libcnb/latest/libcnb/
 [Latest Version]: https://img.shields.io/crates/v/libcnb.svg
 [crates.io]: https://crates.io/crates/libcnb
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.59+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.60+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install
 
 `libcnb.rs` is a framework for writing [Cloud Native Buildpacks](https://buildpacks.io) in Rust.

--- a/examples/basics/Cargo.toml
+++ b/examples/basics/Cargo.toml
@@ -2,7 +2,7 @@
 name = "examples-basics"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 publish = false
 
 [dependencies]

--- a/examples/execd/Cargo.toml
+++ b/examples/execd/Cargo.toml
@@ -2,7 +2,7 @@
 name = "examples-execd"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 publish = false
 
 [dependencies]

--- a/examples/ruby-sample/Cargo.toml
+++ b/examples/ruby-sample/Cargo.toml
@@ -2,7 +2,7 @@
 name = "examples-ruby-sample"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 publish = false
 
 [dependencies]

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcnb-cargo"
 version = "0.10.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 license = "BSD-3-Clause"
 description = "Cargo command for managing buildpacks written with libcnb.rs"
 keywords = ["buildpacks", "CNB"]

--- a/libcnb-cargo/README.md
+++ b/libcnb-cargo/README.md
@@ -30,5 +30,5 @@ INFO - Hint: To test your buildpack locally with pack, run: pack build my-image 
 
 [Latest Version]: https://img.shields.io/crates/v/libcnb-cargo.svg
 [crates.io]: https://crates.io/crates/libcnb-cargo
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.59+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.60+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcnb-data"
 version = "0.10.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 license = "BSD-3-Clause"
 description = "Types for data formats specified in the Cloud Native Buildpack specification, used by libcnb.rs"
 keywords = ["buildpacks", "CNB"]

--- a/libcnb-data/README.md
+++ b/libcnb-data/README.md
@@ -10,5 +10,5 @@ on this crate directly.
 [docs.rs]: https://docs.rs/libcnb-data/latest/libcnb_data/
 [Latest Version]: https://img.shields.io/crates/v/libcnb-data.svg
 [crates.io]: https://crates.io/crates/libcnb-data
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.59+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.60+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb-package/Cargo.toml
+++ b/libcnb-package/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcnb-package"
 version = "0.10.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 license = "BSD-3-Clause"
 description = "Library for cross-compiling and packaging buildpacks written with libcnb.rs"
 keywords = ["buildpacks", "CNB"]

--- a/libcnb-package/README.md
+++ b/libcnb-package/README.md
@@ -10,5 +10,5 @@ directly.
 [docs.rs]: https://docs.rs/libcnb-package/latest/libcnb_package/
 [Latest Version]: https://img.shields.io/crates/v/libcnb-package.svg
 [crates.io]: https://crates.io/crates/libcnb-package
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.59+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.60+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcnb-proc-macros"
 version = "0.10.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 license = "BSD-3-Clause"
 description = "Procedural macros used within libcnb.rs"
 repository = "https://github.com/heroku/libcnb.rs/tree/main/libcnb-proc-macros"

--- a/libcnb-proc-macros/README.md
+++ b/libcnb-proc-macros/README.md
@@ -9,5 +9,5 @@ depending on this crate directly.
 [docs.rs]: https://docs.rs/libcnb-proc-macros/latest/libcnb_proc_macros/
 [Latest Version]: https://img.shields.io/crates/v/libcnb-proc-macros.svg
 [crates.io]: https://crates.io/crates/libcnb-proc-macros
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.59+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.60+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcnb-test"
 version = "0.10.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 license = "BSD-3-Clause"
 description = "An integration testing framework for buildpacks written with libcnb.rs"
 keywords = ["buildpacks", "CNB"]

--- a/libcnb-test/README.md
+++ b/libcnb-test/README.md
@@ -224,5 +224,5 @@ fn additional_buildpacks() {
 [docs.rs]: https://docs.rs/libcnb-test/latest/libcnb_test/
 [Latest Version]: https://img.shields.io/crates/v/libcnb-test.svg
 [crates.io]: https://crates.io/crates/libcnb-test
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.59+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.60+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libcnb"
 version = "0.10.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 license = "BSD-3-Clause"
 description = "A framework for writing Cloud Native Buildpacks in Rust"
 keywords = ["buildpacks", "CNB"]

--- a/test-buildpacks/readonly-layer-files/Cargo.toml
+++ b/test-buildpacks/readonly-layer-files/Cargo.toml
@@ -2,7 +2,7 @@
 name = "readonly-layer-files"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 publish = false
 
 [dependencies]

--- a/test-buildpacks/sbom/Cargo.toml
+++ b/test-buildpacks/sbom/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sbom"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
In preparation of moving `libherokubuildpack` into this mono-repo, this PR bumps the Minimum Supported Rust Version (MSRV) to `1.60`. We need the enhancements around create features for the move so users can turn on/off features of the new crate to reduce code-size. Most notably the `dep:` syntax. See https://doc.rust-lang.org/cargo/reference/features.html:

> Note: The dep: syntax is only available starting with Rust 1.60. Previous versions can only use the implicit feature name.

Related: #10, Closes GUS-W-11795927