### PR TITLE
Add remote .tgz fetcher with component stripping, file filtering, and sha verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ## [Unreleased]
 
+### Added
+
+- libherokubuildpack: `tgz::Fetcher` has been added to fetch, extract, and verify remote tarballs in an efficient manner. ([#521](https://github.com/heroku/libcnb.rs/pull/521))
+
 ### Fixed
 
 - libcnb-test: `TestContext::download_sbom_files` now checks the exit code of the `pack sbom download` command it runs. ([#520](https://github.com/heroku/libcnb.rs/pull/520))

--- a/libherokubuildpack/Cargo.toml
+++ b/libherokubuildpack/Cargo.toml
@@ -15,12 +15,13 @@ include = ["src/**/*", "LICENSE", "README.md"]
 all-features = true
 
 [features]
-default = ["download", "digest", "error", "log", "tar", "toml", "fs"]
+default = ["download", "digest", "error", "log", "tar", "tgz", "toml", "fs"]
 download = ["dep:ureq", "dep:thiserror"]
 digest = ["dep:sha2"]
 error = ["log", "dep:libcnb"]
 log = ["dep:termcolor"]
 tar = ["dep:tar", "dep:flate2"]
+tgz = ["dep:sha2", "dep:flate2", "dep:tar"]
 toml = ["dep:toml"]
 fs = ["dep:pathdiff"]
 

--- a/libherokubuildpack/src/lib.rs
+++ b/libherokubuildpack/src/lib.rs
@@ -19,5 +19,7 @@ pub mod fs;
 pub mod log;
 #[cfg(feature = "tar")]
 pub mod tar;
+#[cfg(feature = "tgz")]
+pub mod tgz;
 #[cfg(feature = "toml")]
 pub mod toml;

--- a/libherokubuildpack/src/tgz.rs
+++ b/libherokubuildpack/src/tgz.rs
@@ -3,9 +3,9 @@ use sha2::{
     digest::{generic_array::GenericArray, OutputSizeUser},
     Digest, Sha256,
 };
-use std::fs::File;
-use std::io::{Seek, SeekFrom};
-use std::path::Path;
+
+
+
 use std::{io::Read, path::StripPrefixError};
 use tar::Archive;
 

--- a/libherokubuildpack/src/tgz.rs
+++ b/libherokubuildpack/src/tgz.rs
@@ -3,78 +3,99 @@ use sha2::{
     digest::{generic_array::GenericArray, OutputSizeUser},
     Digest, Sha256,
 };
-
-
-
+use std::path::PathBuf;
 use std::{io::Read, path::StripPrefixError};
 use tar::Archive;
 
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error("HTTP error while fetching archive: {0}")]
-    Http(#[from] Box<ureq::Error>),
-
-    #[error("Error reading archive entries: {0}")]
-    Entries(std::io::Error),
-
-    #[error("Error reading archive entry: {0}")]
-    Entry(std::io::Error),
-
-    #[error("Error reading archive file path: {0}")]
-    Path(std::io::Error),
-
-    #[error("Failed to validate archive checksum; expected {0}, but found {1}")]
-    Checksum(String, String),
-
-    #[error("Error writing archive entry: {0}")]
-    Unpack(std::io::Error),
-
-    #[error("Error stripping archive entry prefix: {0}")]
-    Prefix(StripPrefixError),
+#[derive(Debug, Clone, Default)]
+pub struct Fetch {
+    remote_uri: String,
+    dest_dir: std::path::PathBuf,
+    strip_prefix: String,
+    filter_prefixes: Vec<String>,
+    verify_digest: String,
 }
 
-/// Fetches a tarball from a url, strips component paths, filters path prefixes,
-/// extracts files to a location, and verifies a sha256 checksum. Care is taken
-/// not to write temporary files or read the entire contents into memory. In an
-/// error scenario, any archive contents already extracted will not be removed.
-///
-/// # Errors
-///
-/// See `Error` for an enumeration of error scenarios.
-pub fn fetch_strip_filter_extract_verify<'a>(
-    uri: impl AsRef<str>,
-    strip_prefix: impl AsRef<str>,
-    filter_prefixes: impl Iterator<Item = &'a str>,
-    dest_dir: impl AsRef<std::path::Path>,
-    sha256: impl AsRef<str>,
-) -> Result<(), Error> {
-    let expected_digest = sha256.as_ref();
-    let destination = dest_dir.as_ref();
-    let body = ureq::get(uri.as_ref())
-        .call()
-        .map_err(Box::new)?
-        .into_reader();
-    let mut archive = Archive::new(GzDecoder::new(DigestingReader::new(body, Sha256::new())));
-    let filters: Vec<&str> = filter_prefixes.into_iter().collect();
-    for entry in archive.entries().map_err(Error::Entries)? {
-        let mut file = entry.map_err(Error::Entry)?;
-        let path = destination.join(
-            file.path()
-                .map_err(Error::Path)?
-                .strip_prefix(strip_prefix.as_ref())
-                .map_err(Error::Prefix)?,
-        );
-        if filters
-            .iter()
-            .any(|prefix| path.starts_with(destination.join(prefix)))
-        {
-            file.unpack(&path).map_err(Error::Unpack)?;
-        }
+#[derive(Default)]
+pub struct FetchBuilder(Fetch);
+
+impl FetchBuilder {
+    #[must_use]
+    pub fn new<S: Into<String>, P: Into<PathBuf>>(remote_uri: S, dest_dir: P) -> Self {
+        Self(Fetch {
+            remote_uri: remote_uri.into(),
+            dest_dir: dest_dir.into(),
+            strip_prefix: String::default(),
+            filter_prefixes: vec![],
+            verify_digest: String::default(),
+        })
     }
-    let actual_digest = format!("{:x}", archive.into_inner().into_inner().finalize());
-    (expected_digest == actual_digest)
-        .then_some(())
-        .ok_or_else(|| Error::Checksum(expected_digest.to_string(), actual_digest))
+
+    #[must_use]
+    pub fn build(&self) -> Fetch {
+        self.0.clone()
+    }
+
+    #[must_use]
+    pub fn verify_digest<S: Into<String>>(&mut self, digest: S) -> &mut Self {
+        self.0.verify_digest = digest.into();
+        self
+    }
+
+    #[must_use]
+    pub fn filter_prefixes<I: IntoIterator<Item = S>, S: Into<String>>(
+        &mut self,
+        prefixes: I,
+    ) -> &mut Self {
+        for prefix in prefixes {
+            self.0.filter_prefixes.push(prefix.into());
+        }
+        self
+    }
+
+    #[must_use]
+    pub fn strip_prefix<S: Into<String>>(&mut self, strip_prefix: S) -> &mut Self {
+        self.0.strip_prefix = strip_prefix.into();
+        self
+    }
+}
+
+impl Fetch {
+    /// Fetches a tarball from a url, strips component paths, filters path prefixes,
+    /// extracts files to a location, and verifies a sha256 checksum. Care is taken
+    /// not to write temporary files or read the entire contents into memory. In an
+    /// error scenario, any archive contents already extracted will not be removed.
+    ///
+    /// # Errors
+    ///
+    /// See `Error` for an enumeration of error scenarios.
+    pub fn fetch(&self) -> Result<(), Error> {
+        let body = ureq::get(&self.remote_uri)
+            .call()
+            .map_err(Box::new)?
+            .into_reader();
+        let mut archive = Archive::new(GzDecoder::new(DigestingReader::new(body, Sha256::new())));
+        for entry in archive.entries().map_err(Error::Entries)? {
+            let mut file = entry.map_err(Error::Entry)?;
+            let path = self.dest_dir.join(
+                file.path()
+                    .map_err(Error::Path)?
+                    .strip_prefix(&self.strip_prefix)
+                    .map_err(Error::Prefix)?,
+            );
+            if self
+                .filter_prefixes
+                .iter()
+                .any(|prefix| path.starts_with(self.dest_dir.join(prefix)))
+            {
+                file.unpack(&path).map_err(Error::Unpack)?;
+            }
+        }
+        let actual_digest = format!("{:x}", archive.into_inner().into_inner().finalize());
+        (self.verify_digest == actual_digest)
+            .then_some(())
+            .ok_or_else(|| Error::Checksum(self.verify_digest.to_string(), actual_digest))
+    }
 }
 
 struct DigestingReader<R: Read, H: sha2::Digest> {
@@ -108,17 +129,45 @@ mod tests {
 
     #[test]
     fn test_fetch_strip_filter_extract_verify() {
-        let dest = tempfile::tempdir().expect("Couldn't create test tmpdir");
-        fetch_strip_filter_extract_verify(
+        let dest = tempfile::tempdir()
+            .expect("Couldn't create test tmpdir")
+            .into_path();
+        FetchBuilder::new(
             "https://mirrors.edge.kernel.org/pub/software/scm/git/git-0.01.tar.gz",
-            "git-0.01",
-            ["README"].into_iter(),
-            dest.path(),
-            "9bdf8a4198b269c5cbe4263b1f581aae885170a6cb93339a2033cb468e57dcd3",
+            dest.clone(),
         )
+        .strip_prefix("git-0.01")
+        .filter_prefixes(vec!["README"])
+        .verify_digest("9bdf8a4198b269c5cbe4263b1f581aae885170a6cb93339a2033cb468e57dcd3")
+        .build()
+        .fetch()
         .expect("Expected to fetch, strip, filter, extract, and verify");
 
-        let target_path = dest.path().join("README");
+        let target_path = dest.join("README");
         assert!(target_path.exists());
     }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("HTTP error while fetching archive: {0}")]
+    Http(#[from] Box<ureq::Error>),
+
+    #[error("Error reading archive entries: {0}")]
+    Entries(std::io::Error),
+
+    #[error("Error reading archive entry: {0}")]
+    Entry(std::io::Error),
+
+    #[error("Error reading archive file path: {0}")]
+    Path(std::io::Error),
+
+    #[error("Failed to validate archive checksum; verify {0}, but found {1}")]
+    Checksum(String, String),
+
+    #[error("Error writing archive entry: {0}")]
+    Unpack(std::io::Error),
+
+    #[error("Error stripping archive entry prefix: {0}")]
+    Prefix(StripPrefixError),
 }

--- a/libherokubuildpack/src/tgz.rs
+++ b/libherokubuildpack/src/tgz.rs
@@ -1,0 +1,134 @@
+use flate2::read::GzDecoder;
+use sha2::{
+    digest::{generic_array::GenericArray, OutputSizeUser},
+    Digest, Sha256,
+};
+use std::fs::File;
+use std::io::{Seek, SeekFrom};
+use std::path::Path;
+use std::{io::Read, path::StripPrefixError};
+use tar::Archive;
+
+/// Decompresses and untars a given .tar.gz file to the given directory.
+pub fn decompress_tarball(
+    tarball: &mut File,
+    destination: impl AsRef<Path>,
+) -> Result<(), std::io::Error> {
+    tarball.seek(SeekFrom::Start(0))?;
+    let mut archive = Archive::new(GzDecoder::new(tarball));
+    archive.unpack(destination)
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("HTTP error while fetching archive: {0}")]
+    Http(#[from] Box<ureq::Error>),
+
+    #[error("Error reading archive entries: {0}")]
+    Entries(std::io::Error),
+
+    #[error("Error reading archive entry: {0}")]
+    Entry(std::io::Error),
+
+    #[error("Error reading archive file path: {0}")]
+    Path(std::io::Error),
+
+    #[error("Failed to validate archive checksum; expected {0}, but found {1}")]
+    Checksum(String, String),
+
+    #[error("Error writing archive entry: {0}")]
+    Unpack(std::io::Error),
+
+    #[error("Error stripping archive entry prefix: {0}")]
+    Prefix(StripPrefixError),
+}
+
+/// Fetches a tarball from a url, strips component paths, filters path prefixes,
+/// extracts files to a location, and verifies a sha256 checksum. Care is taken
+/// not to write temporary files or read the entire contents into memory. In an
+/// error scenario, any archive contents already extracted will not be removed.
+///
+/// # Errors
+///
+/// See `Error` for an enumeration of error scenarios.
+pub fn fetch_strip_filter_extract_verify<'a>(
+    uri: impl AsRef<str>,
+    strip_prefix: impl AsRef<str>,
+    filter_prefixes: impl Iterator<Item = &'a str>,
+    dest_dir: impl AsRef<std::path::Path>,
+    sha256: impl AsRef<str>,
+) -> Result<(), Error> {
+    let expected_digest = sha256.as_ref();
+    let destination = dest_dir.as_ref();
+    let body = ureq::get(uri.as_ref())
+        .call()
+        .map_err(Box::new)?
+        .into_reader();
+    let mut archive = Archive::new(GzDecoder::new(DigestingReader::new(body, Sha256::new())));
+    let filters: Vec<&str> = filter_prefixes.into_iter().collect();
+    for entry in archive.entries().map_err(Error::Entries)? {
+        let mut file = entry.map_err(Error::Entry)?;
+        let path = destination.join(
+            file.path()
+                .map_err(Error::Path)?
+                .strip_prefix(strip_prefix.as_ref())
+                .map_err(Error::Prefix)?,
+        );
+        if filters
+            .iter()
+            .any(|prefix| path.starts_with(destination.join(prefix)))
+        {
+            file.unpack(&path).map_err(Error::Unpack)?;
+        }
+    }
+    let actual_digest = format!("{:x}", archive.into_inner().into_inner().finalize());
+    (expected_digest == actual_digest)
+        .then_some(())
+        .ok_or_else(|| Error::Checksum(expected_digest.to_string(), actual_digest))
+}
+
+struct DigestingReader<R: Read, H: sha2::Digest> {
+    r: R,
+    h: H,
+}
+
+impl<R: Read, H: sha2::Digest> DigestingReader<R, H> {
+    pub fn new(reader: R, hasher: H) -> DigestingReader<R, H> {
+        DigestingReader {
+            r: reader,
+            h: hasher,
+        }
+    }
+    pub fn finalize(self) -> GenericArray<u8, <H as OutputSizeUser>::OutputSize> {
+        self.h.finalize()
+    }
+}
+
+impl<R: Read, H: sha2::Digest> Read for DigestingReader<R, H> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.r.read(buf)?;
+        self.h.update(&buf[..n]);
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fetch_strip_filter_extract_verify() {
+        let dest = tempfile::tempdir().expect("Couldn't create test tmpdir");
+        fetch_strip_filter_extract_verify(
+            "https://mirrors.edge.kernel.org/pub/software/scm/git/git-0.01.tar.gz",
+            "git-0.01",
+            ["README"].into_iter(),
+            dest.path(),
+            "9bdf8a4198b269c5cbe4263b1f581aae885170a6cb93339a2033cb468e57dcd3",
+        )
+        .expect("Expected to fetch, strip, filter, extract, and verify");
+
+        let target_path = dest.path().join("README");
+        assert!(target_path.exists());
+    }
+}

--- a/libherokubuildpack/src/tgz.rs
+++ b/libherokubuildpack/src/tgz.rs
@@ -9,16 +9,6 @@ use std::path::Path;
 use std::{io::Read, path::StripPrefixError};
 use tar::Archive;
 
-/// Decompresses and untars a given .tar.gz file to the given directory.
-pub fn decompress_tarball(
-    tarball: &mut File,
-    destination: impl AsRef<Path>,
-) -> Result<(), std::io::Error> {
-    tarball.seek(SeekFrom::Start(0))?;
-    let mut archive = Archive::new(GzDecoder::new(tarball));
-    archive.unpack(destination)
-}
-
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("HTTP error while fetching archive: {0}")]


### PR DESCRIPTION
Inspired by https://github.com/heroku/buildpacks-go/blob/c61e38767970e7bf53f2569c336896fa24ec7629/src/tgz.rs.

This should be useful across a wide range of languages that use .tgz language runtime distributions with SHA256 checksums. It has a few useful features and should be fairly efficient in memory and IO usage.