### PR TITLE
libherokubuildpack: Use the README for the root module's rustdocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ## [Unreleased]
 
+### Changed
+
+- Improve the `libherokubuildpack` root module rustdocs. ([#503](https://github.com/heroku/libcnb.rs/pull/503))
+
 ## [0.11.0] 2022-09-23
 
 ### Changed

--- a/libherokubuildpack/src/lib.rs
+++ b/libherokubuildpack/src/lib.rs
@@ -1,30 +1,7 @@
-//! Opinionated common code for buildpacks implemented with libcnb.rs
-//!
-//! Contains common helpers and functionality that is not present in the more generic libcnb.rs library.
-//!
-//! # Crate Features
-//!
-//! * **download** -
-//!   Enables helpers to download files over HTTP.
-//! * **digest** -
-//!   Enables helpers to create checksums of files.
-//! * **error** -
-//!   Enables helpers to achieve consistent error logging.
-//! * **log** -
-//!   Enables helpers for logging.
-//! * **tar** -
-//!   Enables helpers for working with tarballs.
-//! * **toml** -
-//!   Enables helpers for working with TOML data.
-//! * **fs** -
-//!   Enables helpers for filesystem related tasks.
-//!
-
-// Enable rustc and Clippy lints that are disabled by default.
-// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
-#![warn(unused_crate_dependencies)]
-// https://rust-lang.github.io/rust-clippy/stable/index.html
+#![doc = include_str!("../README.md")]
+// Enable lints that are disabled by default.
 #![warn(clippy::pedantic)]
+#![warn(unused_crate_dependencies)]
 // In most cases adding error docs provides little value.
 #![allow(clippy::missing_errors_doc)]
 // This lint is too noisy and enforces a style that reduces readability in many cases.


### PR DESCRIPTION
For parity with the other crates, after #460.