### PR TITLE
Always use `Self` when referring to self

### DIFF
--- a/libcnb-data/src/build_plan.rs
+++ b/libcnb-data/src/build_plan.rs
@@ -126,7 +126,7 @@ impl Require {
 
 impl<S: Into<String>> From<S> for Require {
     fn from(s: S) -> Self {
-        Require::new(s)
+        Self::new(s)
     }
 }
 

--- a/libcnb-data/src/buildpack/stack.rs
+++ b/libcnb-data/src/buildpack/stack.rs
@@ -27,12 +27,12 @@ impl TryFrom<StackUnchecked> for Stack {
 
         if id.as_str() == "*" {
             if mixins.is_empty() {
-                Ok(Stack::Any)
+                Ok(Self::Any)
             } else {
                 Err(Self::Error::InvalidAnyStack(mixins))
             }
         } else {
-            Ok(Stack::Specific {
+            Ok(Self::Specific {
                 id: id.parse()?,
                 mixins,
             })

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -153,15 +153,15 @@ impl Serialize for WorkingDirectory {
         S: Serializer,
     {
         match self {
-            WorkingDirectory::App => serializer.serialize_str("."),
-            WorkingDirectory::Directory(path) => path.serialize(serializer),
+            Self::App => serializer.serialize_str("."),
+            Self::Directory(path) => path.serialize(serializer),
         }
     }
 }
 
 impl Default for WorkingDirectory {
     fn default() -> Self {
-        WorkingDirectory::App
+        Self::App
     }
 }
 

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -71,7 +71,7 @@ macro_rules! libcnb_newtype {
         impl ::std::fmt::Display for $error_name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 match self {
-                    $error_name::InvalidValue(value) => {
+                    Self::InvalidValue(value) => {
                         ::std::write!(f, "Invalid Value: {}", value)
                     }
                 }

--- a/libcnb-test/src/app.rs
+++ b/libcnb-test/src/app.rs
@@ -35,8 +35,8 @@ pub(crate) enum AppDir {
 impl AppDir {
     pub fn as_path(&self) -> &Path {
         match self {
-            AppDir::Temporary(temp_dir) => temp_dir.path(),
-            AppDir::Unmanaged(path) => path,
+            Self::Temporary(temp_dir) => temp_dir.path(),
+            Self::Unmanaged(path) => path,
         }
     }
 }
@@ -49,13 +49,13 @@ impl AsRef<OsStr> for AppDir {
 
 impl From<PathBuf> for AppDir {
     fn from(value: PathBuf) -> Self {
-        AppDir::Unmanaged(value)
+        Self::Unmanaged(value)
     }
 }
 
 impl From<TempDir> for AppDir {
     fn from(value: TempDir) -> Self {
-        AppDir::Temporary(value)
+        Self::Temporary(value)
     }
 }
 

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -24,19 +24,19 @@ pub(crate) enum BuildpackReference {
 
 impl From<PathBuf> for BuildpackReference {
     fn from(path: PathBuf) -> Self {
-        BuildpackReference::Path(path)
+        Self::Path(path)
     }
 }
 
 impl From<&TempDir> for BuildpackReference {
     fn from(path: &TempDir) -> Self {
-        BuildpackReference::Path(path.path().into())
+        Self::Path(path.path().into())
     }
 }
 
 impl From<String> for BuildpackReference {
     fn from(id: String) -> Self {
-        BuildpackReference::Id(id)
+        Self::Id(id)
     }
 }
 
@@ -57,8 +57,8 @@ impl PackBuildCommand {
         builder: impl Into<String>,
         path: impl Into<PathBuf>,
         image_name: impl Into<String>,
-    ) -> PackBuildCommand {
-        PackBuildCommand {
+    ) -> Self {
+        Self {
             builder: builder.into(),
             buildpacks: Vec::new(),
             env: BTreeMap::new(),
@@ -84,7 +84,7 @@ impl PackBuildCommand {
 
 impl From<PackBuildCommand> for Command {
     fn from(pack_build_command: PackBuildCommand) -> Self {
-        let mut command = Command::new("pack");
+        let mut command = Self::new("pack");
 
         let mut args = vec![
             String::from("build"),
@@ -156,7 +156,7 @@ impl PackSbomDownloadCommand {
 
 impl From<PackSbomDownloadCommand> for Command {
     fn from(pack_command: PackSbomDownloadCommand) -> Self {
-        let mut command = Command::new("pack");
+        let mut command = Self::new("pack");
 
         let mut args = vec![
             String::from("sbom"),

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -51,7 +51,7 @@ impl Default for TestRunner {
         }
             .expect("Could not connect to local Docker daemon");
 
-        TestRunner::new(tokio_runtime, docker)
+        Self::new(tokio_runtime, docker)
     }
 }
 
@@ -61,7 +61,7 @@ impl TestRunner {
     /// This function is meant for advanced use-cases where fine control over the Tokio runtime
     /// and/or Docker connection is required. For the common use-cases, use `Runner::default`.
     pub fn new(tokio_runtime: tokio::runtime::Runtime, docker: Docker) -> Self {
-        TestRunner {
+        Self {
             docker,
             tokio_runtime,
         }

--- a/libcnb/src/error.rs
+++ b/libcnb/src/error.rs
@@ -61,6 +61,6 @@ pub enum Error<E> {
 #[cfg(feature = "anyhow")]
 impl From<anyhow::Error> for Error<anyhow::Error> {
     fn from(error: anyhow::Error) -> Self {
-        Error::BuildpackError(error)
+        Self::BuildpackError(error)
     }
 }

--- a/libcnb/src/generic.rs
+++ b/libcnb/src/generic.rs
@@ -35,6 +35,6 @@ impl Platform for GenericPlatform {
     }
 
     fn from_path(platform_dir: impl AsRef<Path>) -> std::io::Result<Self> {
-        read_platform_env(platform_dir.as_ref()).map(|env| GenericPlatform { env })
+        read_platform_env(platform_dir.as_ref()).map(|env| Self { env })
     }
 }

--- a/libcnb/src/layer/handling.rs
+++ b/libcnb/src/layer/handling.rs
@@ -169,31 +169,31 @@ pub(crate) enum HandleLayerErrorOrBuildpackError<E> {
 
 impl<E> From<HandleLayerError> for HandleLayerErrorOrBuildpackError<E> {
     fn from(e: HandleLayerError) -> Self {
-        HandleLayerErrorOrBuildpackError::HandleLayerError(e)
+        Self::HandleLayerError(e)
     }
 }
 
 impl<E> From<DeleteLayerError> for HandleLayerErrorOrBuildpackError<E> {
     fn from(e: DeleteLayerError) -> Self {
-        HandleLayerErrorOrBuildpackError::HandleLayerError(HandleLayerError::DeleteLayerError(e))
+        Self::HandleLayerError(HandleLayerError::DeleteLayerError(e))
     }
 }
 
 impl<E> From<ReadLayerError> for HandleLayerErrorOrBuildpackError<E> {
     fn from(e: ReadLayerError) -> Self {
-        HandleLayerErrorOrBuildpackError::HandleLayerError(HandleLayerError::ReadLayerError(e))
+        Self::HandleLayerError(HandleLayerError::ReadLayerError(e))
     }
 }
 
 impl<E> From<WriteLayerError> for HandleLayerErrorOrBuildpackError<E> {
     fn from(e: WriteLayerError) -> Self {
-        HandleLayerErrorOrBuildpackError::HandleLayerError(HandleLayerError::WriteLayerError(e))
+        Self::HandleLayerError(HandleLayerError::WriteLayerError(e))
     }
 }
 
 impl<E> From<std::io::Error> for HandleLayerErrorOrBuildpackError<E> {
     fn from(e: std::io::Error) -> Self {
-        HandleLayerErrorOrBuildpackError::HandleLayerError(HandleLayerError::IoError(e))
+        Self::HandleLayerError(HandleLayerError::IoError(e))
     }
 }
 

--- a/libcnb/src/layer/tests.rs
+++ b/libcnb/src/layer/tests.rs
@@ -123,7 +123,7 @@ struct TestLayerMetadata {
 
 impl Default for TestLayer {
     fn default() -> Self {
-        TestLayer {
+        Self {
             existing_layer_strategy: ExistingLayerStrategy::Recreate,
             write_version: String::from("1.0.0"),
             write_layer_env: None,

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -234,9 +234,9 @@ pub struct DetectArgs {
 }
 
 impl DetectArgs {
-    pub fn parse(args: &[String]) -> Result<DetectArgs, DetectArgsParseError> {
+    pub fn parse(args: &[String]) -> Result<Self, DetectArgsParseError> {
         if let [_, platform_dir_path, build_plan_path] = args {
-            Ok(DetectArgs {
+            Ok(Self {
                 platform_dir_path: PathBuf::from(platform_dir_path),
                 build_plan_path: PathBuf::from(build_plan_path),
             })
@@ -260,9 +260,9 @@ pub struct BuildArgs {
 }
 
 impl BuildArgs {
-    pub fn parse(args: &[String]) -> Result<BuildArgs, BuildArgsParseError> {
+    pub fn parse(args: &[String]) -> Result<Self, BuildArgsParseError> {
         if let [_, layers_dir_path, platform_dir_path, buildpack_plan_path] = args {
-            Ok(BuildArgs {
+            Ok(Self {
                 layers_dir_path: PathBuf::from(layers_dir_path),
                 platform_dir_path: PathBuf::from(platform_dir_path),
                 buildpack_plan_path: PathBuf::from(buildpack_plan_path),

--- a/libcnb/src/sbom.rs
+++ b/libcnb/src/sbom.rs
@@ -25,7 +25,7 @@ impl Sbom {
     /// Note that there is no validation performed by libcnb.rs, the CNB lifecycle will error at
     /// runtime should the SBOM be invalid.
     pub fn from_path<P: AsRef<Path>>(format: SbomFormat, path: P) -> std::io::Result<Self> {
-        fs::read(path.as_ref()).map(|data| Sbom { format, data })
+        fs::read(path.as_ref()).map(|data| Self { format, data })
     }
 
     /// Constructs an `Sbom` from the given bytes, treating it as the SBOM format specified.
@@ -33,7 +33,7 @@ impl Sbom {
     /// Note that there is no validation performed by libcnb.rs, the CNB lifecycle will error at
     /// runtime should the SBOM be invalid.
     pub fn from_bytes<D: Into<Vec<u8>>>(format: SbomFormat, data: D) -> Self {
-        Sbom {
+        Self {
             format,
             data: data.into(),
         }
@@ -49,7 +49,7 @@ impl TryFrom<cyclonedx_bom::models::bom::Bom> for Sbom {
 
         cyclonedx_bom.output_as_json_v1_3(&mut data)?;
 
-        Ok(Sbom {
+        Ok(Self {
             format: SbomFormat::CycloneDxJson,
             data,
         })


### PR DESCRIPTION
I found a few instances of these whilst working on something else. The rest were found (and `--fix`ed) by:
https://rust-lang.github.io/rust-clippy/master/index.html#use_self

That lint isn't enabled by default since it currently has false positives (a few show up in libcnb, but I reverted the changes from those).