### PR TITLE
Introduce CachedLayer and CachedLayerTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ## [Unreleased]
 
+- libcnb: `CachedLayer` trait introduced. Any struct that implements this trait must implement `existing_layer_strategy`. ([#522](https://github.com/heroku/libcnb.rs/pull/522))
+
 ### Fixed
 
 - libcnb-test: `TestContext::download_sbom_files` now checks the exit code of the `pack sbom download` command it runs. ([#520](https://github.com/heroku/libcnb.rs/pull/520))

--- a/examples/ruby-sample/src/layers/bundler.rs
+++ b/examples/ruby-sample/src/layers/bundler.rs
@@ -1,8 +1,10 @@
 use crate::RubyBuildpack;
 use crate::{util, RubyBuildpackError};
 use libcnb::build::BuildContext;
-use libcnb::data::layer_content_metadata::LayerTypes;
-use libcnb::layer::{ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder};
+use libcnb::layer::{
+    CachedLayer, CachedLayerTypes, ExistingLayerStrategy, LayerData, LayerResult,
+    LayerResultBuilder,
+};
 use libcnb::Env;
 use serde::Deserialize;
 use serde::Serialize;
@@ -18,15 +20,14 @@ pub(crate) struct BundlerLayer {
     pub ruby_env: Env,
 }
 
-impl Layer for BundlerLayer {
+impl CachedLayer for BundlerLayer {
     type Buildpack = RubyBuildpack;
     type Metadata = BundlerLayerMetadata;
 
-    fn types(&self) -> LayerTypes {
-        LayerTypes {
+    fn types(&self) -> CachedLayerTypes {
+        CachedLayerTypes {
             build: true,
             launch: true,
-            cache: true,
         }
     }
 

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -36,10 +36,9 @@ impl<B: Buildpack + ?Sized> BuildContext<B> {
     /// ```
     /// # use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
     /// # use libcnb::data::layer_name;
-    /// # use libcnb::data::layer_content_metadata::LayerTypes;
     /// # use libcnb::detect::{DetectContext, DetectResult};
     /// # use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
-    /// # use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
+    /// # use libcnb::layer::{CachedLayer, CachedLayerTypes, LayerResult, LayerResultBuilder, ExistingLayerStrategy, LayerData};
     /// # use libcnb::Buildpack;
     /// # use serde::Deserialize;
     /// # use serde::Serialize;
@@ -75,12 +74,20 @@ impl<B: Buildpack + ?Sized> BuildContext<B> {
     /// #    monologue: String,
     /// # }
     /// #
-    /// impl Layer for ExampleLayer {
+    /// impl CachedLayer for ExampleLayer {
     /// # type Buildpack = ExampleBuildpack;
     /// #   type Metadata = ExampleLayerMetadata;
     /// #
-    /// #    fn types(&self) -> LayerTypes {
+    /// #    fn types(&self) -> CachedLayerTypes {
     /// #        unimplemented!()
+    /// #    }
+    /// #
+    /// #    fn existing_layer_strategy(
+    /// #        &self,
+    /// #        context: &BuildContext<Self::Buildpack>,
+    /// #        layer_data: &LayerData<Self::Metadata>,
+    /// #    ) -> Result<ExistingLayerStrategy, <Self::Buildpack as Buildpack>::Error> {
+    /// #      unimplemented!()
     /// #    }
     /// #
     ///     fn create(


### PR DESCRIPTION
The current default for `existing_layer_strategy` will recreate a layer on every subsequent build. Effectively that means that if `cached: true` but `existing_layer_strategy` is not set, then the layer is not cached. This is documented in #371.

This PR introduces a CachedLayer trait that implements `Layer` such that the user MUST define `existing_layer_strategy`. 

Sidenote: Is it possible to assert some code doesn't compile? It would be good to encode this desire into the framework so someone doesn't accidentally provide a default implementation in the future, for example.


Fixes #371