### PR TITLE
`cargo upgrade`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ### Changed
 
-- Bump Minimum Supported Rust Version (MSRV) to `1.64` ([#500](https://github.com/heroku/libcnb.rs/pull/500))
+- Bump Minimum Supported Rust Version (MSRV) to `1.64`. ([#500](https://github.com/heroku/libcnb.rs/pull/500))
+- Bump minimum external dependency versions. ([#502](https://github.com/heroku/libcnb.rs/pull/502))
 
 ### Added
 

--- a/examples/execd/Cargo.toml
+++ b/examples/execd/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 libcnb.workspace = true
-fastrand = "1.7.0"
+fastrand = "1.8.0"
 
 [dev-dependencies]
 libcnb-test.workspace = true

--- a/examples/ruby-sample/Cargo.toml
+++ b/examples/ruby-sample/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 [dependencies]
 flate2 = "1.0.24"
 libcnb.workspace = true
-serde = "1.0.139"
-sha2 = "0.10.2"
+serde = "1.0.145"
+sha2 = "0.10.6"
 tar = "0.4.38"
 tempfile = "3.3.0"
 ureq = "2.5.0"

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 cargo_metadata = "0.15.0"
-clap = { version = "3.2.11", default-features = false, features = [
+clap = { version = "3.2.22", default-features = false, features = [
   "std",
   "derive",
 ] }

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -14,9 +14,9 @@ include = ["src/**/*", "../LICENSE", "README.md"]
 [dependencies]
 fancy-regex = { version = "0.10.0", default-features = false }
 libcnb-proc-macros.workspace = true
-serde = { version = "1.0.139", features = ["derive"] }
-thiserror = "1.0.31"
+serde = { version = "1.0.145", features = ["derive"] }
+thiserror = "1.0.35"
 toml = "0.5.9"
 
 [dev-dependencies]
-serde_test = "1.0.139"
+serde_test = "1.0.145"

--- a/libcnb-package/Cargo.toml
+++ b/libcnb-package/Cargo.toml
@@ -15,4 +15,4 @@ include = ["src/**/*", "../LICENSE", "README.md"]
 cargo_metadata = "0.15.0"
 libcnb-data.workspace = true
 toml = "0.5.9"
-which = "4.2.5"
+which = "4.3.0"

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -16,5 +16,5 @@ proc-macro = true
 [dependencies]
 cargo_metadata = "0.15.0"
 fancy-regex = { version = "0.10.0", default-features = false }
-quote = "1.0.20"
-syn = { version = "1.0.98", features = ["full"] }
+quote = "1.0.21"
+syn = { version = "1.0.100", features = ["full"] }

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -14,17 +14,17 @@ include = ["src/**/*", "../LICENSE", "README.md"]
 [dependencies]
 bollard = "0.13.0"
 cargo_metadata = "0.15.0"
-fastrand = "1.7.0"
+fastrand = "1.8.0"
 fs_extra = "1.2.0"
 libcnb-data.workspace = true
 libcnb-package.workspace = true
-serde = "1.0.139"
+serde = "1.0.145"
 tempfile = "3.3.0"
-tokio = "1.20.0"
-tokio-stream = "0.1.9"
+tokio = "1.21.1"
+tokio-stream = "0.1.10"
 
 [dev-dependencies]
-indoc = "1.0.6"
+indoc = "1.0.7"
 ureq = { version = "2.5.0", default-features = false }
 
 [features]

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -12,15 +12,15 @@ readme = "../README.md"
 include = ["src/**/*", "../LICENSE", "../README.md"]
 
 [dependencies]
-anyhow = { version = "1.0.58", optional = true }
-cyclonedx-bom = { version = "0.3.2", optional = true }
+anyhow = { version = "1.0.65", optional = true }
+cyclonedx-bom = { version = "0.3.5", optional = true }
 libcnb-data.workspace = true
 libcnb-proc-macros.workspace = true
-serde = { version = "1.0.139", features = ["derive"] }
+serde = { version = "1.0.145", features = ["derive"] }
 stacker = "0.1.15"
-thiserror = "1.0.31"
+thiserror = "1.0.35"
 toml = "0.5.9"
 
 [dev-dependencies]
-fastrand = "1.7.0"
+fastrand = "1.8.0"
 tempfile = "3.3.0"

--- a/libherokubuildpack/Cargo.toml
+++ b/libherokubuildpack/Cargo.toml
@@ -28,10 +28,10 @@ fs = ["dep:pathdiff"]
 flate2 = { version = "1.0.24", optional = true }
 libcnb = { workspace = true, optional = true }
 pathdiff = { version = "0.2.1", optional = true }
-sha2 = { version = "0.10.2", optional = true }
+sha2 = { version = "0.10.6", optional = true }
 tar = { version = "0.4.38", optional = true }
 termcolor = { version = "1.1.3", optional = true }
-thiserror = { version = "1.0.31", optional = true }
+thiserror = { version = "1.0.35", optional = true }
 toml = { version = "0.5.9", optional = true }
 ureq = { version = "2.5.0", optional = true }
 


### PR DESCRIPTION
Generated via:

```
cargo install cargo-edit
cargo upgrade
```

All versions are in-range (that is deleting the lockfile and recreating it would end up with the same versions), however explicitly bumping them ensures downstream consumers of libcnb pick up the updates even if they don't refresh their lockfile manually.