### PR TITLE
Expose `store.toml` contents in `BuildContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ## [Unreleased]
 
+### Added
+
+- libcnb: Add `store` field to `BuildContext`, exposing the contents of `store.toml` if present. ([#543](https://github.com/heroku/libcnb.rs/pull/543))
+
 ## [0.11.2] 2022-12-15
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ members = [
     "libcnb-test",
     "libherokubuildpack",
     "test-buildpacks/readonly-layer-files",
-    "test-buildpacks/sbom"
+    "test-buildpacks/sbom",
+    "test-buildpacks/store",
 ]
 
 [workspace.package]

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -20,6 +20,7 @@ pub struct BuildContext<B: Buildpack + ?Sized> {
     pub platform: B::Platform,
     pub buildpack_plan: BuildpackPlan,
     pub buildpack_descriptor: SingleBuildpackDescriptor<B::Metadata>,
+    pub store: Option<Store>,
 }
 
 impl<B: Buildpack + ?Sized> BuildContext<B> {
@@ -193,8 +194,8 @@ impl BuildResultBuilder {
         self
     }
 
-    pub fn store(mut self, store: Store) -> Self {
-        self.store = Some(store);
+    pub fn store<S: Into<Store>>(mut self, store: S) -> Self {
+        self.store = Some(store.into());
         self
     }
 

--- a/libcnb/src/error.rs
+++ b/libcnb/src/error.rs
@@ -39,6 +39,9 @@ pub enum Error<E> {
     #[error("Cannot read buildpack descriptor (buildpack.toml): {0}")]
     CannotReadBuildpackDescriptor(TomlFileError),
 
+    #[error("Cannot read store (store.toml): {0}")]
+    CannotReadStore(TomlFileError),
+
     #[error("Cannot write build plan: {0}")]
     CannotWriteBuildPlan(TomlFileError),
 

--- a/libcnb/src/layer/tests.rs
+++ b/libcnb/src/layer/tests.rs
@@ -920,6 +920,7 @@ fn build_context(temp_dir: &TempDir) -> BuildContext<TestBuildpack> {
             stacks: vec![Stack::Any],
             metadata: GenericMetadata::default(),
         },
+        store: None,
     }
 }
 

--- a/libcnb/src/util.rs
+++ b/libcnb/src/util.rs
@@ -8,12 +8,14 @@ pub(crate) fn default_on_not_found<T: Default>(
     result: Result<T, std::io::Error>,
 ) -> Result<T, std::io::Error> {
     match result {
-        Err(io_error) => match io_error.kind() {
-            std::io::ErrorKind::NotFound => Ok(T::default()),
-            _ => Err(io_error),
-        },
+        Err(io_error) if is_not_found_error_kind(&io_error) => Ok(T::default()),
         other => other,
     }
+}
+
+/// Checks if the error kind of the given [`std::io::Error`]  is [`std::io::ErrorKind::NotFound`].
+pub(crate) fn is_not_found_error_kind(error: &std::io::Error) -> bool {
+    matches!(error.kind(), std::io::ErrorKind::NotFound)
 }
 
 /// Recursively removes the given path, similar to [`std::fs::remove_dir_all`].

--- a/test-buildpacks/store/Cargo.toml
+++ b/test-buildpacks/store/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "store"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+libcnb.workspace = true
+toml = "0.5.10"
+
+[dev-dependencies]
+libcnb-test.workspace = true

--- a/test-buildpacks/store/buildpack.toml
+++ b/test-buildpacks/store/buildpack.toml
@@ -1,0 +1,9 @@
+api = "0.8"
+
+[buildpack]
+id = "libcnb-test-buildpacks/store"
+version = "0.1.0"
+name = "libcnb test buildpack: store"
+
+[[stacks]]
+id = "*"

--- a/test-buildpacks/store/src/main.rs
+++ b/test-buildpacks/store/src/main.rs
@@ -1,0 +1,53 @@
+// Enable Clippy lints that are disabled by default.
+// https://rust-lang.github.io/rust-clippy/stable/index.html
+#![warn(clippy::pedantic)]
+// This lint is too noisy and enforces a style that reduces readability in many cases.
+#![allow(clippy::module_name_repetitions)]
+
+use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
+use libcnb::data::store::Store;
+use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
+use libcnb::generic::{GenericMetadata, GenericPlatform};
+use libcnb::{buildpack_main, Buildpack};
+use std::io::Error;
+use toml::toml;
+
+pub struct TestBuildpack;
+
+impl Buildpack for TestBuildpack {
+    type Platform = GenericPlatform;
+    type Metadata = GenericMetadata;
+    type Error = TestBuildpackError;
+
+    fn detect(&self, _context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
+        DetectResultBuilder::pass().build()
+    }
+
+    fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
+        println!("context.store={:?}", context.store);
+
+        BuildResultBuilder::new()
+            .store(Store {
+                metadata: (toml! {
+                    pinned_language_runtime_version = "1.2.3"
+                })
+                .as_table()
+                .cloned()
+                .expect("TOML value created with macro wasn't of expected type table!"),
+            })
+            .build()
+    }
+}
+
+#[derive(Debug)]
+pub enum TestBuildpackError {
+    IOError(std::io::Error),
+}
+
+impl From<std::io::Error> for TestBuildpackError {
+    fn from(io_error: Error) -> Self {
+        Self::IOError(io_error)
+    }
+}
+
+buildpack_main!(TestBuildpack);

--- a/test-buildpacks/store/tests/integration_test.rs
+++ b/test-buildpacks/store/tests/integration_test.rs
@@ -1,0 +1,28 @@
+//! Integration tests using libcnb-test.
+//!
+//! All integration tests are skipped by default (using the `ignore` attribute),
+//! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
+
+// Enable Clippy lints that are disabled by default.
+// https://rust-lang.github.io/rust-clippy/stable/index.html
+#![warn(clippy::pedantic)]
+
+use libcnb_test::{assert_contains, BuildConfig, TestRunner};
+use std::env::temp_dir;
+use std::fs;
+
+#[test]
+#[ignore = "integration test"]
+fn test() {
+    let empty_app_dir = temp_dir().join("empty-app-dir");
+    fs::create_dir_all(&empty_app_dir).unwrap();
+
+    let build_config = BuildConfig::new("heroku/builder:22", &empty_app_dir);
+
+    TestRunner::default().build(&build_config, |context| {
+        assert_contains!(&context.pack_stdout, "context.store=None");
+        context.rebuild(&build_config, |context| {
+            assert_contains!(&context.pack_stdout, "context.store=Some(Store { metadata: {\"pinned_language_runtime_version\": String(\"1.2.3\")} })");
+        });
+    });
+}


### PR DESCRIPTION
Up until now, it wasn't possible to access to contents of `store.toml` via libcnb. This PR adds a minimal implementation and tests for accessing that data. I deliberately limited this PR to just that and not address issues with `store.toml` handling in general:

- Ideally, `store.toml` should be typed like layer metadata is. Working with raw TOML with Rust is tedious, especially when we need a specific TOML type (store.toml metadata needs to be a `toml::value::Table`. However, this is not just a matter of slapping a new associated type on `Buildpack` and use that to parse the metadata. We need a mechanism to handle incompatibilities (like we do with layer metadata). (I filed: #544)
- Right now, if the `BuildResult` does not contain `store.toml` data (i.e. that field is `None`), the file on disk is not modified. This is inconsistent with i.e. layers where the metadata needs to be written every time to keep it around. There is currently no way to remove all metadata either since `None` signals "don't change" instead of "no data". (I filed: #545)

Without the fixes for the issues above, this PR a non breaking change we can roll out immediately as a point release to provide the needed functionality to buildpacks that need it and tackle the harder breaking changes separately. 

Closes GUS-W-12299144