### PR TITLE
Add `Clone` for `layer_env::Scope`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ separate changelogs for each crate were used. If you need to refer to these old 
 ### Added
 
 - `Env::get_string_lossy` as a convenience method to work with environment variables directly. Getting a value out of an `Env` and treating its contents as unicode is a common case. Using this new method can simplify buildpack code. ([#565](https://github.com/heroku/libcnb.rs/pull/565))
+- `Clone` implementation for `libcnb::layer_env::Scope`. ([#566](https://github.com/heroku/libcnb.rs/pull/566))
 
 ## [0.11.5] 2023-02-07
 

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -406,7 +406,7 @@ impl PartialOrd for ModificationBehavior {
 }
 
 /// The scope of an environment variable modification.
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub enum Scope {
     All,
     Build,


### PR DESCRIPTION
## Changelog

### Added

- `Clone` implementation for `libcnb::layer_env::Scope`. ([#566](https://github.com/heroku/libcnb.rs/pull/566))
