### PR TITLE
Update `toml` to `0.6.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ libcnb-data = { version = "0.11.4", path = "libcnb-data" }
 libcnb-package = { version = "0.11.4", path = "libcnb-package" }
 libcnb-proc-macros = { version = "0.11.4", path = "libcnb-proc-macros" }
 libcnb-test = { version = "0.11.4", path = "libcnb-test" }
+toml = { version = "0.6.0" }

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -16,7 +16,7 @@ fancy-regex = { version = "0.11.0", default-features = false }
 libcnb-proc-macros.workspace = true
 serde = { version = "1.0.145", features = ["derive"] }
 thiserror = "1.0.35"
-toml = "0.5.9"
+toml.workspace = true
 
 [dev-dependencies]
 serde_test = "1.0.145"

--- a/libcnb-data/src/build_plan.rs
+++ b/libcnb-data/src/build_plan.rs
@@ -1,3 +1,4 @@
+use serde::ser::Error;
 use serde::Serialize;
 use std::collections::VecDeque;
 use toml::value::Table;
@@ -117,7 +118,7 @@ impl Require {
 
             Ok(())
         } else {
-            Err(toml::ser::Error::Custom(String::from(
+            Err(toml::ser::Error::custom(String::from(
                 "Could not be serialized as a TOML Table.",
             )))
         }

--- a/libcnb-data/src/buildpack/api.rs
+++ b/libcnb-data/src/buildpack/api.rs
@@ -7,26 +7,27 @@ use std::fmt::{Display, Formatter};
 ///
 /// This MUST be in form `<major>.<minor>` or `<major>`, where `<major>` is equivalent to `<major>.0`.
 #[derive(Deserialize, Debug, Eq, PartialEq)]
-#[serde(try_from = "&str")]
+#[serde(try_from = "String")]
 pub struct BuildpackApi {
     pub major: u64,
     pub minor: u64,
 }
 
-impl TryFrom<&str> for BuildpackApi {
+impl TryFrom<String> for BuildpackApi {
     type Error = BuildpackApiError;
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    fn try_from(value: String) -> Result<Self, Self::Error> {
         // We're not using the `semver` crate, since it only supports non-range versions of form `X.Y.Z`.
         // If no minor version is specified, it defaults to `0`.
-        let (major, minor) = value.split_once('.').unwrap_or((value, "0"));
+        let (major, minor) = &value.split_once('.').unwrap_or((&value, "0"));
+
         Ok(Self {
             major: major
                 .parse()
-                .map_err(|_| Self::Error::InvalidBuildpackApi(String::from(value)))?,
+                .map_err(|_| Self::Error::InvalidBuildpackApi(value.clone()))?,
             minor: minor
                 .parse()
-                .map_err(|_| Self::Error::InvalidBuildpackApi(String::from(value)))?,
+                .map_err(|_| Self::Error::InvalidBuildpackApi(value.clone()))?,
         })
     }
 }

--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -597,7 +597,7 @@ version = "0.0.1"
         let err = toml::from_str::<BuildpackDescriptor<GenericMetadata>>(toml_str).unwrap_err();
         assert_eq!(
             err.to_string(),
-            "data did not match any variant of untagged enum BuildpackDescriptor"
+            "data did not match any variant of untagged enum BuildpackDescriptor\n"
         );
 
         let err =

--- a/libcnb-data/src/buildpack/version.rs
+++ b/libcnb-data/src/buildpack/version.rs
@@ -8,7 +8,7 @@ use std::fmt::{Display, Formatter};
 /// This MUST be in the form `<X>.<Y>.<Z>` where `X`, `Y`, and `Z` are non-negative integers
 /// and must not contain leading zeros.
 #[derive(Deserialize, Debug, Eq, PartialEq)]
-#[serde(try_from = "&str")]
+#[serde(try_from = "String")]
 pub struct BuildpackVersion {
     pub major: u64,
     pub minor: u64,
@@ -26,10 +26,10 @@ impl BuildpackVersion {
     }
 }
 
-impl TryFrom<&str> for BuildpackVersion {
+impl TryFrom<String> for BuildpackVersion {
     type Error = BuildpackVersionError;
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    fn try_from(value: String) -> Result<Self, Self::Error> {
         // We're not using the `semver` crate, since semver versions also permit pre-release and
         // build metadata suffixes, which are not valid in buildpack versions.
         match value
@@ -47,7 +47,7 @@ impl TryFrom<&str> for BuildpackVersion {
             .as_slice()
         {
             &[major, minor, patch] => Ok(Self::new(major, minor, patch)),
-            _ => Err(Self::Error::InvalidBuildpackVersion(String::from(value))),
+            _ => Err(Self::Error::InvalidBuildpackVersion(value)),
         }
     }
 }

--- a/libcnb-package/Cargo.toml
+++ b/libcnb-package/Cargo.toml
@@ -14,5 +14,5 @@ include = ["src/**/*", "LICENSE", "README.md"]
 [dependencies]
 cargo_metadata = "0.15.0"
 libcnb-data.workspace = true
-toml = "0.5.9"
+toml.workspace = true
 which = "4.3.0"

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -18,7 +18,7 @@ libcnb-data.workspace = true
 libcnb-proc-macros.workspace = true
 serde = { version = "1.0.145", features = ["derive"] }
 thiserror = "1.0.35"
-toml = "0.5.9"
+toml.workspace = true
 
 [dev-dependencies]
 fastrand = "1.8.0"

--- a/libcnb/src/layer/handling.rs
+++ b/libcnb/src/layer/handling.rs
@@ -888,7 +888,7 @@ mod tests {
 
         match super::read_layer::<GenericMetadata, _>(layers_dir, &layer_name) {
             Err(ReadLayerError::LayerContentMetadataParseError(toml_error)) => {
-                assert_eq!(toml_error.line_col(), Some((1, 18)));
+                assert_eq!(toml_error.span(), Some(19..20));
             }
             _ => panic!("Expected ReadLayerError::LayerContentMetadataParseError!"),
         }
@@ -924,7 +924,7 @@ mod tests {
 
         match super::read_layer::<TestLayerMetadata, _>(layers_dir, &layer_name) {
             Err(ReadLayerError::LayerContentMetadataParseError(toml_error)) => {
-                assert_eq!(toml_error.line_col(), Some((6, 12)));
+                assert_eq!(toml_error.span(), Some(110..148));
             }
             _ => panic!("Expected ReadLayerError::LayerContentMetadataParseError!"),
         }

--- a/libherokubuildpack/Cargo.toml
+++ b/libherokubuildpack/Cargo.toml
@@ -35,7 +35,7 @@ sha2 = { version = "0.10.6", optional = true }
 tar = { version = "0.4.38", optional = true }
 termcolor = { version = "1.1.3", optional = true }
 thiserror = { version = "1.0.35", optional = true }
-toml = { version = "0.5.9", optional = true }
+toml = { workspace = true, optional = true }
 ureq = { version = "2.5.0", optional = true }
 
 [dev-dependencies]

--- a/libherokubuildpack/src/toml.rs
+++ b/libherokubuildpack/src/toml.rs
@@ -18,7 +18,7 @@ use std::ops::Deref;
 ///     host = "localhost"
 /// };
 ///
-/// assert_eq!(toml_select_value(vec!["config", "net", "port"], &toml), Some(&toml::Value::from(12345)));
+/// assert_eq!(toml_select_value(vec!["config", "net", "port"], &toml.into()), Some(&toml::Value::from(12345)));
 /// ```
 pub fn toml_select_value<S: AsRef<str>, K: Deref<Target = [S]>>(
     keys: K,
@@ -54,7 +54,7 @@ mod test {
         };
 
         assert_eq!(
-            toml_select_value(vec!["now", "this"], &toml),
+            toml_select_value(vec!["now", "this"], &toml.into()),
             Some(&toml::Value::from("is podracing!"))
         );
     }
@@ -68,7 +68,7 @@ mod test {
         };
 
         assert_eq!(
-            toml_select_value(vec!["now", "this", "is"], &toml),
+            toml_select_value(vec!["now", "this", "is"], &toml.into()),
             Some(&toml::Value::from("podracing"))
         );
     }
@@ -84,7 +84,7 @@ mod test {
         };
 
         assert_eq!(
-            toml_select_value(vec!["now", "this", "is"], &toml),
+            toml_select_value(vec!["now", "this", "is"], &toml.into()),
             Some(&toml::Value::from("podracing"))
         );
     }
@@ -99,7 +99,10 @@ mod test {
             is = "podracing"
         };
 
-        assert_eq!(toml_select_value(vec!["now", "this", "was"], &toml), None);
+        assert_eq!(
+            toml_select_value(vec!["now", "this", "was"], &toml.into()),
+            None
+        );
     }
 
     #[test]
@@ -110,7 +113,7 @@ mod test {
         };
 
         assert_eq!(
-            toml_select_value(vec!["translations", "leet"], &toml),
+            toml_select_value(vec!["translations", "leet"], &toml.into()),
             Some(&toml::Value::from(1337))
         );
     }
@@ -125,7 +128,7 @@ mod test {
         hash_map.insert(String::from("foo"), String::from("bar"));
 
         assert_eq!(
-            toml_select_value::<&str, Vec<&str>>(vec![], &toml),
+            toml_select_value::<&str, Vec<&str>>(vec![], &toml.into()),
             Some(&toml::Value::from(hash_map))
         );
     }

--- a/test-buildpacks/store/Cargo.toml
+++ b/test-buildpacks/store/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 libcnb.workspace = true
-toml = "0.5.10"
+toml.workspace = true
 
 [dev-dependencies]
 libcnb-test.workspace = true

--- a/test-buildpacks/store/src/main.rs
+++ b/test-buildpacks/store/src/main.rs
@@ -28,12 +28,9 @@ impl Buildpack for TestBuildpack {
 
         BuildResultBuilder::new()
             .store(Store {
-                metadata: (toml! {
+                metadata: toml! {
                     pinned_language_runtime_version = "1.2.3"
-                })
-                .as_table()
-                .cloned()
-                .expect("TOML value created with macro wasn't of expected type table!"),
+                },
             })
             .build()
     }


### PR DESCRIPTION
The new version of the `toml` crate is out and comes with a bunch of goodies: https://github.com/toml-rs/toml/blob/main/crates/toml/CHANGELOG.md#060---2023-01-23. There are some breaking changes which this PR addresses. This PR also moves the management of the `toml` create to the workspace to ensure we're using the same version across all libcnb crates.



Obsoletes #552, Ref: GUS-W-