### PR TITLE
Use Cargo 1.64 features for workspace metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ### Changed
 
-- Bump Minimum Supported Rust Version (MSRV) to `1.60` ([#496](https://github.com/heroku/libcnb.rs/pull/496))
+- Bump Minimum Supported Rust Version (MSRV) to `1.64` ([#000](https://github.com/heroku/libcnb.rs/pull/000))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ### Changed
 
-- Bump Minimum Supported Rust Version (MSRV) to `1.64` ([#000](https://github.com/heroku/libcnb.rs/pull/000))
+- Bump Minimum Supported Rust Version (MSRV) to `1.64` ([#500](https://github.com/heroku/libcnb.rs/pull/500))
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ edition = "2021"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
+libcnb = { version = "0.10.0", path = "libcnb" }
 libcnb-data = { version = "0.10.0", path = "libcnb-data" }
 libcnb-package = { version = "0.10.0", path = "libcnb-package" }
 libcnb-proc-macros = { version = "0.10.0", path = "libcnb-proc-macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,3 @@ license = "BSD-3-Clause"
 libcnb-data = { version = "0.10.0", path = "libcnb-data" }
 libcnb-package = { version = "0.10.0", path = "libcnb-package" }
 libcnb-proc-macros = { version = "0.10.0", path = "libcnb-proc-macros" }
-thiserror = "1.0.31"
-toml = "0.5.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ libcnb = { version = "0.10.0", path = "libcnb" }
 libcnb-data = { version = "0.10.0", path = "libcnb-data" }
 libcnb-package = { version = "0.10.0", path = "libcnb-package" }
 libcnb-proc-macros = { version = "0.10.0", path = "libcnb-proc-macros" }
+libcnb-test = { version = "0.10.0", path = "libcnb-test" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,16 @@ members = [
     "test-buildpacks/readonly-layer-files",
     "test-buildpacks/sbom"
 ]
+
+[workspace.package]
+version = "0.10.0"
+rust-version = "1.64"
+edition = "2021"
+license = "BSD-3-Clause"
+
+[workspace.dependencies]
+libcnb-data = { version = "0.10.0", path = "libcnb-data" }
+libcnb-package = { version = "0.10.0", path = "libcnb-package" }
+libcnb-proc-macros = { version = "0.10.0", path = "libcnb-proc-macros" }
+thiserror = "1.0.31"
+toml = "0.5.9"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [docs.rs]: https://docs.rs/libcnb/latest/libcnb/
 [Latest Version]: https://img.shields.io/crates/v/libcnb.svg
 [crates.io]: https://crates.io/crates/libcnb
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.60+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.64+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install
 
 `libcnb.rs` is a framework for writing [Cloud Native Buildpacks](https://buildpacks.io) in Rust.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ easier to gauge cross-crate compatibility.
 ## Prepare Release
 
 1. Create a new branch for the upcoming release
-2. Set `version` in the `package` table of each `Cargo.toml` to the new version
+2. Set `version` in the `workspace.package` table in the root `Cargo.toml` to the new version
 3. Set `version` for any repository-local dependencies of each `Cargo.toml` to the new version
 4. Update [CHANGELOG.md](./CHANGELOG.md)
    1. Move all content under `## [Unreleased]` to a new section that follows this pattern: `## [VERSION] YYYY-MM-DD`

--- a/examples/basics/Cargo.toml
+++ b/examples/basics/Cargo.toml
@@ -6,4 +6,4 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-libcnb = { path = "../../libcnb" }
+libcnb.workspace = true

--- a/examples/basics/Cargo.toml
+++ b/examples/basics/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "examples-basics"
 version = "0.0.0"
-edition = "2021"
-rust-version = "1.60"
+edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/execd/Cargo.toml
+++ b/examples/execd/Cargo.toml
@@ -6,8 +6,8 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-libcnb = { path = "../../libcnb" }
+libcnb.workspace = true
 fastrand = "1.7.0"
 
 [dev-dependencies]
-libcnb-test = { path = "../../libcnb-test" }
+libcnb-test.workspace = true

--- a/examples/execd/Cargo.toml
+++ b/examples/execd/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "examples-execd"
 version = "0.0.0"
-edition = "2021"
-rust-version = "1.60"
+edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/ruby-sample/Cargo.toml
+++ b/examples/ruby-sample/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "examples-ruby-sample"
 version = "0.0.0"
-edition = "2021"
-rust-version = "1.60"
+edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/ruby-sample/Cargo.toml
+++ b/examples/ruby-sample/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 flate2 = "1.0.24"
-libcnb = { path = "../../libcnb" }
+libcnb.workspace = true
 serde = "1.0.139"
 sha2 = "0.10.2"
 tar = "0.4.38"
@@ -15,4 +15,4 @@ tempfile = "3.3.0"
 ureq = "2.5.0"
 
 [dev-dependencies]
-libcnb-test = { path = "../../libcnb-test" }
+libcnb-test.workspace = true

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "libcnb-cargo"
-version = "0.10.0"
-edition = "2021"
-rust-version = "1.60"
-license = "BSD-3-Clause"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 description = "Cargo command for managing buildpacks written with libcnb.rs"
 keywords = ["buildpacks", "CNB"]
 repository = "https://github.com/heroku/libcnb.rs/tree/main/libcnb-cargo"
@@ -21,7 +21,7 @@ clap = { version = "3.2.11", default-features = false, features = [
   "std",
   "derive",
 ] }
-libcnb-package = { version = "0.10.0", path = "../libcnb-package" }
+libcnb-package.workspace = true
 log = "0.4.17"
 pathdiff = "0.2.1"
 stderrlog = { version = "0.5.3", default-features = false }

--- a/libcnb-cargo/README.md
+++ b/libcnb-cargo/README.md
@@ -30,5 +30,5 @@ INFO - Hint: To test your buildpack locally with pack, run: pack build my-image 
 
 [Latest Version]: https://img.shields.io/crates/v/libcnb-cargo.svg
 [crates.io]: https://crates.io/crates/libcnb-cargo
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.60+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.64+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "libcnb-data"
-version = "0.10.0"
-edition = "2021"
-rust-version = "1.60"
-license = "BSD-3-Clause"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 description = "Types for data formats specified in the Cloud Native Buildpack specification, used by libcnb.rs"
 keywords = ["buildpacks", "CNB"]
 repository = "https://github.com/heroku/libcnb.rs/tree/main/libcnb-data"
@@ -13,10 +13,10 @@ include = ["src/**/*", "../LICENSE", "README.md"]
 
 [dependencies]
 fancy-regex = { version = "0.10.0", default-features = false }
-libcnb-proc-macros = { path = "../libcnb-proc-macros", version = "0.10.0" }
+libcnb-proc-macros.workspace = true
 serde = { version = "1.0.139", features = ["derive"] }
-thiserror = "1.0.31"
-toml = "0.5.9"
+thiserror.workspace = true
+toml.workspace = true
 
 [dev-dependencies]
 serde_test = "1.0.139"

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -15,8 +15,8 @@ include = ["src/**/*", "../LICENSE", "README.md"]
 fancy-regex = { version = "0.10.0", default-features = false }
 libcnb-proc-macros.workspace = true
 serde = { version = "1.0.139", features = ["derive"] }
-thiserror.workspace = true
-toml.workspace = true
+thiserror = "1.0.31"
+toml = "0.5.9"
 
 [dev-dependencies]
 serde_test = "1.0.139"

--- a/libcnb-data/README.md
+++ b/libcnb-data/README.md
@@ -10,5 +10,5 @@ on this crate directly.
 [docs.rs]: https://docs.rs/libcnb-data/latest/libcnb_data/
 [Latest Version]: https://img.shields.io/crates/v/libcnb-data.svg
 [crates.io]: https://crates.io/crates/libcnb-data
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.60+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.64+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb-package/Cargo.toml
+++ b/libcnb-package/Cargo.toml
@@ -14,5 +14,5 @@ include = ["src/**/*", "../LICENSE", "README.md"]
 [dependencies]
 cargo_metadata = "0.15.0"
 libcnb-data.workspace = true
-toml.workspace = true
+toml = "0.5.9"
 which = "4.2.5"

--- a/libcnb-package/Cargo.toml
+++ b/libcnb-package/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "libcnb-package"
-version = "0.10.0"
-edition = "2021"
-rust-version = "1.60"
-license = "BSD-3-Clause"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 description = "Library for cross-compiling and packaging buildpacks written with libcnb.rs"
 keywords = ["buildpacks", "CNB"]
 repository = "https://github.com/heroku/libcnb.rs/tree/main/libcnb-package"
@@ -13,6 +13,6 @@ include = ["src/**/*", "../LICENSE", "README.md"]
 
 [dependencies]
 cargo_metadata = "0.15.0"
-libcnb-data = { version = "0.10.0", path = "../libcnb-data" }
-toml = "0.5.9"
+libcnb-data.workspace = true
+toml.workspace = true
 which = "4.2.5"

--- a/libcnb-package/README.md
+++ b/libcnb-package/README.md
@@ -10,5 +10,5 @@ directly.
 [docs.rs]: https://docs.rs/libcnb-package/latest/libcnb_package/
 [Latest Version]: https://img.shields.io/crates/v/libcnb-package.svg
 [crates.io]: https://crates.io/crates/libcnb-package
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.60+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.64+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "libcnb-proc-macros"
-version = "0.10.0"
-edition = "2021"
-rust-version = "1.60"
-license = "BSD-3-Clause"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 description = "Procedural macros used within libcnb.rs"
 repository = "https://github.com/heroku/libcnb.rs/tree/main/libcnb-proc-macros"
 documentation = "https://docs.rs/libcnb-proc-macros"

--- a/libcnb-proc-macros/README.md
+++ b/libcnb-proc-macros/README.md
@@ -9,5 +9,5 @@ depending on this crate directly.
 [docs.rs]: https://docs.rs/libcnb-proc-macros/latest/libcnb_proc_macros/
 [Latest Version]: https://img.shields.io/crates/v/libcnb-proc-macros.svg
 [crates.io]: https://crates.io/crates/libcnb-proc-macros
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.60+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.64+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "libcnb-test"
-version = "0.10.0"
-edition = "2021"
-rust-version = "1.60"
-license = "BSD-3-Clause"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 description = "An integration testing framework for buildpacks written with libcnb.rs"
 keywords = ["buildpacks", "CNB"]
 repository = "https://github.com/heroku/libcnb.rs/tree/main/libcnb-test"
@@ -16,8 +16,8 @@ bollard = "0.13.0"
 cargo_metadata = "0.15.0"
 fastrand = "1.7.0"
 fs_extra = "1.2.0"
-libcnb-data = { version = "0.10.0", path = "../libcnb-data" }
-libcnb-package = { version = "0.10.0", path = "../libcnb-package" }
+libcnb-data.workspace = true
+libcnb-package.workspace = true
 serde = "1.0.139"
 tempfile = "3.3.0"
 tokio = "1.20.0"

--- a/libcnb-test/README.md
+++ b/libcnb-test/README.md
@@ -224,5 +224,5 @@ fn additional_buildpacks() {
 [docs.rs]: https://docs.rs/libcnb-test/latest/libcnb_test/
 [Latest Version]: https://img.shields.io/crates/v/libcnb-test.svg
 [crates.io]: https://crates.io/crates/libcnb-test
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.60+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.64+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "libcnb"
-version = "0.10.0"
-edition = "2021"
-rust-version = "1.60"
-license = "BSD-3-Clause"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 description = "A framework for writing Cloud Native Buildpacks in Rust"
 keywords = ["buildpacks", "CNB"]
 repository = "https://github.com/heroku/libcnb.rs"
@@ -14,12 +14,12 @@ include = ["src/**/*", "../LICENSE", "../README.md"]
 [dependencies]
 anyhow = { version = "1.0.58", optional = true }
 cyclonedx-bom = { version = "0.3.2", optional = true }
-libcnb-data = { version = "0.10.0", path = "../libcnb-data" }
-libcnb-proc-macros = { version = "0.10.0", path = "../libcnb-proc-macros" }
+libcnb-data.workspace = true
+libcnb-proc-macros.workspace = true
 serde = { version = "1.0.139", features = ["derive"] }
 stacker = "0.1.15"
-thiserror = "1.0.31"
-toml = "0.5.9"
+thiserror.workspace = true
+toml.workspace = true
 
 [dev-dependencies]
 fastrand = "1.7.0"

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -18,8 +18,8 @@ libcnb-data.workspace = true
 libcnb-proc-macros.workspace = true
 serde = { version = "1.0.139", features = ["derive"] }
 stacker = "0.1.15"
-thiserror.workspace = true
-toml.workspace = true
+thiserror = "1.0.31"
+toml = "0.5.9"
 
 [dev-dependencies]
 fastrand = "1.7.0"

--- a/libherokubuildpack/Cargo.toml
+++ b/libherokubuildpack/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "libherokubuildpack"
-version = "0.10.0"
-edition = "2021"
-rust-version = "1.60"
-license = "BSD-3-Clause"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 description = "Opinionated common code for buildpacks implemented with libcnb.rs"
 keywords = ["buildpacks", "CNB"]
 repository = "https://github.com/heroku/libcnb.rs/tree/main/libherokubuildpack"
@@ -26,9 +26,9 @@ fs = ["dep:pathdiff"]
 
 [dependencies]
 flate2 = { version = "1.0.24", optional = true }
-libcnb = { path = "../libcnb", version = "0.10.0", optional = true }
+libcnb = { workspace = true, optional = true }
 pathdiff = { version = "0.2.1", optional = true }
-sha2 = { version ="0.10.2", optional = true }
+sha2 = { version = "0.10.2", optional = true }
 tar = { version = "0.4.38", optional = true }
 termcolor = { version = "1.1.3", optional = true }
 thiserror = { version = "1.0.31", optional = true }

--- a/libherokubuildpack/README.md
+++ b/libherokubuildpack/README.md
@@ -33,5 +33,5 @@ The feature names line up with the modules in this crate. All features are enabl
 [docs.rs]: https://docs.rs/libcnb-test/latest/libherokubuildpack/
 [Latest Version]: https://img.shields.io/crates/v/libherokubuildpack.svg
 [crates.io]: https://crates.io/crates/libherokubuildpack
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.60+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.64+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/test-buildpacks/readonly-layer-files/Cargo.toml
+++ b/test-buildpacks/readonly-layer-files/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-libcnb = { path = "../../libcnb" }
+libcnb.workspace = true
 
 [dev-dependencies]
-libcnb-test = { path = "../../libcnb-test" }
+libcnb-test.workspace = true

--- a/test-buildpacks/readonly-layer-files/Cargo.toml
+++ b/test-buildpacks/readonly-layer-files/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "readonly-layer-files"
 version = "0.0.0"
-edition = "2021"
-rust-version = "1.60"
+edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [dependencies]

--- a/test-buildpacks/sbom/Cargo.toml
+++ b/test-buildpacks/sbom/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-libcnb = { path = "../../libcnb" }
+libcnb.workspace = true
 
 [dev-dependencies]
-libcnb-test = { path = "../../libcnb-test" }
+libcnb-test.workspace = true

--- a/test-buildpacks/sbom/Cargo.toml
+++ b/test-buildpacks/sbom/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sbom"
 version = "0.0.0"
-edition = "2021"
-rust-version = "1.60"
+edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [dependencies]


### PR DESCRIPTION
Cargo `1.64` allows to specify some package metadata at workspace level (https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#cargo-improvements-workspace-inheritance-and-multi-target-builds). This is something we wanted for some time now, especially when #492 was implemented. 

The new Cargo version also allows to specify dependencies at workspace level that packages can inherit. This is quite useful for repository-local dependencies that are now only specified once and not across all packages in the repository. This makes cutting a release even easier.

Downsides are that Rust 1.64 is a very new release at the time of writing and people using libcnb might need to bump their Rust version in both CI and locally to use it. However, it will only affect users that bump their libcnb version.

Closes GUS-W-11800636