### PR TITLE
`cargo upgrade`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ## [Unreleased]
 
+### Added
+
 - `libcnb-package`: Add cross-compilation assistance for Linux `aarch64-unknown-linux-musl`. ([#577](https://github.com/heroku/libcnb.rs/pull/577))
+
+### Changed
+
 - `libcnb-package`: buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need to adapt. The output of `cargo 
 libcnb package` will refer to the new locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
+- Bump minimum external dependency versions. ([#587](https://github.com/heroku/libcnb.rs/pull/587))
 
 ## [0.13.0] 2023-06-21
 
@@ -20,9 +26,9 @@ The highlight of this release is the `cargo libcnb package` changes to support c
   - When used in a buildpack directory it will compile only that buildpack.
   - When used in a workspace directory it will compile all buildpacks found in subdirectories.
 - `libcnb-package`: Changed `default_buildpack_directory_name` to accept a `BuildpackId` ([#575](https://github.com/heroku/libcnb.rs/pull/575))
-  
-### Added 
- 
+
+### Added
+
 - `libcnb-cargo`
   - Buildpacks can reference other buildpacks within a workspace by using `uri = "libcnb:{buildpack_id}"` as a dependency entry in the buildpack's [package.toml](https://buildpacks.io/docs/reference/config/package-config/) file. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
 - `libcnb-data`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ libcnb-data = { version = "0.13.0", path = "libcnb-data" }
 libcnb-package = { version = "0.13.0", path = "libcnb-package" }
 libcnb-proc-macros = { version = "0.13.0", path = "libcnb-proc-macros" }
 libcnb-test = { version = "0.13.0", path = "libcnb-test" }
-toml = { version = "0.7.1" }
+toml = { version = "0.7.5" }

--- a/examples/ruby-sample/Cargo.toml
+++ b/examples/ruby-sample/Cargo.toml
@@ -6,13 +6,13 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-flate2 = "1.0.24"
+flate2 = "1.0.26"
 libcnb.workspace = true
-serde = "1.0.145"
-sha2 = "0.10.6"
+serde = "1.0.166"
+sha2 = "0.10.7"
 tar = "0.4.38"
-tempfile = "3.3.0"
-ureq = "2.5.0"
+tempfile = "3.6.0"
+ureq = "2.7.1"
 
 [dev-dependencies]
 libcnb-test.workspace = true

--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -16,8 +16,8 @@ name = "cargo-libcnb"
 path = "src/main.rs"
 
 [dependencies]
-cargo_metadata = "0.15.0"
-clap = { version = "4.0.11", default-features = false, features = [
+cargo_metadata = "0.15.4"
+clap = { version = "4.3.10", default-features = false, features = [
   "derive",
   "error-context",
   "help",
@@ -27,9 +27,9 @@ clap = { version = "4.0.11", default-features = false, features = [
 libcnb-data.workspace = true
 libcnb-package.workspace = true
 pathdiff = "0.2.1"
-thiserror = "1.0.40"
+thiserror = "1.0.41"
 toml.workspace = true
 
 [dev-dependencies]
 fs_extra = "1.3.0"
-tempfile = "3.3.0"
+tempfile = "3.6.0"

--- a/libcnb-data/Cargo.toml
+++ b/libcnb-data/Cargo.toml
@@ -14,10 +14,10 @@ include = ["src/**/*", "LICENSE", "README.md"]
 [dependencies]
 fancy-regex = { version = "0.11.0", default-features = false }
 libcnb-proc-macros.workspace = true
-serde = { version = "1.0.145", features = ["derive"] }
-thiserror = "1.0.35"
+serde = { version = "1.0.166", features = ["derive"] }
+thiserror = "1.0.41"
 toml.workspace = true
 uriparse = "0.6.4"
 
 [dev-dependencies]
-serde_test = "1.0.145"
+serde_test = "1.0.166"

--- a/libcnb-package/Cargo.toml
+++ b/libcnb-package/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 include = ["src/**/*", "LICENSE", "README.md"]
 
 [dependencies]
-cargo_metadata = "0.15.0"
+cargo_metadata = "0.15.4"
 libcnb-data.workspace = true
 petgraph = { version = "0.6.3", default-features = false }
 toml.workspace = true
-which = "4.3.0"
+which = "4.4.0"

--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*", "LICENSE", "README.md"]
 proc-macro = true
 
 [dependencies]
-cargo_metadata = "0.15.0"
+cargo_metadata = "0.15.4"
 fancy-regex = { version = "0.11.0", default-features = false }
-quote = "1.0.21"
-syn = { version = "2.0.2", features = ["full"] }
+quote = "1.0.29"
+syn = { version = "2.0.23", features = ["full"] }

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -13,19 +13,19 @@ include = ["src/**/*", "LICENSE", "README.md"]
 
 [dependencies]
 bollard = "0.14.0"
-cargo_metadata = "0.15.0"
+cargo_metadata = "0.15.4"
 fastrand = "2.0.0"
-fs_extra = "1.2.0"
+fs_extra = "1.3.0"
 libcnb-data.workspace = true
 libcnb-package.workspace = true
-serde = "1.0.145"
-tempfile = "3.3.0"
-tokio = "1.21.1"
-tokio-stream = "0.1.10"
+serde = "1.0.166"
+tempfile = "3.6.0"
+tokio = "1.29.1"
+tokio-stream = "0.1.14"
 
 [dev-dependencies]
-indoc = "2.0.0"
-ureq = { version = "2.5.0", default-features = false }
+indoc = "2.0.2"
+ureq = { version = "2.7.1", default-features = false }
 
 [features]
 # Enables experimental support for connecting to a remote Docker daemon.

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -12,14 +12,14 @@ readme = "README.md"
 include = ["src/**/*", "LICENSE", "README.md"]
 
 [dependencies]
-anyhow = { version = "1.0.65", optional = true }
+anyhow = { version = "1.0.71", optional = true }
 cyclonedx-bom = { version = "0.4.0", optional = true }
 libcnb-data.workspace = true
 libcnb-proc-macros.workspace = true
-serde = { version = "1.0.145", features = ["derive"] }
-thiserror = "1.0.35"
+serde = { version = "1.0.166", features = ["derive"] }
+thiserror = "1.0.41"
 toml.workspace = true
 
 [dev-dependencies]
 fastrand = "2.0.0"
-tempfile = "3.3.0"
+tempfile = "3.6.0"

--- a/libherokubuildpack/Cargo.toml
+++ b/libherokubuildpack/Cargo.toml
@@ -27,16 +27,16 @@ command = ["write", "dep:crossbeam-utils"]
 write = []
 
 [dependencies]
-crossbeam-utils = { version = "0.8.2", optional = true }
-flate2 = { version = "1.0.24", optional = true }
+crossbeam-utils = { version = "0.8.16", optional = true }
+flate2 = { version = "1.0.26", optional = true }
 libcnb = { workspace = true, optional = true }
 pathdiff = { version = "0.2.1", optional = true }
-sha2 = { version = "0.10.6", optional = true }
+sha2 = { version = "0.10.7", optional = true }
 tar = { version = "0.4.38", optional = true }
-termcolor = { version = "1.1.3", optional = true }
-thiserror = { version = "1.0.35", optional = true }
+termcolor = { version = "1.2.0", optional = true }
+thiserror = { version = "1.0.41", optional = true }
 toml = { workspace = true, optional = true }
-ureq = { version = "2.5.0", optional = true }
+ureq = { version = "2.7.1", optional = true }
 
 [dev-dependencies]
-tempfile = "3.3.0"
+tempfile = "3.6.0"


### PR DESCRIPTION
Generated via:

```
cargo install cargo-edit
cargo upgrade
```

All versions are in-range (that is deleting the lockfile and recreating it would end up with the same versions), however explicitly bumping them ensures downstream consumers of libcnb pick up the updates even if they don't refresh their lockfile manually.