### PR TITLE
Bump to `0.11.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ## [Unreleased]
 
+## [0.11.0] 2022-09-23
+
 ### Changed
 
 - Bump Minimum Supported Rust Version (MSRV) to `1.64` ([#500](https://github.com/heroku/libcnb.rs/pull/500))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 rust-version = "1.64"
 edition = "2021"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
-libcnb = { version = "0.10.0", path = "libcnb" }
-libcnb-data = { version = "0.10.0", path = "libcnb-data" }
-libcnb-package = { version = "0.10.0", path = "libcnb-package" }
-libcnb-proc-macros = { version = "0.10.0", path = "libcnb-proc-macros" }
-libcnb-test = { version = "0.10.0", path = "libcnb-test" }
+libcnb = { version = "0.11.0", path = "libcnb" }
+libcnb-data = { version = "0.11.0", path = "libcnb-data" }
+libcnb-package = { version = "0.11.0", path = "libcnb-package" }
+libcnb-proc-macros = { version = "0.11.0", path = "libcnb-proc-macros" }
+libcnb-test = { version = "0.11.0", path = "libcnb-test" }


### PR DESCRIPTION
Release preperations for `0.11.0`. I opted to not write a description for this release as it would just re-state what is in the (very brief) changelog itself.