### PR TITLE
Move packaged buildpack directory out of `target/`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,4 @@ jobs:
         # Uses a non-libc image to validate the static musl cross-compilation.
         # TODO: Switch this back to using the `alpine` tag once the stable Pack CLI release supports
         # image extensions (currently newer sample alpine images fail to build with stable Pack).
-        run: pack build example-basics --builder cnbs/sample-builder@sha256:da5ff69191919f1ff30d5e28859affff8e39f23038137c7751e24a42e919c1ab --trust-builder --buildpack libcnb-packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_basics --path examples/
+        run: pack build example-basics --builder cnbs/sample-builder@sha256:da5ff69191919f1ff30d5e28859affff8e39f23038137c7751e24a42e919c1ab --trust-builder --buildpack packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_basics --path examples/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,4 @@ jobs:
         # Uses a non-libc image to validate the static musl cross-compilation.
         # TODO: Switch this back to using the `alpine` tag once the stable Pack CLI release supports
         # image extensions (currently newer sample alpine images fail to build with stable Pack).
-        run: pack build example-basics --builder cnbs/sample-builder@sha256:da5ff69191919f1ff30d5e28859affff8e39f23038137c7751e24a42e919c1ab --trust-builder --buildpack target/buildpack/x86_64-unknown-linux-musl/debug/libcnb-examples_basics --path examples/
+        run: pack build example-basics --builder cnbs/sample-builder@sha256:da5ff69191919f1ff30d5e28859affff8e39f23038137c7751e24a42e919c1ab --trust-builder --buildpack libcnb-packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_basics --path examples/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /target/
-/libcnb-packaged/
+/packaged/
 .DS_Store
 .idea
 Cargo.lock
 **/fixtures/*/target/
-**/fixtures/*/libcnb-packaged/
+**/fixtures/*/packaged/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /target/
+/libcnb-packaged/
 .DS_Store
 .idea
 Cargo.lock
 **/fixtures/*/target/
+**/fixtures/*/libcnb-packaged/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ separate changelogs for each crate were used. If you need to refer to these old 
   - `get_buildpack_target_dir` was renamed to `get_buildpack_package_dir` ([#583](https://github.com/heroku/libcnb.rs/pull/583))
 - `libherokubuildpack`: Switch the `flate2` decompression backend from `miniz_oxide` to `zlib`. ([#593](https://github.com/heroku/libcnb.rs/pull/593))
 - Bump minimum external dependency versions. ([#587](https://github.com/heroku/libcnb.rs/pull/587))
-- `libcnb-cargo`: Default location for packaged buildpacks moved from Cargo's `target` directory to `libcnb-packaged` in the Cargo workspace root. This simplifies the path and stops modification of the `target` directory which previously might have caching implications when other tools didn't expect non-Cargo output in that directory. Users that implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new locations. ([#583](https://github.com/heroku/libcnb.rs/pull/583))
+- `libcnb-cargo`: Default location for packaged buildpacks moved from Cargo's `target` directory to `packaged` in the Cargo workspace root. This simplifies the path and stops modification of the `target` directory which previously might have caching implications when other tools didn't expect non-Cargo output in that directory. Users that implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new locations. ([#583](https://github.com/heroku/libcnb.rs/pull/583))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ separate changelogs for each crate were used. If you need to refer to these old 
 - `libcnb-package`: buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
 - `libherokubuildpack`: Switch the `flate2` decompression backend from `miniz_oxide` to `zlib`. ([#593](https://github.com/heroku/libcnb.rs/pull/593))
 - Bump minimum external dependency versions. ([#587](https://github.com/heroku/libcnb.rs/pull/587))
+- `libcnb-cargo`: Default location for packaged buildpacks moved from Cargo's `target` directory to `libcnb-packaged` in the Cargo workspace root. This simplifies the path and stops modification of the `target` directory which previously might have caching implications when other tools didn't expect non-Cargo output in that directory. Users that implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new locations. ([#583](https://github.com/heroku/libcnb.rs/pull/583))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ separate changelogs for each crate were used. If you need to refer to these old 
   - `TestRunner::new` has been removed, since its only purpose was for advanced configuration that's no longer applicable. Use `TestRunner::default` instead. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
   - `LogOutput` no longer exposes `stdout_raw` and `stderr_raw`. ([#607](https://github.com/heroku/libcnb.rs/pull/607))
   - Improved wording of panic error messages. ([#619](https://github.com/heroku/libcnb.rs/pull/619) and [#620](https://github.com/heroku/libcnb.rs/pull/620))
-- `libcnb-package`: buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
+- `libcnb-package`:
+  - buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
+  - `get_buildpack_target_dir` was renamed to `get_buildpack_package_dir` ([#583](https://github.com/heroku/libcnb.rs/pull/583))
 - `libherokubuildpack`: Switch the `flate2` decompression backend from `miniz_oxide` to `zlib`. ([#593](https://github.com/heroku/libcnb.rs/pull/593))
 - Bump minimum external dependency versions. ([#587](https://github.com/heroku/libcnb.rs/pull/587))
 - `libcnb-cargo`: Default location for packaged buildpacks moved from Cargo's `target` directory to `libcnb-packaged` in the Cargo workspace root. This simplifies the path and stops modification of the `target` directory which previously might have caching implications when other tools didn't expect non-Cargo output in that directory. Users that implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new locations. ([#583](https://github.com/heroku/libcnb.rs/pull/583))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ separate changelogs for each crate were used. If you need to refer to these old 
 ### Added
 
 - `libcnb-package`: Add cross-compilation assistance for Linux `aarch64-unknown-linux-musl`. ([#577](https://github.com/heroku/libcnb.rs/pull/577))
+- `libcnb-cargo`: Add `--package-dir` command line option to control where packaged buildpacks are written to. ([#583](https://github.com/heroku/libcnb.rs/pull/583))
 - `libcnb-test`:
   - `LogOutput` now implements `std::fmt::Display`. ([#635](https://github.com/heroku/libcnb.rs/pull/635))
   - `ContainerConfig` now implements `Clone`. ([#636](https://github.com/heroku/libcnb.rs/pull/636))

--- a/libcnb-cargo/src/cli.rs
+++ b/libcnb-cargo/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(bin_name = "cargo")]
@@ -25,6 +26,9 @@ pub(crate) struct PackageArgs {
     /// Build for the target triple
     #[arg(long, default_value = "x86_64-unknown-linux-musl")]
     pub target: String,
+    /// Directory for packaged buildpacks, defaults to 'libcnb-packaged' in Cargo workspace root
+    #[arg(long)]
+    pub package_dir: Option<PathBuf>,
 }
 
 #[cfg(test)]

--- a/libcnb-cargo/src/cli.rs
+++ b/libcnb-cargo/src/cli.rs
@@ -26,7 +26,7 @@ pub(crate) struct PackageArgs {
     /// Build for the target triple
     #[arg(long, default_value = "x86_64-unknown-linux-musl")]
     pub target: String,
-    /// Directory for packaged buildpacks, defaults to 'libcnb-packaged' in Cargo workspace root
+    /// Directory for packaged buildpacks, defaults to 'packaged' in Cargo workspace root
     #[arg(long)]
     pub package_dir: Option<PathBuf>,
 }

--- a/libcnb-cargo/src/package/command.rs
+++ b/libcnb-cargo/src/package/command.rs
@@ -39,7 +39,7 @@ pub(crate) fn execute(args: &PackageArgs) -> Result<()> {
         cargo_metadata
             .workspace_root
             .into_std_path_buf()
-            .join("libcnb-packaged")
+            .join("packaged")
     });
 
     std::fs::create_dir_all(&package_dir)

--- a/libcnb-cargo/src/package/error.rs
+++ b/libcnb-cargo/src/package/error.rs
@@ -27,6 +27,9 @@ pub(crate) enum Error {
         source: cargo_metadata::Error,
     },
 
+    #[error("Could not create package directory: {0}\nError: {1}")]
+    CreatePackageDirectory(PathBuf, std::io::Error),
+
     #[error("Could not determine a target directory for buildpack with id `{buildpack_id}`")]
     TargetDirectoryLookup { buildpack_id: BuildpackId },
 

--- a/libcnb-cargo/tests/test.rs
+++ b/libcnb-cargo/tests/test.rs
@@ -25,7 +25,7 @@ fn package_buildpack_in_single_buildpack_project() {
         .unwrap();
 
     let packaged_buildpack_dir = create_packaged_buildpack_dir_resolver(
-        &fixture_dir.path().join(TARGET_DIR_NAME),
+        &fixture_dir.path().join(DEFAULT_PACKAGE_DIR_NAME),
         true,
         X86_64_UNKNOWN_LINUX_MUSL,
     )(&buildpack_id);
@@ -50,7 +50,7 @@ fn package_single_meta_buildpack_in_monorepo_buildpack_project() {
         .unwrap();
 
     let packaged_buildpack_dir_resolver = create_packaged_buildpack_dir_resolver(
-        &fixture_dir.path().join(TARGET_DIR_NAME),
+        &fixture_dir.path().join(DEFAULT_PACKAGE_DIR_NAME),
         true,
         X86_64_UNKNOWN_LINUX_MUSL,
     );
@@ -110,7 +110,7 @@ fn package_single_buildpack_in_monorepo_buildpack_project() {
         .unwrap();
 
     let packaged_buildpack_dir = create_packaged_buildpack_dir_resolver(
-        &fixture_dir.path().join(TARGET_DIR_NAME),
+        &fixture_dir.path().join(DEFAULT_PACKAGE_DIR_NAME),
         true,
         X86_64_UNKNOWN_LINUX_MUSL,
     )(&buildpack_id);
@@ -140,7 +140,7 @@ fn package_all_buildpacks_in_monorepo_buildpack_project() {
         .unwrap();
 
     let packaged_buildpack_dir_resolver = create_packaged_buildpack_dir_resolver(
-        &fixture_dir.path().join(TARGET_DIR_NAME),
+        &fixture_dir.path().join(DEFAULT_PACKAGE_DIR_NAME),
         true,
         X86_64_UNKNOWN_LINUX_MUSL,
     );
@@ -275,16 +275,15 @@ fn validate_packaged_meta_buildpack(
 }
 
 fn create_packaged_buildpack_dir_resolver(
-    cargo_target_dir: &Path,
+    package_dir: &Path,
     release: bool,
     target_triple: &str,
 ) -> impl Fn(&BuildpackId) -> PathBuf {
-    let cargo_target_dir = PathBuf::from(cargo_target_dir);
+    let package_dir = PathBuf::from(package_dir);
     let target_triple = target_triple.to_string();
 
     move |buildpack_id| {
-        cargo_target_dir
-            .join("buildpack")
+        package_dir
             .join(&target_triple)
             .join(if release { "release" } else { "debug" })
             .join(buildpack_id.as_str().replace('/', "_"))
@@ -330,5 +329,5 @@ fn copy_dir_recursively(source: &Path, destination: &Path) -> std::io::Result<()
 }
 
 const X86_64_UNKNOWN_LINUX_MUSL: &str = "x86_64-unknown-linux-musl";
-const TARGET_DIR_NAME: &str = "target";
 const CARGO_LIBCNB_BINARY_UNDER_TEST: &str = env!("CARGO_BIN_EXE_cargo-libcnb");
+const DEFAULT_PACKAGE_DIR_NAME: &str = "libcnb-packaged";

--- a/libcnb-cargo/tests/test.rs
+++ b/libcnb-cargo/tests/test.rs
@@ -330,4 +330,4 @@ fn copy_dir_recursively(source: &Path, destination: &Path) -> std::io::Result<()
 
 const X86_64_UNKNOWN_LINUX_MUSL: &str = "x86_64-unknown-linux-musl";
 const CARGO_LIBCNB_BINARY_UNDER_TEST: &str = env!("CARGO_BIN_EXE_cargo-libcnb");
-const DEFAULT_PACKAGE_DIR_NAME: &str = "libcnb-packaged";
+const DEFAULT_PACKAGE_DIR_NAME: &str = "packaged";

--- a/libcnb-package/src/lib.rs
+++ b/libcnb-package/src/lib.rs
@@ -255,14 +255,13 @@ pub fn find_buildpack_dirs(start_dir: &Path, ignore: &[PathBuf]) -> std::io::Res
 
 /// Provides a standard path to use for storing a compiled buildpack's artifacts.
 #[must_use]
-pub fn get_buildpack_target_dir(
+pub fn get_buildpack_package_dir(
     buildpack_id: &BuildpackId,
-    target_dir: &Path,
+    package_dir: &Path,
     is_release: bool,
     target_triple: &str,
 ) -> PathBuf {
-    target_dir
-        .join("buildpack")
+    package_dir
         .join(target_triple)
         .join(if is_release { "release" } else { "debug" })
         .join(default_buildpack_directory_name(buildpack_id))
@@ -270,27 +269,23 @@ pub fn get_buildpack_target_dir(
 
 #[cfg(test)]
 mod tests {
-    use crate::get_buildpack_target_dir;
+    use crate::get_buildpack_package_dir;
     use libcnb_data::buildpack_id;
     use std::path::PathBuf;
 
     #[test]
     fn test_get_buildpack_target_dir() {
         let buildpack_id = buildpack_id!("some-org/with-buildpack");
-        let target_dir = PathBuf::from("/target");
+        let package_dir = PathBuf::from("/package");
         let target_triple = "x86_64-unknown-linux-musl";
 
         assert_eq!(
-            get_buildpack_target_dir(&buildpack_id, &target_dir, false, target_triple),
-            PathBuf::from(
-                "/target/buildpack/x86_64-unknown-linux-musl/debug/some-org_with-buildpack"
-            )
+            get_buildpack_package_dir(&buildpack_id, &package_dir, false, target_triple),
+            PathBuf::from("/package/x86_64-unknown-linux-musl/debug/some-org_with-buildpack")
         );
         assert_eq!(
-            get_buildpack_target_dir(&buildpack_id, &target_dir, true, target_triple),
-            PathBuf::from(
-                "/target/buildpack/x86_64-unknown-linux-musl/release/some-org_with-buildpack"
-            )
+            get_buildpack_package_dir(&buildpack_id, &package_dir, true, target_triple),
+            PathBuf::from("/package/x86_64-unknown-linux-musl/release/some-org_with-buildpack")
         );
     }
 }


### PR DESCRIPTION
`cargo libcnb package` currently puts the packaged buildpacks in Cargo's `target` directory. This requires a deep path to avoid clashing with Cargo itself. Modifiying the `target` directory might also interfere with other Rust tooling that doesn't expect non-Cargo files in that directory. One case is caching via https://github.com/Swatinem/rust-cache.

This PR moves the packaged buildpacks into a dedicated directory. The default name and location for that directory is `$WORKSPACE_ROOT/libcnb-packaged`. This can be changed via the new `--package-dir` option of `cargo libcnb package`.

See: https://github.com/heroku/libcnb.rs/pull/580#discussion_r1238406927

Closes GUS-W-13813150
