### PR TITLE
Fix Clippy errors with Rust 1.66/1.67

### DIFF
--- a/examples/ruby-sample/tests/integration_test.rs
+++ b/examples/ruby-sample/tests/integration_test.rs
@@ -83,7 +83,7 @@ where
     let mut buffer = vec![];
     stream.read_to_end(&mut buffer)?;
 
-    Ok(format!("{}", String::from_utf8_lossy(&buffer)))
+    Ok(String::from_utf8_lossy(&buffer).to_string())
 }
 
 const TEST_PORT: u16 = 12346;

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -43,7 +43,7 @@ pub(crate) fn package_crate_buildpack(
 
     assemble_buildpack_directory(
         buildpack_dir.path(),
-        &cargo_manifest_dir.join("buildpack.toml"),
+        cargo_manifest_dir.join("buildpack.toml"),
         &buildpack_binaries,
     )
     .map_err(PackageCrateBuildpackError::CannotAssembleBuildpackDirectory)?;

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -45,7 +45,7 @@ pub trait Buildpack {
     /// (using its [`Debug`](std::fmt::Debug) implementation) to stderr.
     fn on_error(&self, error: crate::Error<Self::Error>) {
         eprintln!("Unhandled error:");
-        eprintln!("> {:?}", error);
+        eprintln!("> {error:?}");
         eprintln!("Buildpack will exit!");
     }
 }

--- a/libcnb/src/layer/handling.rs
+++ b/libcnb/src/layer/handling.rs
@@ -263,7 +263,7 @@ fn delete_layer<P: AsRef<Path>>(
     let layer_toml = layers_dir.as_ref().join(format!("{layer_name}.toml"));
 
     default_on_not_found(remove_dir_recursively(&layer_dir))?;
-    default_on_not_found(fs::remove_file(&layer_toml))?;
+    default_on_not_found(fs::remove_file(layer_toml))?;
 
     Ok(())
 }
@@ -541,10 +541,7 @@ mod tests {
                 assert_eq!(path, execd_file);
             }
             other => {
-                panic!(
-                    "Expected WriteLayerError::MissingExecDFile, but got {:?}",
-                    other
-                );
+                panic!("Expected WriteLayerError::MissingExecDFile, but got {other:?}");
             }
         };
     }
@@ -877,7 +874,7 @@ mod tests {
         let layers_dir = temp_dir.path();
         let layer_dir = layers_dir.join(layer_name.as_str());
 
-        fs::create_dir_all(&layer_dir).unwrap();
+        fs::create_dir_all(layer_dir).unwrap();
         fs::write(
             layers_dir.join(format!("{layer_name}.toml")),
             r#"
@@ -910,7 +907,7 @@ mod tests {
         let layers_dir = temp_dir.path();
         let layer_dir = layers_dir.join(layer_name.as_str());
 
-        fs::create_dir_all(&layer_dir).unwrap();
+        fs::create_dir_all(layer_dir).unwrap();
         fs::write(
             layers_dir.join(format!("{layer_name}.toml")),
             r#"
@@ -940,7 +937,7 @@ mod tests {
         let layers_dir = temp_dir.path();
         let layer_dir = layers_dir.join(layer_name.as_str());
 
-        fs::create_dir_all(&layer_dir).unwrap();
+        fs::create_dir_all(layer_dir).unwrap();
 
         match super::read_layer::<GenericMetadata, _>(layers_dir, &layer_name) {
             Ok(Some(layer_data)) => {

--- a/libcnb/src/layer/tests.rs
+++ b/libcnb/src/layer/tests.rs
@@ -472,7 +472,7 @@ fn update_with_incompatible_metadata_replace() {
 
     // Create a layer by hand that has incompatible metadata
     let test_layer_dir = temp_dir.path().join("layers").join(layer_name.as_str());
-    fs::create_dir_all(&test_layer_dir).unwrap();
+    fs::create_dir_all(test_layer_dir).unwrap();
 
     let test_layer_toml = temp_dir
         .path()
@@ -480,7 +480,7 @@ fn update_with_incompatible_metadata_replace() {
         .join(format!("{layer_name}.toml"));
 
     fs::write(
-        &test_layer_toml,
+        test_layer_toml,
         r#"
 [metadata]
 v = "3.2.1"
@@ -562,7 +562,7 @@ fn update_with_incompatible_metadata_recreate() {
 
     // Create a layer by hand that has incompatible metadata
     let test_layer_dir = temp_dir.path().join("layers").join(layer_name.as_str());
-    fs::create_dir_all(&test_layer_dir).unwrap();
+    fs::create_dir_all(test_layer_dir).unwrap();
 
     let test_layer_toml = temp_dir
         .path()
@@ -570,7 +570,7 @@ fn update_with_incompatible_metadata_recreate() {
         .join(format!("{layer_name}.toml"));
 
     fs::write(
-        &test_layer_toml,
+        test_layer_toml,
         r#"
 [metadata]
 versi_on = "3.2.1"
@@ -641,7 +641,7 @@ fn error_handling_no_metadata_toml() {
     let layer_name = random_layer_name();
 
     let layer_dir = temp_dir.path().join("layers").join(layer_name.as_str());
-    fs::create_dir_all(&layer_dir).unwrap();
+    fs::create_dir_all(layer_dir).unwrap();
 
     let handle_layer_result = handle_layer(&context, layer_name, TestLayer::default()).unwrap();
 
@@ -671,7 +671,7 @@ fn error_handling_no_directory() {
         .join(format!("{layer_name}.toml"));
 
     fs::write(
-        &layer_toml_path,
+        layer_toml_path,
         r#"
 [metadata]
 version = "3.2.1"

--- a/libcnb/src/platform.rs
+++ b/libcnb/src/platform.rs
@@ -87,7 +87,7 @@ mod tests {
         let env_dir = tmpdir.path().join("env");
         fs::create_dir(&env_dir).unwrap();
         let dummy_dir = env_dir.join("foobar");
-        fs::create_dir(&dummy_dir).unwrap();
+        fs::create_dir(dummy_dir).unwrap();
         fs::write(env_dir.join("FOO"), "BAR").unwrap();
 
         let result = read_platform_env(tmpdir.path());
@@ -104,7 +104,7 @@ mod tests {
         let dummy_dir = env_dir.join("foobar");
         fs::create_dir(&dummy_dir).unwrap();
         let dst_symlink = env_dir.join("data");
-        std::os::unix::fs::symlink(&dummy_dir, &dst_symlink).unwrap();
+        std::os::unix::fs::symlink(&dummy_dir, dst_symlink).unwrap();
         fs::write(env_dir.join("FOO"), "BAR").unwrap();
 
         let result = read_platform_env(tmpdir.path());

--- a/libherokubuildpack/src/error.rs
+++ b/libherokubuildpack/src/error.rs
@@ -63,7 +63,7 @@ where
     match error {
         libcnb::Error::BuildpackError(buildpack_error) => f(buildpack_error),
         libcnb_error => {
-            log_error("Internal Buildpack Error", format!("{}", libcnb_error));
+            log_error("Internal Buildpack Error", libcnb_error.to_string());
         }
     }
 }

--- a/libherokubuildpack/src/tar.rs
+++ b/libherokubuildpack/src/tar.rs
@@ -1,6 +1,6 @@
 use flate2::read::GzDecoder;
 use std::fs::File;
-use std::io::{Seek, SeekFrom};
+use std::io::Seek;
 use std::path::Path;
 use tar::Archive;
 
@@ -9,7 +9,7 @@ pub fn decompress_tarball(
     tarball: &mut File,
     destination: impl AsRef<Path>,
 ) -> Result<(), std::io::Error> {
-    tarball.seek(SeekFrom::Start(0))?;
+    tarball.rewind()?;
     let mut archive = Archive::new(GzDecoder::new(tarball));
     archive.unpack(destination)
 }


### PR DESCRIPTION
Rust 1.66.0 is due out as stable today.

Under that version the following new Clippy errors are shown:

```
$ cargo clippy --all-targets
warning: the borrowed expression implements the required traits
   --> libcnb/src/layer/handling.rs:266:42
    |
266 |     default_on_not_found(fs::remove_file(&layer_toml))?;
    |                                          ^^^^^^^^^^^ help: change this to: `layer_toml`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `#[warn(clippy::needless_borrow)]` on by default

warning: variables can be used directly in the `format!` string
  --> libcnb/src/buildpack.rs:48:9
   |
48 |         eprintln!("> {:?}", error);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
note: the lint level is defined here
  --> libcnb/src/lib.rs:2:9
   |
2  | #![warn(clippy::pedantic)]
   |         ^^^^^^^^^^^^^^^^
   = note: `#[warn(clippy::uninlined_format_args)]` implied by `#[warn(clippy::pedantic)]`
help: change this to
   |
48 -         eprintln!("> {:?}", error);
48 +         eprintln!("> {error:?}");
   |

warning: `libcnb` (lib) generated 2 warnings
warning: the borrowed expression implements the required traits
  --> libcnb-test/src/build.rs:46:9
   |
46 |         &cargo_manifest_dir.join("buildpack.toml"),
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `cargo_manifest_dir.join("buildpack.toml")`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
   = note: `#[warn(clippy::needless_borrow)]` on by default

warning: `libcnb-test` (lib) generated 1 warning
warning: `libcnb-test` (lib test) generated 1 warning (1 duplicate)
warning: variables can be used directly in the `format!` string
  --> libherokubuildpack/src/error.rs:66:51
   |
66 |             log_error("Internal Buildpack Error", format!("{}", libcnb_error));
   |                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
note: the lint level is defined here
  --> libherokubuildpack/src/lib.rs:3:9
   |
3  | #![warn(clippy::pedantic)]
   |         ^^^^^^^^^^^^^^^^
   = note: `#[warn(clippy::uninlined_format_args)]` implied by `#[warn(clippy::pedantic)]`
help: change this to
   |
66 -             log_error("Internal Buildpack Error", format!("{}", libcnb_error));
66 +             log_error("Internal Buildpack Error", format!("{libcnb_error}"));
   |

warning: `libherokubuildpack` (lib) generated 1 warning
warning: `libherokubuildpack` (lib test) generated 1 warning (1 duplicate)
warning: the borrowed expression implements the required traits
   --> libcnb/src/layer/handling.rs:880:28
    |
880 |         fs::create_dir_all(&layer_dir).unwrap();
    |                            ^^^^^^^^^^ help: change this to: `layer_dir`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> libcnb/src/layer/handling.rs:913:28
    |
913 |         fs::create_dir_all(&layer_dir).unwrap();
    |                            ^^^^^^^^^^ help: change this to: `layer_dir`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> libcnb/src/layer/handling.rs:943:28
    |
943 |         fs::create_dir_all(&layer_dir).unwrap();
    |                            ^^^^^^^^^^ help: change this to: `layer_dir`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> libcnb/src/layer/tests.rs:475:24
    |
475 |     fs::create_dir_all(&test_layer_dir).unwrap();
    |                        ^^^^^^^^^^^^^^^ help: change this to: `test_layer_dir`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> libcnb/src/layer/tests.rs:483:9
    |
483 |         &test_layer_toml,
    |         ^^^^^^^^^^^^^^^^ help: change this to: `test_layer_toml`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> libcnb/src/layer/tests.rs:565:24
    |
565 |     fs::create_dir_all(&test_layer_dir).unwrap();
    |                        ^^^^^^^^^^^^^^^ help: change this to: `test_layer_dir`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> libcnb/src/layer/tests.rs:573:9
    |
573 |         &test_layer_toml,
    |         ^^^^^^^^^^^^^^^^ help: change this to: `test_layer_toml`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> libcnb/src/layer/tests.rs:644:24
    |
644 |     fs::create_dir_all(&layer_dir).unwrap();
    |                        ^^^^^^^^^^ help: change this to: `layer_dir`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> libcnb/src/layer/tests.rs:674:9
    |
674 |         &layer_toml_path,
    |         ^^^^^^^^^^^^^^^^ help: change this to: `layer_toml_path`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
  --> libcnb/src/platform.rs:90:24
   |
90 |         fs::create_dir(&dummy_dir).unwrap();
   |                        ^^^^^^^^^^ help: change this to: `dummy_dir`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> libcnb/src/platform.rs:107:48
    |
107 |         std::os::unix::fs::symlink(&dummy_dir, &dst_symlink).unwrap();
    |                                                ^^^^^^^^^^^^ help: change this to: `dst_symlink`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: `libcnb` (lib test) generated 13 warnings (2 duplicates)
```


And then under Rust 1.67.0 (currently in beta, and what I run locally), the following additional errors are shown:

```
$ cargo clippy --all-targets
warning: used `seek` to go to the start of the stream
  --> libherokubuildpack/src/tar.rs:12:13
   |
12 |     tarball.seek(SeekFrom::Start(0))?;
   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `rewind()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#seek_to_start_instead_of_rewind
   = note: `#[warn(clippy::seek_to_start_instead_of_rewind)]` on by default

warning: `libherokubuildpack` (lib) generated 1 warning
warning: `libherokubuildpack` (lib test) generated 1 warning (1 duplicate)
warning: variables can be used directly in the `format!` string
   --> libcnb/src/layer/handling.rs:544:17
    |
544 | /                 panic!(
545 | |                     "Expected WriteLayerError::MissingExecDFile, but got {:?}",
546 | |                     other
547 | |                 );
    | |_________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: `#[warn(clippy::uninlined_format_args)]` on by default

warning: `libcnb` (lib test) generated 1 warning
```

The vast majority of these were fixed using the `--fix` option to `cargo clippy`.

GUS-W-12225195.