### PR TITLE
libcnb-test: Check the exit code of `pack sbom download`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ## [Unreleased]
 
+### Fixed
+
+- libcnb-test: `TestContext::download_sbom_files` now checks the exit code of the `pack sbom download` command it runs. ([#520](https://github.com/heroku/libcnb.rs/pull/520))
+
 ### Changed
 
 - libcnb: Drop the use of the `stacker` crate when recursively removing layer directories. ([#517](https://github.com/heroku/libcnb.rs/pull/517))

--- a/libcnb-test/src/test_context.rs
+++ b/libcnb-test/src/test_context.rs
@@ -1,7 +1,7 @@
 use crate::pack::{run_pack_command, PackSbomDownloadCommand};
 use crate::{
     container_port_mapping, util, BuildConfig, ContainerConfig, ContainerContext, LogOutput,
-    TestRunner,
+    PackResult, TestRunner,
 };
 use bollard::container::{Config, CreateContainerOptions, StartContainerOptions};
 use bollard::image::RemoveImageOptions;
@@ -202,7 +202,7 @@ impl<'a> TestContext<'a> {
         let mut command = PackSbomDownloadCommand::new(&self.image_name);
         command.output_dir(temp_dir.path());
 
-        run_pack_command(command);
+        run_pack_command(command, &PackResult::Success);
 
         f(SbomFiles {
             sbom_files_directory: temp_dir.path().into(),

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -1,5 +1,5 @@
 use crate::pack::{run_pack_command, PackBuildCommand};
-use crate::{app, build, util, BuildConfig, BuildpackReference, PackResult, TestContext};
+use crate::{app, build, util, BuildConfig, BuildpackReference, TestContext};
 use bollard::Docker;
 use std::borrow::Borrow;
 use std::env;
@@ -156,7 +156,7 @@ impl TestRunner {
             };
         }
 
-        let output = run_pack_command(pack_command);
+        let output = run_pack_command(pack_command, &config.expected_pack_result);
 
         let test_context = TestContext {
             pack_stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
@@ -166,21 +166,6 @@ impl TestRunner {
             runner: self,
         };
 
-        if (config.expected_pack_result == PackResult::Failure && output.status.success())
-            || (config.expected_pack_result == PackResult::Success && !output.status.success())
-        {
-            panic!(
-                "pack command unexpectedly {} with exit-code {}!\n\npack stdout:\n{}\n\npack stderr:\n{}",
-                if output.status.success() { "succeeded" } else { "failed" },
-                output
-                    .status
-                    .code()
-                    .map_or(String::from("<unknown>"), |exit_code| exit_code.to_string()),
-                test_context.pack_stdout,
-                test_context.pack_stderr
-            );
-        } else {
-            f(test_context);
-        }
+        f(test_context);
     }
 }


### PR DESCRIPTION
Previously if the `pack sbom download` command exited non-zero, `TestContext::download_sbom_files` would ignore the error and return an `SbomFiles` referencing an empty directory.

Now, such errors will result in a test panic showing the stdout/stderr from pack - like already occurs for errors during `pack build`.

I tried writing an integration test for this, however wasn't able to find an easy way to make `pack sbom download` fail (it appears to succeed even for images that don't have any SBOMs for example, and I don't want to resort to having to make manual `docker rmi <image>` calls etc). However the implementation is already tested via the `pack build` consumer, so this could be worse.

Fixes #519.
GUS-W-11924792.