### PR TITLE
Prepare 0.11.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ## [Unreleased]
 
+## [0.11.2] 2022-12-15
+
 ### Fixed
 
 - libcnb-test: `TestContext::download_sbom_files` now checks the exit code of the `pack sbom download` command it runs. ([#520](https://github.com/heroku/libcnb.rs/pull/520))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.1"
+version = "0.11.2"
 rust-version = "1.64"
 edition = "2021"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
-libcnb = { version = "0.11.1", path = "libcnb" }
-libcnb-data = { version = "0.11.1", path = "libcnb-data" }
-libcnb-package = { version = "0.11.1", path = "libcnb-package" }
-libcnb-proc-macros = { version = "0.11.1", path = "libcnb-proc-macros" }
-libcnb-test = { version = "0.11.1", path = "libcnb-test" }
+libcnb = { version = "0.11.2", path = "libcnb" }
+libcnb-data = { version = "0.11.2", path = "libcnb-data" }
+libcnb-package = { version = "0.11.2", path = "libcnb-package" }
+libcnb-proc-macros = { version = "0.11.2", path = "libcnb-proc-macros" }
+libcnb-test = { version = "0.11.2", path = "libcnb-test" }


### PR DESCRIPTION
It has been some time since the last release. Nothing major in 0.11.2, but luckily no breaking changes to people can easily upgrade and get slightly faster compiles, bugfixes and the new `CommandExt` helper.