### PR TITLE
Fix Clippy errors with Rust 1.65

### DIFF
--- a/examples/ruby-sample/src/layers/bundler.rs
+++ b/examples/ruby-sample/src/layers/bundler.rs
@@ -39,7 +39,7 @@ impl Layer for BundlerLayer {
 
         util::run_simple_command(
             Command::new("gem")
-                .args(&["install", "bundler", "--force"])
+                .args(["install", "bundler", "--force"])
                 .envs(&self.ruby_env),
             RubyBuildpackError::GemInstallBundlerCommandError,
             RubyBuildpackError::GemInstallBundlerUnexpectedExitStatus,
@@ -49,7 +49,7 @@ impl Layer for BundlerLayer {
 
         util::run_simple_command(
             Command::new("bundle")
-                .args(&[
+                .args([
                     "install",
                     "--path",
                     layer_path.to_str().unwrap(),
@@ -93,7 +93,7 @@ impl Layer for BundlerLayer {
 
         util::run_simple_command(
             Command::new("bundle")
-                .args(&["config", "--local", "path", layer.path.to_str().unwrap()])
+                .args(["config", "--local", "path", layer.path.to_str().unwrap()])
                 .envs(&self.ruby_env),
             RubyBuildpackError::BundleConfigCommandError,
             RubyBuildpackError::BundleConfigUnexpectedExitStatus,
@@ -101,7 +101,7 @@ impl Layer for BundlerLayer {
 
         util::run_simple_command(
             Command::new("bundle")
-                .args(&[
+                .args([
                     "config",
                     "--local",
                     "bin",

--- a/examples/ruby-sample/src/layers/ruby.rs
+++ b/examples/ruby-sample/src/layers/ruby.rs
@@ -38,7 +38,7 @@ impl Layer for RubyLayer {
         )
         .map_err(RubyBuildpackError::RubyDownloadError)?;
 
-        util::untar(ruby_tgz.path(), &layer_path).map_err(RubyBuildpackError::RubyUntarError)?;
+        util::untar(ruby_tgz.path(), layer_path).map_err(RubyBuildpackError::RubyUntarError)?;
 
         LayerResultBuilder::new(GenericMetadata::default())
             .env(

--- a/libcnb-test/src/app.rs
+++ b/libcnb-test/src/app.rs
@@ -86,7 +86,7 @@ mod tests {
                 std::fs::create_dir_all(dir).unwrap();
             }
 
-            std::fs::write(absolute_path, &contents).unwrap();
+            std::fs::write(absolute_path, contents).unwrap();
         }
 
         let temp_app_dir = super::copy_app(source_app_dir.path()).unwrap();

--- a/libcnb/src/error.rs
+++ b/libcnb/src/error.rs
@@ -11,7 +11,7 @@ pub type Result<T, E> = std::result::Result<T, Error<E>>;
 
 /// An error that occurred during buildpack execution.
 #[derive(thiserror::Error, Debug)]
-pub enum Error<E: Debug> {
+pub enum Error<E> {
     #[error("HandleLayer error: {0}")]
     HandleLayerError(#[from] HandleLayerError),
 

--- a/libcnb/src/layer/handling.rs
+++ b/libcnb/src/layer/handling.rs
@@ -415,7 +415,7 @@ mod tests {
         )
         .unwrap();
 
-        super::delete_layer(&layers_dir, &layer_name).unwrap();
+        super::delete_layer(layers_dir, &layer_name).unwrap();
 
         assert!(!layer_dir.exists());
         assert!(!layers_dir.join(format!("{layer_name}.toml")).exists());
@@ -439,7 +439,7 @@ mod tests {
         )
         .unwrap();
 
-        super::delete_layer(&layers_dir, &layer_name).unwrap();
+        super::delete_layer(layers_dir, &layer_name).unwrap();
 
         assert!(!layer_dir.exists());
         assert!(!layers_dir.join(format!("{layer_name}.toml")).exists());
@@ -451,7 +451,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let layers_dir = temp_dir.path();
 
-        super::delete_layer(&layers_dir, &layer_name).unwrap();
+        super::delete_layer(layers_dir, &layer_name).unwrap();
     }
 
     #[test]
@@ -466,7 +466,7 @@ mod tests {
         fs::write(&foo_execd_file, "foo-contents").unwrap();
 
         super::write_layer(
-            &layers_dir,
+            layers_dir,
             &layer_name,
             &LayerEnv::new().chainable_insert(
                 Scope::All,
@@ -520,7 +520,7 @@ mod tests {
 
         let execd_file = PathBuf::from("/this/path/should/not/exist/exec_d_binary");
         let write_layer_error = super::write_layer(
-            &layers_dir,
+            layers_dir,
             &layer_name,
             &LayerEnv::new(),
             &LayerContentMetadata {
@@ -565,7 +565,7 @@ mod tests {
         fs::write(&baz_execd_file, "baz-contents").unwrap();
 
         super::write_layer(
-            &layers_dir,
+            layers_dir,
             &layer_name,
             &LayerEnv::new()
                 .chainable_insert(
@@ -596,7 +596,7 @@ mod tests {
         fs::write(layer_dir.join("content.txt"), "Hello World!").unwrap();
 
         super::write_layer(
-            &layers_dir,
+            layers_dir,
             &layer_name,
             &LayerEnv::new().chainable_insert(
                 Scope::All,
@@ -667,7 +667,7 @@ mod tests {
         let layer_dir = layers_dir.join(layer_name.as_str());
 
         super::write_layer(
-            &layers_dir,
+            layers_dir,
             &layer_name,
             &LayerEnv::new(),
             &LayerContentMetadata {
@@ -698,7 +698,7 @@ mod tests {
         fs::write(&foo_execd_file, "foo-contents").unwrap();
 
         super::write_layer(
-            &layers_dir,
+            layers_dir,
             &layer_name,
             &LayerEnv::new(),
             &LayerContentMetadata {
@@ -720,7 +720,7 @@ mod tests {
         );
 
         super::write_layer(
-            &layers_dir,
+            layers_dir,
             &layer_name,
             &LayerEnv::new(),
             &LayerContentMetadata {
@@ -754,7 +754,7 @@ mod tests {
         fs::write(&foo_execd_file, "foo-contents").unwrap();
 
         super::write_layer(
-            &layers_dir,
+            layers_dir,
             &layer_name,
             &LayerEnv::new(),
             &LayerContentMetadata {
@@ -776,7 +776,7 @@ mod tests {
         );
 
         super::write_layer(
-            &layers_dir,
+            layers_dir,
             &layer_name,
             &LayerEnv::new(),
             &LayerContentMetadata {
@@ -831,7 +831,7 @@ mod tests {
         fs::create_dir_all(layer_dir.join("env")).unwrap();
         fs::write(layer_dir.join("env/CUSTOM_ENV"), "CUSTOM_ENV_VALUE").unwrap();
 
-        let layer_data = super::read_layer::<TestLayerMetadata, _>(&layers_dir, &layer_name)
+        let layer_data = super::read_layer::<TestLayerMetadata, _>(layers_dir, &layer_name)
             .unwrap()
             .unwrap();
 
@@ -889,7 +889,7 @@ mod tests {
         )
         .unwrap();
 
-        match super::read_layer::<GenericMetadata, _>(&layers_dir, &layer_name) {
+        match super::read_layer::<GenericMetadata, _>(layers_dir, &layer_name) {
             Err(ReadLayerError::LayerContentMetadataParseError(toml_error)) => {
                 assert_eq!(toml_error.line_col(), Some((1, 18)));
             }
@@ -925,7 +925,7 @@ mod tests {
         )
         .unwrap();
 
-        match super::read_layer::<TestLayerMetadata, _>(&layers_dir, &layer_name) {
+        match super::read_layer::<TestLayerMetadata, _>(layers_dir, &layer_name) {
             Err(ReadLayerError::LayerContentMetadataParseError(toml_error)) => {
                 assert_eq!(toml_error.line_col(), Some((6, 12)));
             }
@@ -942,7 +942,7 @@ mod tests {
 
         fs::create_dir_all(&layer_dir).unwrap();
 
-        match super::read_layer::<GenericMetadata, _>(&layers_dir, &layer_name) {
+        match super::read_layer::<GenericMetadata, _>(layers_dir, &layer_name) {
             Ok(Some(layer_data)) => {
                 assert_eq!(
                     layer_data.content_metadata,
@@ -964,7 +964,7 @@ mod tests {
 
         fs::write(layers_dir.join(format!("{layer_name}.toml")), "").unwrap();
 
-        match super::read_layer::<GenericMetadata, _>(&layers_dir, &layer_name) {
+        match super::read_layer::<GenericMetadata, _>(layers_dir, &layer_name) {
             Ok(None) => {}
             _ => panic!("Expected Ok(None)!"),
         }
@@ -976,7 +976,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let layers_dir = temp_dir.path();
 
-        match super::read_layer::<GenericMetadata, _>(&layers_dir, &layer_name) {
+        match super::read_layer::<GenericMetadata, _>(layers_dir, &layer_name) {
             Ok(None) => {}
             _ => panic!("Expected Ok(None)!"),
         }

--- a/libcnb/src/layer/tests.rs
+++ b/libcnb/src/layer/tests.rs
@@ -291,7 +291,7 @@ fn create_then_recreate() {
     // Add a random file to the layer directory between handle_layer calls to assess if the layer is
     // actually recreated without any residue left in the directory
     fs::write(
-        handle_layer_result.path.join(&residue_file_name),
+        handle_layer_result.path.join(residue_file_name),
         "RESIDUE DATA",
     )
     .unwrap();
@@ -353,7 +353,7 @@ fn create_then_recreate() {
         fs::read_to_string(handle_layer_result.path.join(TEST_LAYER_UPDATE_FILE_NAME)).ok();
 
     let residue_file_contents =
-        fs::read_to_string(handle_layer_result.path.join(&residue_file_name)).ok();
+        fs::read_to_string(handle_layer_result.path.join(residue_file_name)).ok();
 
     assert_eq!(
         create_file_contents,
@@ -384,8 +384,8 @@ fn create_then_keep() {
     // Add a random file to the layer directory between handle_layer calls to assess if the layer is
     // kept as-is.
     fs::write(
-        handle_layer_result.path.join(&residue_file_name),
-        &residue_file_data,
+        handle_layer_result.path.join(residue_file_name),
+        residue_file_data,
     )
     .unwrap();
 
@@ -447,7 +447,7 @@ fn create_then_keep() {
         fs::read_to_string(handle_layer_result.path.join(TEST_LAYER_UPDATE_FILE_NAME)).ok();
 
     let residue_file_contents =
-        fs::read_to_string(handle_layer_result.path.join(&residue_file_name)).ok();
+        fs::read_to_string(handle_layer_result.path.join(residue_file_name)).ok();
 
     assert_eq!(
         create_file_contents,

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -305,8 +305,8 @@ impl LayerEnv {
                     _ => unreachable!("Unexpected Scope in read_from_layer_dir implementation. This is a libcnb implementation error!"),
                 };
 
-                target_delta.insert(ModificationBehavior::Prepend, &name, &path);
-                target_delta.insert(ModificationBehavior::Delimiter, &name, PATH_LIST_SEPARATOR);
+                target_delta.insert(ModificationBehavior::Prepend, name, path);
+                target_delta.insert(ModificationBehavior::Delimiter, name, PATH_LIST_SEPARATOR);
             }
         }
 
@@ -430,36 +430,36 @@ impl LayerEnvDelta {
         for ((modification_behavior, name), value) in &self.entries {
             match modification_behavior {
                 ModificationBehavior::Override => {
-                    result_env.insert(&name, &value);
+                    result_env.insert(name, value);
                 }
                 ModificationBehavior::Default => {
-                    if !result_env.contains_key(&name) {
-                        result_env.insert(&name, &value);
+                    if !result_env.contains_key(name) {
+                        result_env.insert(name, value);
                     }
                 }
                 ModificationBehavior::Append => {
-                    let mut previous_value = result_env.get(&name).unwrap_or_default();
+                    let mut previous_value = result_env.get(name).unwrap_or_default();
 
                     if previous_value.len() > 0 {
-                        previous_value.push(self.delimiter_for(&name));
+                        previous_value.push(self.delimiter_for(name));
                     }
 
-                    previous_value.push(&value);
+                    previous_value.push(value);
 
-                    result_env.insert(&name, previous_value);
+                    result_env.insert(name, previous_value);
                 }
                 ModificationBehavior::Prepend => {
-                    let previous_value = result_env.get(&name).unwrap_or_default();
+                    let previous_value = result_env.get(name).unwrap_or_default();
 
                     let mut new_value = OsString::new();
-                    new_value.push(&value);
+                    new_value.push(value);
 
                     if !previous_value.is_empty() {
-                        new_value.push(self.delimiter_for(&name));
+                        new_value.push(self.delimiter_for(name));
                         new_value.push(previous_value);
                     }
 
-                    result_env.insert(&name, new_value);
+                    result_env.insert(name, new_value);
                 }
                 ModificationBehavior::Delimiter => (),
             };
@@ -562,7 +562,7 @@ impl LayerEnvDelta {
                 #[cfg(target_family = "unix")]
                 {
                     use std::os::unix::ffi::OsStrExt;
-                    fs::write(file_path, &value.as_bytes())?;
+                    fs::write(file_path, value.as_bytes())?;
                 }
 
                 #[cfg(not(target_family = "unix"))]
@@ -765,8 +765,8 @@ mod tests {
 
         let temp_dir = tempdir().unwrap();
 
-        original_delta.write_to_env_dir(&temp_dir.path()).unwrap();
-        let disk_delta = LayerEnvDelta::read_from_env_dir(&temp_dir.path()).unwrap();
+        original_delta.write_to_env_dir(temp_dir.path()).unwrap();
+        let disk_delta = LayerEnvDelta::read_from_env_dir(temp_dir.path()).unwrap();
 
         assert_eq!(original_delta, disk_delta);
     }
@@ -873,7 +873,7 @@ mod tests {
         fs::create_dir_all(layer_dir.join("include")).unwrap();
         fs::create_dir_all(layer_dir.join("pkgconfig")).unwrap();
 
-        let layer_env = LayerEnv::read_from_layer_dir(&layer_dir).unwrap();
+        let layer_env = LayerEnv::read_from_layer_dir(layer_dir).unwrap();
 
         let env = layer_env.apply_to_empty(Scope::Launch);
         assert_eq!(env.get("PATH").unwrap(), layer_dir.join("bin"));
@@ -894,7 +894,7 @@ mod tests {
         fs::create_dir_all(layer_dir.join("include")).unwrap();
         fs::create_dir_all(layer_dir.join("pkgconfig")).unwrap();
 
-        let layer_env = LayerEnv::read_from_layer_dir(&layer_dir).unwrap();
+        let layer_env = LayerEnv::read_from_layer_dir(layer_dir).unwrap();
 
         let env = layer_env.apply_to_empty(Scope::Build);
         assert_eq!(env.get("PATH").unwrap(), layer_dir.join("bin"));


### PR DESCRIPTION
Using Rust 1.65, Clippy reports a number of new errors.

All but one of the changes are the result of running: `cargo clippy --all-targets --fix`

GUS-W-11798350.