### PR TITLE
Clean up `TestContext` when pack build unexpectedly succeeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ### Changed
 
+- `libcnb-test`: ensures that an image created during a test run will be cleaned up when `.expected_pack_result(PackResult::Failure)` is used but the result is  `PackResult::Success`. ([#588](https://github.com/heroku/libcnb.rs/pull/588))
 - `libcnb-package`: buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need to adapt. The output of `cargo 
 libcnb package` will refer to the new locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
 - Bump minimum external dependency versions. ([#587](https://github.com/heroku/libcnb.rs/pull/587))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 ### Changed
 
-- `libcnb-test`: ensures that an image created during a test run will be cleaned up when `.expected_pack_result(PackResult::Failure)` is used but the result is  `PackResult::Success`. ([#588](https://github.com/heroku/libcnb.rs/pull/588))
+- `libcnb-test`: ensures that an image created during a test run will be cleaned up when `.expected_pack_result(PackResult::Failure)` is used but the result is `PackResult::Success`. ([#588](https://github.com/heroku/libcnb.rs/pull/588))
 - `libcnb-package`: buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need to adapt. The output of `cargo 
 libcnb package` will refer to the new locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
 - Bump minimum external dependency versions. ([#587](https://github.com/heroku/libcnb.rs/pull/587))

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -156,15 +156,18 @@ impl TestRunner {
             };
         }
 
-        let output = run_pack_command(pack_command, &config.expected_pack_result);
-
-        let test_context = TestContext {
-            pack_stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-            pack_stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        let mut test_context = TestContext {
+            pack_stdout: String::new(),
+            pack_stderr: String::new(),
             image_name,
             config: config.clone(),
             runner: self,
         };
+
+        let output = run_pack_command(pack_command, &config.expected_pack_result);
+
+        test_context.pack_stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        test_context.pack_stderr = String::from_utf8_lossy(&output.stderr).into_owned();
 
         f(test_context);
     }


### PR DESCRIPTION
Moves the creation of the `TestContext` to before the invocation of `run_pack_command` so that the context will be cleaned up regardless of the outcome.

@fixes #586