### PR TITLE
Fix typo in the rustdoc for `libcnb_runtime_build`

### DIFF
--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -151,7 +151,7 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
 
 /// Build entry point for this framework.
 ///
-/// Exposed only to allow for advanced use-cases where detect is programmatically invoked.
+/// Exposed only to allow for advanced use-cases where build is programmatically invoked.
 #[doc(hidden)]
 pub fn libcnb_runtime_build<B: Buildpack>(
     buildpack: &B,


### PR DESCRIPTION
`s/detect/build/`