### PR TITLE
Fix lint failures with Rust 1.70

### DIFF
--- a/libcnb/src/exit_code.rs
+++ b/libcnb/src/exit_code.rs
@@ -1,7 +1,7 @@
-///! libcnb exit code constants
-///
-/// Constants are prefixed with the phase they're valid for since their meaning can change between
-/// different CNB phases.
+//! libcnb exit code constants
+//!
+//! Constants are prefixed with the phase they're valid for since their meaning can change between
+//! different CNB phases.
 
 pub(crate) const GENERIC_SUCCESS: i32 = 0;
 pub(crate) const GENERIC_UNSPECIFIED_ERROR: i32 = 1;


### PR DESCRIPTION
Fixes:

```
error: this is an outer doc comment and does not apply to the parent module or crate
 --> libcnb/src/exit_code.rs:1:1
  |
1 | ///! libcnb exit code constants
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_doc_comments
  = note: `-D clippy::suspicious-doc-comments` implied by `-D warnings`
help: use an inner doc comment to document the parent module or crate
  |
1 | //! libcnb exit code constants
  |
```

As seen in:
https://github.com/heroku/libcnb.rs/actions/runs/5218101938/jobs/9418580736?pr=573#step:5:231

GUS-W-13567582.