### PR TITLE
Introduce a release script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "examples/basics",
     "examples/execd",
     "examples/ruby-sample",
+    "scripts/prepare",
     "libcnb",
     "libcnb-cargo",
     "libcnb-data",

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,19 +6,19 @@ easier to gauge cross-crate compatibility.
 ## Prepare Release
 
 1. Create a new branch for the upcoming release
-2. Update [Cargo.toml](./Cargo.toml) in the root of the repository:
-   1. In the `workspace.package` table, update `version` to the new version
-   2. In the `workspace.dependencies` table, update the `version` of each of the repository-local dependencies to the new version
-3. Update [CHANGELOG.md](./CHANGELOG.md)
-   1. Move all content under `## [Unreleased]` to a new section that follows this pattern: `## [VERSION] YYYY-MM-DD`
-   2. If appropriate, add a high-level summary of changes at the beginning of the new section
-4. Commit the changes, push them and open a PR targeting `main`
+2. Run the prerelease script:
+
+```
+$ cargo run -p prepare
+```
+
+3. Commit the changes, push them and open a PR targeting `main`
 
 ## Release
 
 1. After peer-review, merge the release preparation PR
 2. On your local machine, run `git switch main && git pull` to ensure you're on the `main` branch with the latest changes
-3. Create a (lightweight) Git tag for the release and push it: (i.e. for version `1.1.38`: `git tag v1.1.38 && git push origin v1.1.38`) 
+3. Create a (lightweight) Git tag for the release and push it: (i.e. for version `1.1.38`: `git tag v1.1.38 && git push origin v1.1.38`)
 4. Use `cargo` to release all crates, making sure to release dependencies of other crates first:
    1. `cargo publish -p libcnb-proc-macros`
    2. `cargo publish -p libcnb-data`

--- a/scripts/prepare/Cargo.toml
+++ b/scripts/prepare/Cargo.toml
@@ -6,5 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = "0.4.23"
+comrak = "0.15.0"
+regex = "1.7.1"
 semver = "1.0.16"
 toml_edit = "0.17.1"

--- a/scripts/prepare/Cargo.toml
+++ b/scripts/prepare/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "prepare"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+semver = "1.0.16"
+toml_edit = "0.17.1"

--- a/scripts/prepare/Cargo.toml
+++ b/scripts/prepare/Cargo.toml
@@ -11,3 +11,4 @@ comrak = "0.15.0"
 regex = "1.7.1"
 semver = "1.0.16"
 toml_edit = "0.17.1"
+libcnb-test = { path = "../../libcnb-test" }

--- a/scripts/prepare/src/cargo_versions.rs
+++ b/scripts/prepare/src/cargo_versions.rs
@@ -1,0 +1,143 @@
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
+pub(crate) enum SemVerLevel {
+    Major,
+    Minor,
+    Patch,
+}
+
+pub(crate) struct CargoVersionUpdate {
+    pub current_version: String,
+    pub next_version: String,
+    pub document: toml_edit::Document,
+}
+
+#[derive(Debug)]
+pub(crate) enum BePreparedError {
+    TomlError(toml_edit::TomlError),
+    SemverError(semver::Error),
+    Editorial(String),
+}
+
+/// Update Cargo.toml contents according to the SemVerLevel given (major, minor, patch)
+///
+pub(crate) fn cargo_doc_apply_level(
+    toml_string: &str,
+    level: &SemVerLevel,
+) -> Result<CargoVersionUpdate, BePreparedError> {
+    let mut document = toml_string
+        .parse::<toml_edit::Document>()
+        .map_err(BePreparedError::TomlError)?;
+
+    let current_version = workspace_version_from_doc(&document)?;
+    let next_version = next_version_from_semver(&current_version, level)?;
+
+    document["workspace"]["package"]["version"] = toml_edit::value(next_version.clone());
+
+    let dependencies = document["workspace"]["dependencies"]
+        .as_table()
+        .unwrap()
+        .iter()
+        .map(|(name, _)| name.to_string())
+        .collect::<Vec<String>>();
+
+    for dependency in dependencies.iter() {
+        document["workspace"]["dependencies"][dependency]["version"] =
+            toml_edit::value(next_version.clone());
+    }
+
+    Ok(CargoVersionUpdate {
+        current_version,
+        next_version,
+        document,
+    })
+}
+
+fn next_version_from_semver(
+    old_version: &str,
+    level: &SemVerLevel,
+) -> Result<String, BePreparedError> {
+    let mut version = semver::Version::parse(old_version).map_err(BePreparedError::SemverError)?;
+    match level {
+        SemVerLevel::Major => {
+            version.major += 1;
+            version.minor = 0;
+            version.patch = 0;
+        }
+        SemVerLevel::Minor => {
+            version.minor += 1;
+            version.patch = 0;
+        }
+        SemVerLevel::Patch => {
+            version.patch += 1;
+        }
+    }
+
+    Ok(version.to_string())
+}
+
+fn workspace_version_from_doc(doc: &toml_edit::Document) -> Result<String, BePreparedError> {
+    let version = doc["workspace"]["package"]["version"]
+        .as_value() // Needed to get raw value without formatting
+        .ok_or_else(|| {
+            BePreparedError::Editorial(String::from(
+                "Expected workspace.package.version to exist in toml document but it did not ",
+            ))
+        })?
+        .as_str()
+        .ok_or_else(|| {
+            BePreparedError::Editorial(String::from(
+                "Expected workspace.package.version to be a string but it is not",
+            ))
+        })?
+        .to_string();
+
+    Ok(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libcnb_test::assert_contains;
+
+    #[test]
+    fn cargo_doc_apply_level_updates_toml_correctly() {
+        let cargo_toml = r#"
+[workspace.package]
+version = "0.11.3"
+rust-version = "1.64"
+edition = "2021"
+license = "BSD-3-Clause"
+
+[workspace.dependencies]
+libcnb = { version = "0.11.3", path = "libcnb" }
+libcnb-data = { version = "0.11.3", path = "libcnb-data" }
+"#;
+
+        let doc = cargo_doc_apply_level(cargo_toml, &SemVerLevel::Major).unwrap();
+        assert_eq!(doc.current_version, "0.11.3");
+        assert_eq!(doc.next_version, "1.0.0");
+
+        let doc_string = doc.document.to_string();
+
+        assert_contains!(
+            doc_string,
+            r#"
+[workspace.package]
+version = "1.0.0"
+"#
+        );
+        assert_contains!(
+            doc_string,
+            r#"
+libcnb = { version = "1.0.0", path = "libcnb" }
+"#
+        );
+
+        assert_contains!(
+            doc_string,
+            r#"
+libcnb-data = { version = "1.0.0", path = "libcnb-data" }
+"#
+        );
+    }
+}

--- a/scripts/prepare/src/changelog.rs
+++ b/scripts/prepare/src/changelog.rs
@@ -1,0 +1,240 @@
+use crate::cargo_versions::{CargoVersionUpdate, SemVerLevel};
+
+use comrak::arena_tree::Node;
+use comrak::nodes::NodeValue::{Heading, List, Text};
+use comrak::nodes::{Ast, NodeHeading};
+use std::cell::RefCell;
+
+/// Convert a changelog markdown string into semver level
+///
+/// This code parses the changelog to determine the the semver level change (major, minor, patch)
+/// based on what was documented as modified.
+///
+/// Emits a warning to stderr if any one of: fixed, changed, or added sections are
+/// not present under `## [Unreleased]`
+///
+/// Errors if none of those sections are present.
+pub(crate) fn semver_from_changelog(changelog: &str) -> Result<SemVerLevel, String> {
+    let mut unreleased = None;
+    let mut fixed = None;
+    let mut changed = None;
+    let mut added = None;
+
+    let arena = comrak::Arena::new();
+    let root = comrak::parse_document(&arena, changelog, &comrak::ComrakOptions::default());
+    let mut nodes = root.children().peekable();
+
+    // Find the Unreleased section, it's a header node that has a single child, a text node
+    for node in nodes.by_ref() {
+        if is_header(node, 2) && child_contains(node, "[Unreleased]") {
+            unreleased = Some(node);
+            break;
+        }
+    }
+
+    if unreleased.is_none() {
+        return Err(String::from(
+            "Missing the `## Unreleased` header from CHANGELOG.md",
+        ));
+    }
+
+    // Check search sub headers to find fixed, added, and changed header nodes
+    for node in nodes {
+        if is_header(node, 2) {
+            // Too far
+            break;
+        }
+
+        if is_header(node, 3) {
+            if child_contains(node, "Fixed") {
+                fixed = Some(node)
+            }
+            if child_contains(node, "Added") {
+                added = Some(node)
+            }
+            if child_contains(node, "Changed") {
+                changed = Some(node)
+            }
+        }
+    }
+
+    [
+        (changed, SemVerLevel::Major, "Changed"),
+        (added, SemVerLevel::Minor, "Added"),
+        (fixed, SemVerLevel::Patch, "Fixed"),
+    ]
+    .iter()
+    .filter_map(|(node, level, name)| {
+        node.and_then(|node| Some((node, level))) // Unwrap Some(node) and continue
+            .or_else(|| {
+                // Emit warning and filter
+                eprintln!("Warning: Changelog.md is missing a `### {}` section", name);
+                None
+            })
+    })
+    .find_map(|(node, level)| {
+        if sibling_is_list(node) {
+            Some(level.clone())
+        } else {
+            None
+        }
+    })
+    .ok_or_else(|| String::from("No changes found in the CHANGELOG.md cannot continue"))
+}
+
+#[derive(Debug)]
+pub(crate) enum ChangelogError {
+    RegexError(regex::Error),
+    CannotFindUnreleasedSection(String),
+}
+
+fn version_ymd_md_string<D: chrono::Datelike>(version: &str, now: D) -> String {
+    format!(
+        "## [{}] {}-{:0width$}-{:0width$}",
+        version,
+        now.year(),
+        now.month(),
+        now.day(),
+        width = 2,
+    )
+}
+
+/// LOL
+pub(crate) fn changelog_doc_update_versions(
+    contents: &str,
+    cargo_doc: &CargoVersionUpdate,
+) -> Result<String, ChangelogError> {
+    let unreleased_re =
+        regex::Regex::new(r"## \[Unreleased\]").map_err(ChangelogError::RegexError)?;
+
+    if unreleased_re.is_match(contents) {
+        let new_contents = unreleased_re
+            .replacen(
+                contents,
+                1,
+                format!(
+                    "## [Unreleased]\n\n{}",
+                    version_ymd_md_string(&cargo_doc.next_version, chrono::Local::now())
+                ),
+            )
+            .to_string();
+        Ok(new_contents)
+    } else {
+        Err(ChangelogError::CannotFindUnreleasedSection(String::from(
+            "Could not find `## [Unreleased]` in changelog",
+        )))
+    }
+}
+
+fn is_header(node: &Node<RefCell<Ast>>, desired_level: u32) -> bool {
+    if let Heading(NodeHeading { level, .. }) = &(*node.data.borrow()).value {
+        if level == &desired_level {
+            return true;
+        }
+    }
+    false
+}
+
+fn child_contains(node: &Node<RefCell<Ast>>, desired_contains: &str) -> bool {
+    if let Some(node) = node.first_child() {
+        if let Text(contents) = &(*node.data.borrow()).value {
+            if std::str::from_utf8(contents)
+                .unwrap()
+                .contains(desired_contains)
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn sibling_is_list(node: &Node<RefCell<Ast>>) -> bool {
+    if let Some(node) = node.next_sibling() {
+        if let List(_) = &(*node.data.borrow()).value {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ymd_version() {
+        let date = chrono::NaiveDate::from_ymd_opt(2000, 1, 12).unwrap();
+        assert_eq!(
+            "## [1.1.1] 2000-01-12",
+            version_ymd_md_string("1.1.1", date)
+        );
+    }
+
+    #[test]
+    fn semver_errors_without_unreleased() {
+        let changelog = r"
+
+## Ooops unr3l3453d accidentally deleted
+            ";
+        assert!(semver_from_changelog(changelog).is_err());
+    }
+
+    #[test]
+    fn semver_from_changelog_finds_major_minor_patch_okay() {
+        let changelog = r"
+## [Unreleased]
+
+### Fixed
+
+- The world
+
+### Changed
+
+- The game
+
+### Added
+
+- Good measure
+            ";
+        assert_eq!(
+            SemVerLevel::Major,
+            semver_from_changelog(changelog).unwrap()
+        );
+
+        let changelog = r"
+## [Unreleased]
+
+### Fixed
+
+- The world
+
+### Changed
+
+### Added
+
+- Good measure
+";
+        assert_eq!(
+            SemVerLevel::Minor,
+            semver_from_changelog(changelog).unwrap()
+        );
+
+        let changelog = r"
+## [Unreleased]
+
+### Fixed
+
+- The world
+
+### Changed
+
+### Added
+
+";
+        assert_eq!(
+            SemVerLevel::Patch,
+            semver_from_changelog(changelog).unwrap()
+        );
+    }
+}

--- a/scripts/prepare/src/main.rs
+++ b/scripts/prepare/src/main.rs
@@ -1,3 +1,7 @@
+use comrak::arena_tree::Node;
+use comrak::nodes::NodeValue::{Heading, List, Text};
+use comrak::nodes::{Ast, NodeHeading};
+use std::cell::RefCell;
 use std::{
     env,
     path::{Path, PathBuf},
@@ -6,24 +10,168 @@ use std::{
 
 fn main() {
     let root = libcnb_root().expect("Could not determine root of libcnb.rs");
-    println!("Found project root at {}", root.display());
-
+    let changelog = root.join("CHANGELOG.md");
     let cargo = root.join("Cargo.toml");
+
+    println!("Found project root at {}", root.display());
+    println!("\n## Detecting semver from CHANGELOG.md\n");
+
+    let changelog_contents =
+        std::fs::read_to_string(&changelog).expect("Could not read in CHANGELOG.md");
+    let semver_level = semver_from_changelog(&changelog_contents)
+        .expect("Could not determine SemVer from CHANGELOG.md");
+
+    println!("semver change is: {:?}", semver_level);
     println!("\n## Updating Cargo.toml {}\n", cargo.display());
 
-    let level = SemVerLevel::Patch;
     let mut doc = toml_doc_from(&cargo).expect("Could not parse Cargo.toml");
 
     let old_version =
         workspace_version_from_doc(&doc).expect("Could not parse version from Cargo.toml");
-    println!("Last release was version '{}'", old_version);
+    println!("Last release was version: '{}'", old_version);
 
-    let new_version = apply_semver(&old_version, level).expect("Could not parse version as semver");
+    let new_version =
+        apply_semver(&old_version, semver_level).expect("Could not parse version as semver");
     println!("Updated version {}", new_version);
 
     update_versions_in_doc(&mut doc, &new_version);
 
-    write_doc_to_file(doc, &cargo).expect("Could not update Cargo.toml")
+    write_doc_to_file(doc, &cargo).expect("Could not update Cargo.toml");
+
+    println!("\n## Updating CHANGELOG.md {}\n", changelog.display());
+
+    let unreleased_re = regex::Regex::new(r"## \[Unreleased\]").expect("Regex is invalid");
+    if unreleased_re.is_match(&changelog_contents) {
+        let changelog_contents = unreleased_re
+            .replacen(
+                &changelog_contents,
+                1,
+                format!(
+                    "## [Unreleased]\n\n{}",
+                    version_ymd_md_string(&new_version, chrono::Local::now())
+                ),
+            )
+            .to_string();
+
+        std::fs::write(changelog, changelog_contents).expect("Could not update CHANGELOG.md");
+    } else {
+        panic!("Could not find `## [Unreleased]` in changelog")
+    }
+}
+
+fn is_header(node: &Node<RefCell<Ast>>, desired_level: u32) -> bool {
+    if let Heading(NodeHeading { level, .. }) = &(*node.data.borrow()).value {
+        if level == &desired_level {
+            return true;
+        }
+    }
+    false
+}
+
+fn child_contains(node: &Node<RefCell<Ast>>, desired_contains: &str) -> bool {
+    if let Some(node) = node.first_child() {
+        if let Text(contents) = &(*node.data.borrow()).value {
+            if std::str::from_utf8(&contents)
+                .unwrap()
+                .contains(desired_contains)
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn sibling_is_list(node: &Node<RefCell<Ast>>) -> bool {
+    if let Some(node) = node.next_sibling() {
+        if let List(_) = &(*node.data.borrow()).value {
+            return true;
+        }
+    }
+    false
+}
+
+fn semver_from_changelog(changelog: &str) -> Result<SemVerLevel, BePreparedError> {
+    let arena = comrak::Arena::new();
+    let root = comrak::parse_document(&arena, changelog, &comrak::ComrakOptions::default());
+    let mut nodes = root.children().peekable();
+
+    // Find the Unreleased section, it's a header node that has a single child, a text node
+    let mut unreleased = None;
+    while let Some(node) = nodes.next() {
+        if is_header(node, 2) && child_contains(node, "[Unreleased]") {
+            unreleased = Some(node);
+            break;
+        }
+    }
+
+    if unreleased.is_none() {
+        return Err(BePreparedError::Editorial(String::from(
+            "Missing the `## Unreleased` header from CHANGELOG.md",
+        )));
+    }
+
+    // Check search sub headers to find fixed, added, and changed header nodes
+    let mut fixed = None;
+    let mut changed = None;
+    let mut added = None;
+    while let Some(node) = nodes.next() {
+        if is_header(node, 2) {
+            // Too far
+            break;
+        }
+
+        if is_header(node, 3) {
+            if child_contains(node, "Fixed") {
+                fixed = Some(node)
+            }
+            if child_contains(node, "Added") {
+                added = Some(node)
+            }
+            if child_contains(node, "Changed") {
+                changed = Some(node)
+            }
+        }
+    }
+
+    if let Some(node) = changed {
+        if sibling_is_list(node) {
+            return Ok(SemVerLevel::Major);
+        }
+    } else {
+        println!("Warning: Changelog.md is missing a `### Fixed` section");
+    }
+
+    if let Some(node) = added {
+        if sibling_is_list(node) {
+            return Ok(SemVerLevel::Minor);
+        }
+    } else {
+        println!("Warning: Changelog.md is missing a `### Added` section");
+    }
+
+    if let Some(node) = fixed {
+        if sibling_is_list(node) {
+            return Ok(SemVerLevel::Patch);
+        }
+    } else {
+        println!("Warning: Changelog.md is missing a `### Added` section");
+    }
+
+    Err(BePreparedError::Editorial(String::from(
+        "No changes found in the CHANGELOG.md cannot continue",
+    )))
+}
+
+fn version_ymd_md_string<D: chrono::Datelike>(version: &str, now: D) -> String {
+    format!(
+        "## [{}] {}-{:0width$}-{:0width$}",
+        version,
+        now.year(),
+        now.month(),
+        now.day(),
+        width = 2,
+    )
 }
 
 fn write_doc_to_file(doc: toml_edit::Document, cargo_toml: &Path) -> Result<(), BePreparedError> {
@@ -120,4 +268,87 @@ enum BePreparedError {
     TomlError(toml_edit::TomlError),
     SemverError(semver::Error),
     Editorial(String),
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use chrono::prelude::*;
+
+    #[test]
+    fn semver_errors_without_unreleased() {
+        let changelog = r"
+
+## Ooops unr3l3453d accidentally deleted
+            ";
+        assert!(semver_from_changelog(changelog).is_err());
+    }
+
+    #[test]
+    fn semver_from_changelog_finds_major_minor_patch_okay() {
+        let changelog = r"
+## [Unreleased]
+
+### Fixed
+
+- The world
+
+### Changed
+
+- The game
+
+### Added
+
+- Good measure
+            ";
+        assert_eq!(
+            SemVerLevel::Major,
+            semver_from_changelog(changelog).unwrap()
+        );
+
+        let changelog = r"
+## [Unreleased]
+
+### Fixed
+
+- The world
+
+### Changed
+
+### Added
+
+- Good measure
+";
+        assert_eq!(
+            SemVerLevel::Minor,
+            semver_from_changelog(changelog).unwrap()
+        );
+
+        let changelog = r"
+## [Unreleased]
+
+### Fixed
+
+- The world
+
+### Changed
+
+### Added
+
+";
+        assert_eq!(
+            SemVerLevel::Patch,
+            semver_from_changelog(changelog).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_ymd_version() {
+        let date = NaiveDate::from_ymd_opt(2000, 1, 12).unwrap();
+        assert_eq!(
+            "## [1.1.1] 2000-01-12",
+            version_ymd_md_string("1.1.1", date)
+        );
+    }
 }

--- a/scripts/prepare/src/main.rs
+++ b/scripts/prepare/src/main.rs
@@ -1,354 +1,59 @@
-use comrak::arena_tree::Node;
-use comrak::nodes::NodeValue::{Heading, List, Text};
-use comrak::nodes::{Ast, NodeHeading};
-use std::cell::RefCell;
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
-// use toml;
+use crate::cargo_versions::cargo_doc_apply_level;
+use crate::changelog::{changelog_doc_update_versions, semver_from_changelog};
+use std::{env, path::PathBuf};
+
+mod cargo_versions;
+mod changelog;
 
 fn main() {
     let root = libcnb_root().expect("Could not determine root of libcnb.rs");
     let changelog = root.join("CHANGELOG.md");
     let cargo = root.join("Cargo.toml");
+    let changelog_contents =
+        std::fs::read_to_string(&changelog).expect("Could not read in CHANGELOG.md");
+    let cargo_contents = std::fs::read_to_string(&cargo).expect("Could not read in Cargo.toml");
 
     println!("Found project root at {}", root.display());
     println!("\n## Detecting semver from CHANGELOG.md\n");
 
-    let changelog_contents =
-        std::fs::read_to_string(&changelog).expect("Could not read in CHANGELOG.md");
     let semver_level = semver_from_changelog(&changelog_contents)
         .expect("Could not determine SemVer from CHANGELOG.md");
 
     println!("semver change is: {:?}", semver_level);
     println!("\n## Updating Cargo.toml {}\n", cargo.display());
 
-    let mut doc = toml_doc_from(&cargo).expect("Could not parse Cargo.toml");
+    let cargo_doc = cargo_doc_apply_level(&cargo_contents, &semver_level)
+        .expect("Could not update Cargo.toml versions");
 
-    let old_version =
-        workspace_version_from_doc(&doc).expect("Could not parse version from Cargo.toml");
-    println!("Last release was version: '{}'", old_version);
-
-    let new_version =
-        apply_semver(&old_version, semver_level).expect("Could not parse version as semver");
-    println!("Updated version {}", new_version);
-
-    update_versions_in_doc(&mut doc, &new_version);
-
-    write_doc_to_file(doc, &cargo).expect("Could not update Cargo.toml");
-
+    println!("Last release was version: '{}'", cargo_doc.current_version);
+    println!("Updated version {}", cargo_doc.next_version);
     println!("\n## Updating CHANGELOG.md {}\n", changelog.display());
 
-    let unreleased_re = regex::Regex::new(r"## \[Unreleased\]").expect("Regex is invalid");
-    if unreleased_re.is_match(&changelog_contents) {
-        let changelog_contents = unreleased_re
-            .replacen(
-                &changelog_contents,
-                1,
-                format!(
-                    "## [Unreleased]\n\n{}",
-                    version_ymd_md_string(&new_version, chrono::Local::now())
-                ),
-            )
-            .to_string();
+    let changelog_doc = changelog_doc_update_versions(&changelog_contents, &cargo_doc)
+        .expect("Could not update CHANGELOG.md");
 
-        std::fs::write(changelog, changelog_contents).expect("Could not update CHANGELOG.md");
-    } else {
-        panic!("Could not find `## [Unreleased]` in changelog")
-    }
+    std::fs::write(cargo, cargo_doc.document.to_string()).expect("Could not write to Cargo.toml");
+    std::fs::write(changelog, changelog_doc).expect("Could not update CHANGELOG.md");
 }
 
-fn is_header(node: &Node<RefCell<Ast>>, desired_level: u32) -> bool {
-    if let Heading(NodeHeading { level, .. }) = &(*node.data.borrow()).value {
-        if level == &desired_level {
-            return true;
-        }
-    }
-    false
+#[derive(Debug)]
+enum FindRootError {
+    IoError(std::io::Error),
+    NoSuchDirectoryError(String),
 }
 
-fn child_contains(node: &Node<RefCell<Ast>>, desired_contains: &str) -> bool {
-    if let Some(node) = node.first_child() {
-        if let Text(contents) = &(*node.data.borrow()).value {
-            if std::str::from_utf8(&contents)
-                .unwrap()
-                .contains(desired_contains)
-            {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-fn sibling_is_list(node: &Node<RefCell<Ast>>) -> bool {
-    if let Some(node) = node.next_sibling() {
-        if let List(_) = &(*node.data.borrow()).value {
-            return true;
-        }
-    }
-    false
-}
-
-fn semver_from_changelog(changelog: &str) -> Result<SemVerLevel, BePreparedError> {
-    let arena = comrak::Arena::new();
-    let root = comrak::parse_document(&arena, changelog, &comrak::ComrakOptions::default());
-    let mut nodes = root.children().peekable();
-
-    // Find the Unreleased section, it's a header node that has a single child, a text node
-    let mut unreleased = None;
-    while let Some(node) = nodes.next() {
-        if is_header(node, 2) && child_contains(node, "[Unreleased]") {
-            unreleased = Some(node);
-            break;
-        }
-    }
-
-    if unreleased.is_none() {
-        return Err(BePreparedError::Editorial(String::from(
-            "Missing the `## Unreleased` header from CHANGELOG.md",
-        )));
-    }
-
-    // Check search sub headers to find fixed, added, and changed header nodes
-    let mut fixed = None;
-    let mut changed = None;
-    let mut added = None;
-    while let Some(node) = nodes.next() {
-        if is_header(node, 2) {
-            // Too far
-            break;
-        }
-
-        if is_header(node, 3) {
-            if child_contains(node, "Fixed") {
-                fixed = Some(node)
-            }
-            if child_contains(node, "Added") {
-                added = Some(node)
-            }
-            if child_contains(node, "Changed") {
-                changed = Some(node)
-            }
-        }
-    }
-
-    if let Some(node) = changed {
-        if sibling_is_list(node) {
-            return Ok(SemVerLevel::Major);
-        }
-    } else {
-        println!("Warning: Changelog.md is missing a `### Fixed` section");
-    }
-
-    if let Some(node) = added {
-        if sibling_is_list(node) {
-            return Ok(SemVerLevel::Minor);
-        }
-    } else {
-        println!("Warning: Changelog.md is missing a `### Added` section");
-    }
-
-    if let Some(node) = fixed {
-        if sibling_is_list(node) {
-            return Ok(SemVerLevel::Patch);
-        }
-    } else {
-        println!("Warning: Changelog.md is missing a `### Added` section");
-    }
-
-    Err(BePreparedError::Editorial(String::from(
-        "No changes found in the CHANGELOG.md cannot continue",
-    )))
-}
-
-fn version_ymd_md_string<D: chrono::Datelike>(version: &str, now: D) -> String {
-    format!(
-        "## [{}] {}-{:0width$}-{:0width$}",
-        version,
-        now.year(),
-        now.month(),
-        now.day(),
-        width = 2,
-    )
-}
-
-fn write_doc_to_file(doc: toml_edit::Document, cargo_toml: &Path) -> Result<(), BePreparedError> {
-    std::fs::write(cargo_toml, doc.to_string()).map_err(BePreparedError::IoError)?;
-    Ok(())
-}
-
-fn toml_doc_from(file: &Path) -> Result<toml_edit::Document, BePreparedError> {
-    let toml_string = std::fs::read_to_string(file).map_err(BePreparedError::IoError)?;
-    let doc = toml_string
-        .parse::<toml_edit::Document>()
-        .map_err(BePreparedError::TomlError)?;
-    Ok(doc)
-}
-
-fn apply_semver(old_version: &str, level: SemVerLevel) -> Result<String, BePreparedError> {
-    let mut version = semver::Version::parse(&old_version).map_err(BePreparedError::SemverError)?;
-    match level {
-        SemVerLevel::Major => {
-            version.major += 1;
-            version.minor = 0;
-            version.patch = 0;
-        }
-        SemVerLevel::Minor => {
-            version.minor += 1;
-            version.patch = 0;
-        }
-        SemVerLevel::Patch => {
-            version.patch += 1;
-        }
-    }
-
-    Ok(version.to_string())
-}
-
-fn workspace_version_from_doc(doc: &toml_edit::Document) -> Result<String, BePreparedError> {
-    let version = doc["workspace"]["package"]["version"]
-        .as_value() // Needed to get raw value without formatting
-        .ok_or(BePreparedError::Editorial(String::from(
-            "Expected workspace.package.version to exist in toml document but it did not ",
-        )))?
-        .as_str()
-        .ok_or(BePreparedError::Editorial(String::from(
-            "Expected workspace.package.version to be a string but it is not",
-        )))?
-        .to_string();
-
-    Ok(version)
-}
-
-fn update_versions_in_doc(doc: &mut toml_edit::Document, new_version: &str) {
-    doc["workspace"]["package"]["version"] = toml_edit::value(new_version.clone());
-
-    let dependencies = doc["workspace"]["dependencies"]
-        .as_table()
-        .unwrap()
-        .iter()
-        .map(|(name, _)| name.to_string())
-        .collect::<Vec<String>>();
-
-    for dependency in dependencies.iter() {
-        doc["workspace"]["dependencies"][dependency]["version"] =
-            toml_edit::value(new_version.clone());
-    }
-}
-
-fn libcnb_root() -> Result<PathBuf, BePreparedError> {
-    let path = env::current_dir().map_err(BePreparedError::IoError)?;
+fn libcnb_root() -> Result<PathBuf, FindRootError> {
+    let path = env::current_dir().map_err(FindRootError::IoError)?;
     let mut path_ancestors = path.as_path().ancestors();
 
     let root = path_ancestors
         .find(|p| matches!(p.file_name(), Some(name) if name.to_str() == Some("libcnb.rs")))
         .ok_or_else(|| {
-            BePreparedError::NoSuchDirectory(format!(
+            FindRootError::NoSuchDirectoryError(format!(
                 "Could not find directory named `libcnb.rs` in a parent of {}",
                 path.display()
             ))
         })?;
 
     Ok(root.to_path_buf())
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
-enum SemVerLevel {
-    Major,
-    Minor,
-    Patch,
-}
-
-#[derive(Debug)]
-enum BePreparedError {
-    IoError(std::io::Error),
-    NoSuchDirectory(String),
-    TomlError(toml_edit::TomlError),
-    SemverError(semver::Error),
-    Editorial(String),
-}
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-    use chrono::prelude::*;
-
-    #[test]
-    fn semver_errors_without_unreleased() {
-        let changelog = r"
-
-## Ooops unr3l3453d accidentally deleted
-            ";
-        assert!(semver_from_changelog(changelog).is_err());
-    }
-
-    #[test]
-    fn semver_from_changelog_finds_major_minor_patch_okay() {
-        let changelog = r"
-## [Unreleased]
-
-### Fixed
-
-- The world
-
-### Changed
-
-- The game
-
-### Added
-
-- Good measure
-            ";
-        assert_eq!(
-            SemVerLevel::Major,
-            semver_from_changelog(changelog).unwrap()
-        );
-
-        let changelog = r"
-## [Unreleased]
-
-### Fixed
-
-- The world
-
-### Changed
-
-### Added
-
-- Good measure
-";
-        assert_eq!(
-            SemVerLevel::Minor,
-            semver_from_changelog(changelog).unwrap()
-        );
-
-        let changelog = r"
-## [Unreleased]
-
-### Fixed
-
-- The world
-
-### Changed
-
-### Added
-
-";
-        assert_eq!(
-            SemVerLevel::Patch,
-            semver_from_changelog(changelog).unwrap()
-        );
-    }
-
-    #[test]
-    fn test_ymd_version() {
-        let date = NaiveDate::from_ymd_opt(2000, 1, 12).unwrap();
-        assert_eq!(
-            "## [1.1.1] 2000-01-12",
-            version_ymd_md_string("1.1.1", date)
-        );
-    }
 }

--- a/scripts/prepare/src/main.rs
+++ b/scripts/prepare/src/main.rs
@@ -1,0 +1,123 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+// use toml;
+
+fn main() {
+    let root = libcnb_root().expect("Could not determine root of libcnb.rs");
+    println!("Found project root at {}", root.display());
+
+    let cargo = root.join("Cargo.toml");
+    println!("\n## Updating Cargo.toml {}\n", cargo.display());
+
+    let level = SemVerLevel::Patch;
+    let mut doc = toml_doc_from(&cargo).expect("Could not parse Cargo.toml");
+
+    let old_version =
+        workspace_version_from_doc(&doc).expect("Could not parse version from Cargo.toml");
+    println!("Last release was version '{}'", old_version);
+
+    let new_version = apply_semver(&old_version, level).expect("Could not parse version as semver");
+    println!("Updated version {}", new_version);
+
+    update_versions_in_doc(&mut doc, &new_version);
+
+    write_doc_to_file(doc, &cargo).expect("Could not update Cargo.toml")
+}
+
+fn write_doc_to_file(doc: toml_edit::Document, cargo_toml: &Path) -> Result<(), BePreparedError> {
+    std::fs::write(cargo_toml, doc.to_string()).map_err(BePreparedError::IoError)?;
+    Ok(())
+}
+
+fn toml_doc_from(file: &Path) -> Result<toml_edit::Document, BePreparedError> {
+    let toml_string = std::fs::read_to_string(file).map_err(BePreparedError::IoError)?;
+    let doc = toml_string
+        .parse::<toml_edit::Document>()
+        .map_err(BePreparedError::TomlError)?;
+    Ok(doc)
+}
+
+fn apply_semver(old_version: &str, level: SemVerLevel) -> Result<String, BePreparedError> {
+    let mut version = semver::Version::parse(&old_version).map_err(BePreparedError::SemverError)?;
+    match level {
+        SemVerLevel::Major => {
+            version.major += 1;
+            version.minor = 0;
+            version.patch = 0;
+        }
+        SemVerLevel::Minor => {
+            version.minor += 1;
+            version.patch = 0;
+        }
+        SemVerLevel::Patch => {
+            version.patch += 1;
+        }
+    }
+
+    Ok(version.to_string())
+}
+
+fn workspace_version_from_doc(doc: &toml_edit::Document) -> Result<String, BePreparedError> {
+    let version = doc["workspace"]["package"]["version"]
+        .as_value() // Needed to get raw value without formatting
+        .ok_or(BePreparedError::Editorial(String::from(
+            "Expected workspace.package.version to exist in toml document but it did not ",
+        )))?
+        .as_str()
+        .ok_or(BePreparedError::Editorial(String::from(
+            "Expected workspace.package.version to be a string but it is not",
+        )))?
+        .to_string();
+
+    Ok(version)
+}
+
+fn update_versions_in_doc(doc: &mut toml_edit::Document, new_version: &str) {
+    doc["workspace"]["package"]["version"] = toml_edit::value(new_version.clone());
+
+    let dependencies = doc["workspace"]["dependencies"]
+        .as_table()
+        .unwrap()
+        .iter()
+        .map(|(name, _)| name.to_string())
+        .collect::<Vec<String>>();
+
+    for dependency in dependencies.iter() {
+        doc["workspace"]["dependencies"][dependency]["version"] =
+            toml_edit::value(new_version.clone());
+    }
+}
+
+fn libcnb_root() -> Result<PathBuf, BePreparedError> {
+    let path = env::current_dir().map_err(BePreparedError::IoError)?;
+    let mut path_ancestors = path.as_path().ancestors();
+
+    let root = path_ancestors
+        .find(|p| matches!(p.file_name(), Some(name) if name.to_str() == Some("libcnb.rs")))
+        .ok_or_else(|| {
+            BePreparedError::NoSuchDirectory(format!(
+                "Could not find directory named `libcnb.rs` in a parent of {}",
+                path.display()
+            ))
+        })?;
+
+    Ok(root.to_path_buf())
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
+enum SemVerLevel {
+    Major,
+    Minor,
+    Patch,
+}
+
+#[derive(Debug)]
+enum BePreparedError {
+    IoError(std::io::Error),
+    NoSuchDirectory(String),
+    TomlError(toml_edit::TomlError),
+    SemverError(semver::Error),
+    Editorial(String),
+}


### PR DESCRIPTION
## What

Add a script for preparing the library for a release. I've got something similar (though less solid) on my preparing my legacy buildpack for a release: https://github.com/heroku/heroku-buildpack-ruby/blob/a1dc09a93fc81a73482d6db0ecb02298001d5af4/Rakefile#L70-L104. 

While this isn't a buildpack, the preparation and updating are similar experiences.

## Why

Releasing is a chore. Automation improves quality and reduces toil.

Worst case, this is a throwaway experiment:  I want to explore automating our processes using Rust to serve as an opportunity for me to learn and to inform future efforts in scripting and automation. 

Best case, it helps us move towards more automation: For example, we could move this logic into a GitHub action. That would allow one fewer review step for the release process. 

## Demo

```
$ cargo run -p prepare
    Finished dev [unoptimized + debuginfo] target(s) in 0.37s
     Running `target/debug/prepare`
# Preparing libcnb.rs for release

 - Found project root at /Users/rschneeman/Documents/projects/work/libcnb.rs

## Detecting semver from CHANGELOG.md

- Semver change is: Major

## Updating Cargo.toml /Users/rschneeman/Documents/projects/work/libcnb.rs/Cargo.toml

- Last release was version: '0.11.3'
- Updated version: '1.0.0'

## Updating CHANGELOG.md /Users/rschneeman/Documents/projects/work/libcnb.rs/CHANGELOG.md

- Done
```

## Features

### Detect SemVer value from CHANGELOG.md

The script parses the CHANGELOG.md as an AST and knows if the next feature should be a major/minor/patch bump based on the presence/absence of Changed/Added/Fixed sections.

### Update the Cargo.toml

Once we know the semver change, the script can read in the old version from `Cargo.toml`, apply the SemVer update to that version and write the new version back to `Cargo.toml`. This process uses `toml_edit` which preserves formatting including whitespace, ordering, and comments.

### Updating the CHANGELOG.md

Finally the changelog needs to move the elements under `## [Unreleased]` to a new section with the version and date. The version was determined previously and the date is grabbed via `crono`.


## Draft comments

I'm looking for feedback on the overall idea as well as implementation-specific bits. The intent here is to be explorative so, go wild. That being said, I would like to actually ship some automation, so while it will be valuable to think about the best possible ways forward, I'm also looking for guidance on where "good enough" lies. 

Ultimately I want scripting and automation to be high-quality and robust (both to the user and maintainer), but I'm mindful that it should be pragmatic as well. 