### PR TITLE
Support local buildpacks and meta-buildpacks in libcnb-test

### DIFF
--- a/libcnb-cargo/fixtures/multiple_buildpacks/buildpacks/one/buildpack.toml
+++ b/libcnb-cargo/fixtures/multiple_buildpacks/buildpacks/one/buildpack.toml
@@ -5,4 +5,4 @@ id = "multiple-buildpacks/one"
 version = "0.0.0"
 
 [[stacks]]
-id = "some-stack"
+id = "*"

--- a/libcnb-cargo/fixtures/multiple_buildpacks/buildpacks/two/buildpack.toml
+++ b/libcnb-cargo/fixtures/multiple_buildpacks/buildpacks/two/buildpack.toml
@@ -5,4 +5,4 @@ id = "multiple-buildpacks/two"
 version = "0.0.0"
 
 [[stacks]]
-id = "some-stack"
+id = "*"

--- a/libcnb-cargo/fixtures/multiple_buildpacks/meta-buildpacks/meta-two/buildpack.toml
+++ b/libcnb-cargo/fixtures/multiple_buildpacks/meta-buildpacks/meta-two/buildpack.toml
@@ -1,0 +1,31 @@
+api = "0.8"
+
+[buildpack]
+id = "multiple-buildpacks/meta-two"
+name = "Meta-buildpack Test"
+version = "0.0.0"
+homepage = "https://example.com"
+description = "Official test example"
+keywords = ["test"]
+
+[[buildpack.licenses]]
+type = "BSD-3-Clause"
+
+[[order]]
+
+[[order.group]]
+id = "multiple-buildpacks/one"
+version = "0.0.0"
+
+[[order.group]]
+id = "multiple-buildpacks/two"
+version = "0.0.0"
+
+[[order.group]]
+id = "heroku/procfile"
+version = "2.0.0"
+optional = true
+
+[metadata]
+[metadata.extra]
+some_key = "some_value"

--- a/libcnb-cargo/fixtures/multiple_buildpacks/meta-buildpacks/meta-two/package.toml
+++ b/libcnb-cargo/fixtures/multiple_buildpacks/meta-buildpacks/meta-two/package.toml
@@ -1,0 +1,11 @@
+[buildpack]
+uri = "."
+
+[[dependencies]]
+uri = "libcnb:multiple-buildpacks/one"
+
+[[dependencies]]
+uri = "libcnb:multiple-buildpacks/two"
+
+[[dependencies]]
+uri = "docker://docker.io/heroku/procfile-cnb:2.0.0"

--- a/libcnb-cargo/fixtures/single_buildpack/buildpack.toml
+++ b/libcnb-cargo/fixtures/single_buildpack/buildpack.toml
@@ -5,4 +5,4 @@ id = "single-buildpack"
 version = "0.0.0"
 
 [[stacks]]
-id = "some-stack"
+id = "*"

--- a/libcnb-cargo/src/package/error.rs
+++ b/libcnb-cargo/src/package/error.rs
@@ -4,88 +4,59 @@ use libcnb_package::buildpack_dependency::{
     RewriteBuildpackageLocalDependenciesError,
     RewriteBuildpackageRelativePathDependenciesToAbsoluteError,
 };
+use libcnb_package::buildpack_package::ReadBuildpackPackageError;
 use libcnb_package::dependency_graph::{CreateDependencyGraphError, GetDependenciesError};
+use libcnb_package::output::AssembleBuildpackDirectoryError;
+use libcnb_package::{FindCargoWorkspaceError, ReadBuildpackDataError, ReadBuildpackageDataError};
 use std::path::PathBuf;
+use std::process::ExitStatus;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
     #[error("Failed to get current dir\nError: {0}")]
     GetCurrentDir(std::io::Error),
 
-    #[error("Could not locate a Cargo workspace within `{path}` or it's parent directories")]
-    GetWorkspaceDirectory { path: PathBuf },
+    #[error("Could not locate a Cargo workspace within `{0}` or it's parent directories")]
+    GetWorkspaceDirectory(PathBuf),
 
-    #[error("Could not execute `cargo locate-project --workspace --message-format plain in {path}\nError: {source}")]
-    GetWorkspaceCommand {
-        path: PathBuf,
-        source: std::io::Error,
-    },
+    #[error("Could not read Cargo.toml metadata in `{0}`\nError: {1}")]
+    ReadCargoMetadata(PathBuf, cargo_metadata::Error),
 
-    #[error("Could not read Cargo.toml metadata in `{path}`\nError: {source}")]
-    ReadCargoMetadata {
-        path: PathBuf,
-        source: cargo_metadata::Error,
-    },
-
-    #[error("Could not determine a target directory for buildpack with id `{buildpack_id}`")]
-    TargetDirectoryLookup { buildpack_id: BuildpackId },
-
-    #[error("{message}")]
-    CrossCompilationHelp { message: String },
+    #[error("{0}")]
+    CrossCompilationHelp(String),
 
     #[error("No environment variable named `CARGO` is set")]
-    GetCargoBin(#[from] std::env::VarError),
-
-    #[error("Meta-buildpack is missing expected package.toml file")]
-    MissingBuildpackageData,
+    GetCargoBin(std::env::VarError),
 
     #[error("Failed to serialize package.toml\nError: {0}")]
     SerializeBuildpackage(toml::ser::Error),
 
-    #[error("Error while finding buildpack directories\nLocation: {path}\nError: {source}")]
-    FindBuildpackDirs {
-        path: PathBuf,
-        source: std::io::Error,
-    },
+    #[error("Error while finding buildpack directories\nLocation: {0}\nError: {1}")]
+    FindBuildpackDirs(PathBuf, std::io::Error),
 
     #[error("There was a problem with the build configuration")]
     BinaryConfig,
 
-    #[error("I/O error while executing Cargo for target {target}\nError: {source}")]
-    BinaryBuildExecution {
-        target: String,
-        source: std::io::Error,
-    },
+    #[error("I/O error while executing Cargo for target {0}\nError: {1}")]
+    BinaryBuildExecution(String, std::io::Error),
 
-    #[error("Unexpected Cargo exit status for target {target}\nExit Status: {code}\nExamine Cargo output for details and potential compilation errors.")]
-    BinaryBuildExitStatus { target: String, code: String },
+    #[error("Unexpected Cargo exit status for target {0}\nExit Status: {1}\nExamine Cargo output for details and potential compilation errors.")]
+    BinaryBuildExitStatus(String, String),
 
-    #[error("Configured buildpack target name {target} could not be found!")]
-    BinaryBuildMissingTarget { target: String },
+    #[error("Configured buildpack target name {0} could not be found!")]
+    BinaryBuildMissingTarget(String),
 
-    #[error("Failed to read buildpack data\nLocation: {path}\nError: {source}")]
-    ReadBuildpackData {
-        path: PathBuf,
-        source: std::io::Error,
-    },
+    #[error("Failed to read buildpack data\nLocation: {0}\nError: {1}")]
+    ReadBuildpackData(PathBuf, std::io::Error),
 
-    #[error("Failed to parse buildpack data\nLocation: {path}\nError: {source}")]
-    ParseBuildpackData {
-        path: PathBuf,
-        source: toml::de::Error,
-    },
+    #[error("Failed to parse buildpack data\nLocation: {0}\nError: {1}")]
+    ParseBuildpackData(PathBuf, toml::de::Error),
 
-    #[error("Failed to read buildpackage data\nLocation: {path}\nError: {source}")]
-    ReadBuildpackageData {
-        path: PathBuf,
-        source: std::io::Error,
-    },
+    #[error("Failed to read buildpackage data\nLocation: {0}\nError: {1}")]
+    ReadBuildpackageData(PathBuf, std::io::Error),
 
-    #[error("Failed to parse buildpackage data\nLocation: {path}\nError: {source}")]
-    ParseBuildpackageData {
-        path: PathBuf,
-        source: toml::de::Error,
-    },
+    #[error("Failed to parse buildpackage data\nLocation: {0}\nError: {1}")]
+    ParseBuildpackageData(PathBuf, toml::de::Error),
 
     #[error("Failed to lookup buildpack dependency with id `{0}`")]
     BuildpackDependencyLookup(BuildpackId),
@@ -108,16 +79,10 @@ pub(crate) enum Error {
     #[error("No buildpacks found!")]
     NoBuildpacksFound,
 
-    #[error("Could not assemble buildpack directory\nPath: {0}\nError: {1}")]
-    AssembleBuildpackDirectory(PathBuf, std::io::Error),
-
     #[error(
         "Failed to write package.toml to the target buildpack directory\nPath: {0}\nError: {1}"
     )]
     WriteBuildpackage(PathBuf, std::io::Error),
-
-    #[error("I/O error while creating target buildpack directory\nPath: {0}\nError: {1}")]
-    CreateBuildpackTargetDirectory(PathBuf, std::io::Error),
 
     #[error(
         "Failed to write buildpack.toml to the target buildpack directory\nPath: {0}\nError: {1}"
@@ -129,6 +94,33 @@ pub(crate) enum Error {
 
     #[error("I/O error while calculating directory size\nPath: {0}\nError: {1}")]
     CalculateDirectorySize(PathBuf, std::io::Error),
+
+    #[error("Could not read Cargo.toml metadata from workspace\nPath: {0}\nError: {1}")]
+    GetBuildpackOutputDir(PathBuf, cargo_metadata::Error),
+
+    #[error("Failed to spawn Cargo command\nError: {0}")]
+    SpawnCargoCommand(std::io::Error),
+
+    #[error("Unexpected Cargo exit status while attempting to read workspace root\nExit Status: {0}\nExamine Cargo output for details and potential compilation errors.")]
+    CargoCommandFailure(String),
+
+    #[error("Could not create buildpack directory\nPath: {0}\nError: {1}")]
+    CreateBuildpackDestinationDirectory(PathBuf, std::io::Error),
+
+    #[error("Could not create buildpack bin directory\nPath: {0}\nError: {1}")]
+    CreateBinDirectory(PathBuf, std::io::Error),
+
+    #[error("Could not write `build` binary to destination\nPath: {0}\nError: {1}")]
+    WriteBuildBinary(PathBuf, std::io::Error),
+
+    #[error("Could not write `detect` binary to destination\nPath: {0}\nError: {1}")]
+    WriteDetectBinary(PathBuf, std::io::Error),
+
+    #[error("Could not create buildpack additional binary directory\nPath: {0}\nError: {1}")]
+    CreateAdditionalBinariesDirectory(PathBuf, std::io::Error),
+
+    #[error("Could not write additional binary to destination\nPath: {0}\nError: {1}")]
+    WriteAdditionalBinary(PathBuf, std::io::Error),
 }
 
 impl From<BuildBinariesError> for Error {
@@ -137,49 +129,20 @@ impl From<BuildBinariesError> for Error {
             BuildBinariesError::ConfigError(_) => Error::BinaryConfig,
 
             BuildBinariesError::BuildError(target, BuildError::IoError(source)) => {
-                Error::BinaryBuildExecution { target, source }
+                Error::BinaryBuildExecution(target, source)
             }
 
             BuildBinariesError::BuildError(
                 target,
                 BuildError::UnexpectedCargoExitStatus(exit_status),
-            ) => Error::BinaryBuildExitStatus {
-                target,
-                code: exit_status
-                    .code()
-                    .map_or_else(|| String::from("<unknown>"), |code| code.to_string()),
-            },
+            ) => Error::BinaryBuildExitStatus(target, exit_status_or_unknown(exit_status)),
 
             BuildBinariesError::MissingBuildpackTarget(target) => {
-                Error::BinaryBuildMissingTarget { target }
+                Error::BinaryBuildMissingTarget(target)
             }
-        }
-    }
-}
 
-impl From<libcnb_package::buildpack_package::ReadBuildpackPackageError> for Error {
-    fn from(value: libcnb_package::buildpack_package::ReadBuildpackPackageError) -> Self {
-        match value {
-            libcnb_package::buildpack_package::ReadBuildpackPackageError::ReadBuildpackDataError(error) => match error
-            {
-                libcnb_package::ReadBuildpackDataError::ReadingBuildpack { path, source } => {
-                    Error::ReadBuildpackData { path, source }
-                }
-                libcnb_package::ReadBuildpackDataError::ParsingBuildpack { path, source } => {
-                    Error::ParseBuildpackData { path, source }
-                }
-            },
-            libcnb_package::buildpack_package::ReadBuildpackPackageError::ReadBuildpackageDataError(error) => {
-                match error {
-                    libcnb_package::ReadBuildpackageDataError::ReadingBuildpackage {
-                        path,
-                        source,
-                    } => Error::ReadBuildpackageData { path, source },
-                    libcnb_package::ReadBuildpackageDataError::ParsingBuildpackage {
-                        path,
-                        source,
-                    } => Error::ParseBuildpackageData { path, source },
-                }
+            BuildBinariesError::ReadCargoMetadata(path, error) => {
+                Error::ReadCargoMetadata(path, error)
             }
         }
     }
@@ -227,4 +190,94 @@ impl From<RewriteBuildpackageRelativePathDependenciesToAbsoluteError> for Error 
             RewriteBuildpackageRelativePathDependenciesToAbsoluteError::GetBuildpackDependenciesError(error) => Error::GetBuildpackDependencies(error)
         }
     }
+}
+
+impl From<ReadBuildpackPackageError> for Error {
+    fn from(value: ReadBuildpackPackageError) -> Self {
+        match value {
+            ReadBuildpackPackageError::ReadBuildpackDataError(error) => error.into(),
+            ReadBuildpackPackageError::ReadBuildpackageDataError(error) => error.into(),
+        }
+    }
+}
+
+impl From<ReadBuildpackDataError> for Error {
+    fn from(value: ReadBuildpackDataError) -> Self {
+        match value {
+            ReadBuildpackDataError::ReadingBuildpack(path, source) => {
+                Error::ReadBuildpackData(path, source)
+            }
+            ReadBuildpackDataError::ParsingBuildpack(path, source) => {
+                Error::ParseBuildpackData(path, source)
+            }
+        }
+    }
+}
+
+impl From<ReadBuildpackageDataError> for Error {
+    fn from(value: ReadBuildpackageDataError) -> Self {
+        match value {
+            ReadBuildpackageDataError::ReadingBuildpackage(path, source) => {
+                Error::ReadBuildpackageData(path, source)
+            }
+            ReadBuildpackageDataError::ParsingBuildpackage(path, source) => {
+                Error::ParseBuildpackageData(path, source)
+            }
+        }
+    }
+}
+
+impl From<FindCargoWorkspaceError> for Error {
+    fn from(value: FindCargoWorkspaceError) -> Self {
+        match value {
+            FindCargoWorkspaceError::GetCargoEnv(error) => Error::GetCargoBin(error),
+            FindCargoWorkspaceError::SpawnCommand(error) => Error::SpawnCargoCommand(error),
+            FindCargoWorkspaceError::CommandFailure(exit_status) => {
+                Error::CargoCommandFailure(exit_status_or_unknown(exit_status))
+            }
+            FindCargoWorkspaceError::GetParentDirectory(path) => Error::GetWorkspaceDirectory(path),
+        }
+    }
+}
+
+impl From<AssembleBuildpackDirectoryError> for Error {
+    fn from(value: AssembleBuildpackDirectoryError) -> Self {
+        match value {
+            AssembleBuildpackDirectoryError::CreateBuildpackDestinationDirectory(path, error) => {
+                Error::CreateBuildpackDestinationDirectory(path, error)
+            }
+            AssembleBuildpackDirectoryError::WriteBuildpack(path, error) => {
+                Error::WriteBuildpack(path, error)
+            }
+            AssembleBuildpackDirectoryError::SerializeBuildpackage(error) => {
+                Error::SerializeBuildpackage(error)
+            }
+            AssembleBuildpackDirectoryError::WriteBuildpackage(path, error) => {
+                Error::WriteBuildpackage(path, error)
+            }
+            AssembleBuildpackDirectoryError::CreateBinDirectory(path, error) => {
+                Error::CreateBinDirectory(path, error)
+            }
+            AssembleBuildpackDirectoryError::WriteBuildBinary(path, error) => {
+                Error::WriteBuildBinary(path, error)
+            }
+            AssembleBuildpackDirectoryError::WriteDetectBinary(path, error) => {
+                Error::WriteDetectBinary(path, error)
+            }
+            AssembleBuildpackDirectoryError::CreateAdditionalBinariesDirectory(path, error) => {
+                Error::CreateAdditionalBinariesDirectory(path, error)
+            }
+            AssembleBuildpackDirectoryError::WriteAdditionalBinary(path, error) => {
+                Error::WriteAdditionalBinary(path, error)
+            }
+            AssembleBuildpackDirectoryError::RewriteLocalDependencies(error) => error.into(),
+            AssembleBuildpackDirectoryError::RewriteRelativePathDependencies(error) => error.into(),
+        }
+    }
+}
+
+fn exit_status_or_unknown(exit_status: ExitStatus) -> String {
+    exit_status
+        .code()
+        .map_or_else(|| String::from("<unknown>"), |code| code.to_string())
 }

--- a/libcnb-package/src/lib.rs
+++ b/libcnb-package/src/lib.rs
@@ -10,12 +10,13 @@ pub mod buildpack_package;
 pub mod config;
 pub mod cross_compile;
 pub mod dependency_graph;
+pub mod output;
 
-use crate::build::BuildpackBinaries;
-use libcnb_data::buildpack::{BuildpackDescriptor, BuildpackId};
+use libcnb_data::buildpack::BuildpackDescriptor;
 use libcnb_data::buildpackage::Buildpackage;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use toml::Table;
 
 /// The profile to use when invoking Cargo.
@@ -50,14 +51,10 @@ pub fn read_buildpack_data(
     let dir = project_path.as_ref();
     let buildpack_descriptor_path = dir.join("buildpack.toml");
     fs::read_to_string(&buildpack_descriptor_path)
-        .map_err(|e| ReadBuildpackDataError::ReadingBuildpack {
-            path: buildpack_descriptor_path.clone(),
-            source: e,
-        })
+        .map_err(|e| ReadBuildpackDataError::ReadingBuildpack(buildpack_descriptor_path.clone(), e))
         .and_then(|file_contents| {
-            toml::from_str(&file_contents).map_err(|e| ReadBuildpackDataError::ParsingBuildpack {
-                path: buildpack_descriptor_path.clone(),
-                source: e,
+            toml::from_str(&file_contents).map_err(|e| {
+                ReadBuildpackDataError::ParsingBuildpack(buildpack_descriptor_path.clone(), e)
             })
         })
         .map(|buildpack_descriptor| BuildpackData {
@@ -69,14 +66,8 @@ pub fn read_buildpack_data(
 /// An error from [`read_buildpack_data`]
 #[derive(Debug)]
 pub enum ReadBuildpackDataError {
-    ReadingBuildpack {
-        path: PathBuf,
-        source: std::io::Error,
-    },
-    ParsingBuildpack {
-        path: PathBuf,
-        source: toml::de::Error,
-    },
+    ReadingBuildpack(PathBuf, std::io::Error),
+    ParsingBuildpack(PathBuf, toml::de::Error),
 }
 
 /// A parsed buildpackage descriptor and it's path.
@@ -101,16 +92,15 @@ pub fn read_buildpackage_data(
     }
 
     fs::read_to_string(&buildpackage_descriptor_path)
-        .map_err(|e| ReadBuildpackageDataError::ReadingBuildpackage {
-            path: buildpackage_descriptor_path.clone(),
-            source: e,
+        .map_err(|e| {
+            ReadBuildpackageDataError::ReadingBuildpackage(buildpackage_descriptor_path.clone(), e)
         })
         .and_then(|file_contents| {
             toml::from_str(&file_contents).map_err(|e| {
-                ReadBuildpackageDataError::ParsingBuildpackage {
-                    path: buildpackage_descriptor_path.clone(),
-                    source: e,
-                }
+                ReadBuildpackageDataError::ParsingBuildpackage(
+                    buildpackage_descriptor_path.clone(),
+                    e,
+                )
             })
         })
         .map(|buildpackage_descriptor| {
@@ -124,93 +114,8 @@ pub fn read_buildpackage_data(
 /// An error from [`read_buildpackage_data`]
 #[derive(Debug)]
 pub enum ReadBuildpackageDataError {
-    ReadingBuildpackage {
-        path: PathBuf,
-        source: std::io::Error,
-    },
-    ParsingBuildpackage {
-        path: PathBuf,
-        source: toml::de::Error,
-    },
-}
-
-/// Creates a buildpack directory and copies all buildpack assets to it.
-///
-/// Assembly of the directory follows the constraints set by the libcnb framework. For example,
-/// the buildpack binary is only copied once and symlinks are used to refer to it when the CNB
-/// spec requires different file(name)s.
-///
-/// This function will not validate if the buildpack descriptor at the given path is valid and will
-/// use it as-is.
-///
-/// # Errors
-///
-/// Will return `Err` if the buildpack directory could not be assembled.
-pub fn assemble_buildpack_directory(
-    destination_path: impl AsRef<Path>,
-    buildpack_descriptor_path: impl AsRef<Path>,
-    buildpack_binaries: &BuildpackBinaries,
-) -> std::io::Result<()> {
-    fs::create_dir_all(destination_path.as_ref())?;
-
-    fs::copy(
-        buildpack_descriptor_path.as_ref(),
-        destination_path.as_ref().join("buildpack.toml"),
-    )?;
-
-    let bin_path = destination_path.as_ref().join("bin");
-    fs::create_dir_all(&bin_path)?;
-
-    fs::copy(
-        &buildpack_binaries.buildpack_target_binary_path,
-        bin_path.join("build"),
-    )?;
-
-    create_file_symlink("build", bin_path.join("detect"))?;
-
-    if !buildpack_binaries.additional_target_binary_paths.is_empty() {
-        let additional_binaries_dir = destination_path
-            .as_ref()
-            .join(".libcnb-cargo")
-            .join("additional-bin");
-
-        fs::create_dir_all(&additional_binaries_dir)?;
-
-        for (binary_target_name, binary_path) in &buildpack_binaries.additional_target_binary_paths
-        {
-            fs::copy(
-                binary_path,
-                additional_binaries_dir.join(binary_target_name),
-            )?;
-        }
-    }
-
-    Ok(())
-}
-
-#[cfg(target_family = "unix")]
-fn create_file_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
-    original: P,
-    link: Q,
-) -> std::io::Result<()> {
-    std::os::unix::fs::symlink(original.as_ref(), link.as_ref())
-}
-
-#[cfg(target_family = "windows")]
-fn create_file_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
-    original: P,
-    link: Q,
-) -> std::io::Result<()> {
-    std::os::windows::fs::symlink_file(original.as_ref(), link.as_ref())
-}
-
-/// Construct a good default filename for a buildpack directory.
-///
-/// This function ensures the resulting name is valid and does not contain problematic characters
-/// such as `/`.
-#[must_use]
-pub fn default_buildpack_directory_name(buildpack_id: &BuildpackId) -> String {
-    buildpack_id.replace('/', "_")
+    ReadingBuildpackage(PathBuf, std::io::Error),
+    ParsingBuildpackage(PathBuf, toml::de::Error),
 }
 
 /// Recursively walks the file system from the given `start_dir` to locate any folders containing a
@@ -253,44 +158,39 @@ pub fn find_buildpack_dirs(start_dir: &Path, ignore: &[PathBuf]) -> std::io::Res
     Ok(buildpack_dirs)
 }
 
-/// Provides a standard path to use for storing a compiled buildpack's artifacts.
-#[must_use]
-pub fn get_buildpack_target_dir(
-    buildpack_id: &BuildpackId,
-    target_dir: &Path,
-    is_release: bool,
-    target_triple: &str,
-) -> PathBuf {
-    target_dir
-        .join("buildpack")
-        .join(target_triple)
-        .join(if is_release { "release" } else { "debug" })
-        .join(default_buildpack_directory_name(buildpack_id))
+/// TODO
+/// ## Errors
+pub fn find_cargo_workspace(dir_in_workspace: &Path) -> Result<PathBuf, FindCargoWorkspaceError> {
+    let cargo_bin = std::env::var("CARGO")
+        .map(PathBuf::from)
+        .map_err(FindCargoWorkspaceError::GetCargoEnv)?;
+
+    let output = Command::new(cargo_bin)
+        .args(["locate-project", "--workspace", "--message-format", "plain"])
+        .current_dir(dir_in_workspace)
+        .output()
+        .map_err(FindCargoWorkspaceError::SpawnCommand)?;
+
+    let status = output.status;
+
+    output
+        .status
+        .success()
+        .then_some(output)
+        .ok_or(FindCargoWorkspaceError::CommandFailure(status))
+        .and_then(|output| {
+            let root_cargo_toml = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+            root_cargo_toml
+                .parent()
+                .map(Path::to_path_buf)
+                .ok_or(FindCargoWorkspaceError::GetParentDirectory(root_cargo_toml))
+        })
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::get_buildpack_target_dir;
-    use libcnb_data::buildpack_id;
-    use std::path::PathBuf;
-
-    #[test]
-    fn test_get_buildpack_target_dir() {
-        let buildpack_id = buildpack_id!("some-org/with-buildpack");
-        let target_dir = PathBuf::from("/target");
-        let target_triple = "x86_64-unknown-linux-musl";
-
-        assert_eq!(
-            get_buildpack_target_dir(&buildpack_id, &target_dir, false, target_triple),
-            PathBuf::from(
-                "/target/buildpack/x86_64-unknown-linux-musl/debug/some-org_with-buildpack"
-            )
-        );
-        assert_eq!(
-            get_buildpack_target_dir(&buildpack_id, &target_dir, true, target_triple),
-            PathBuf::from(
-                "/target/buildpack/x86_64-unknown-linux-musl/release/some-org_with-buildpack"
-            )
-        );
-    }
+#[derive(Debug)]
+pub enum FindCargoWorkspaceError {
+    GetCargoEnv(std::env::VarError),
+    SpawnCommand(std::io::Error),
+    CommandFailure(std::process::ExitStatus),
+    GetParentDirectory(PathBuf),
 }

--- a/libcnb-package/src/output.rs
+++ b/libcnb-package/src/output.rs
@@ -1,0 +1,243 @@
+use crate::build::BuildpackBinaries;
+use crate::buildpack_dependency::{
+    rewrite_buildpackage_local_dependencies,
+    rewrite_buildpackage_relative_path_dependencies_to_absolute,
+    RewriteBuildpackageLocalDependenciesError,
+    RewriteBuildpackageRelativePathDependenciesToAbsoluteError,
+};
+use crate::CargoProfile;
+use libcnb_data::buildpack::BuildpackId;
+use libcnb_data::buildpackage::Buildpackage;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub struct BuildpackOutputDirectoryLocator {
+    root_dir: PathBuf,
+    cargo_profile: CargoProfile,
+    target_triple: String,
+}
+
+impl BuildpackOutputDirectoryLocator {
+    #[must_use]
+    pub fn new(root_dir: PathBuf, cargo_profile: CargoProfile, target_triple: String) -> Self {
+        Self {
+            root_dir,
+            cargo_profile,
+            target_triple,
+        }
+    }
+
+    #[must_use]
+    pub fn get(&self, buildpack_id: &BuildpackId) -> PathBuf {
+        self.root_dir
+            .join("buildpack")
+            .join(&self.target_triple)
+            .join(match self.cargo_profile {
+                CargoProfile::Dev => "debug",
+                CargoProfile::Release => "release",
+            })
+            .join(default_buildpack_directory_name(buildpack_id))
+    }
+}
+
+/// Construct a good default filename for a buildpack directory.
+///
+/// This function ensures the resulting name is valid and does not contain problematic characters
+/// such as `/`.
+#[must_use]
+pub fn default_buildpack_directory_name(buildpack_id: &BuildpackId) -> String {
+    buildpack_id.replace('/', "_")
+}
+
+#[derive(Debug)]
+pub enum AssembleBuildpackDirectoryError {
+    CreateBuildpackDestinationDirectory(PathBuf, std::io::Error),
+    WriteBuildpack(PathBuf, std::io::Error),
+    SerializeBuildpackage(toml::ser::Error),
+    WriteBuildpackage(PathBuf, std::io::Error),
+    CreateBinDirectory(PathBuf, std::io::Error),
+    WriteBuildBinary(PathBuf, std::io::Error),
+    WriteDetectBinary(PathBuf, std::io::Error),
+    CreateAdditionalBinariesDirectory(PathBuf, std::io::Error),
+    WriteAdditionalBinary(PathBuf, std::io::Error),
+    RewriteLocalDependencies(RewriteBuildpackageLocalDependenciesError),
+    RewriteRelativePathDependencies(RewriteBuildpackageRelativePathDependenciesToAbsoluteError),
+}
+
+/// Creates a buildpack directory and copies all buildpack assets to it.
+///
+/// Assembly of the directory follows the constraints set by the libcnb framework. For example,
+/// the buildpack binary is only copied once and symlinks are used to refer to it when the CNB
+/// spec requires different file(name)s.
+///
+/// This function will not validate if the buildpack descriptor at the given path is valid and will
+/// use it as-is.
+///
+/// # Errors
+///
+/// Will return `Err` if the buildpack directory could not be assembled.
+pub fn assemble_single_buildpack_directory(
+    destination_path: impl AsRef<Path>,
+    buildpack_path: impl AsRef<Path>,
+    buildpackage: Option<&Buildpackage>,
+    buildpack_binaries: &BuildpackBinaries,
+) -> Result<(), AssembleBuildpackDirectoryError> {
+    fs::create_dir_all(destination_path.as_ref()).map_err(|e| {
+        AssembleBuildpackDirectoryError::CreateBuildpackDestinationDirectory(
+            destination_path.as_ref().to_path_buf(),
+            e,
+        )
+    })?;
+
+    let destination_path = destination_path.as_ref();
+
+    fs::copy(
+        buildpack_path.as_ref(),
+        destination_path.join("buildpack.toml"),
+    )
+    .map_err(|e| {
+        AssembleBuildpackDirectoryError::WriteBuildpack(destination_path.join("buildpack.toml"), e)
+    })?;
+
+    let default_buildpackage = Buildpackage::default();
+    let buildpackage_content = toml::to_string(buildpackage.unwrap_or(&default_buildpackage))
+        .map_err(AssembleBuildpackDirectoryError::SerializeBuildpackage)?;
+
+    fs::write(destination_path.join("package.toml"), buildpackage_content).map_err(|e| {
+        AssembleBuildpackDirectoryError::WriteBuildpackage(destination_path.join("package.toml"), e)
+    })?;
+
+    let bin_path = destination_path.join("bin");
+    fs::create_dir_all(&bin_path)
+        .map_err(|e| AssembleBuildpackDirectoryError::CreateBinDirectory(bin_path.clone(), e))?;
+
+    fs::copy(
+        &buildpack_binaries.buildpack_target_binary_path,
+        bin_path.join("build"),
+    )
+    .map_err(|e| AssembleBuildpackDirectoryError::WriteBuildBinary(bin_path.join("build"), e))?;
+
+    create_file_symlink("build", bin_path.join("detect")).map_err(|e| {
+        AssembleBuildpackDirectoryError::WriteDetectBinary(bin_path.join("detect"), e)
+    })?;
+
+    if !buildpack_binaries.additional_target_binary_paths.is_empty() {
+        let additional_binaries_dir = destination_path
+            .join(".libcnb-cargo")
+            .join("additional-bin");
+
+        fs::create_dir_all(&additional_binaries_dir).map_err(|e| {
+            AssembleBuildpackDirectoryError::CreateAdditionalBinariesDirectory(
+                additional_binaries_dir.clone(),
+                e,
+            )
+        })?;
+
+        for (binary_target_name, binary_path) in &buildpack_binaries.additional_target_binary_paths
+        {
+            fs::copy(
+                binary_path,
+                additional_binaries_dir.join(binary_target_name),
+            )
+            .map_err(|e| {
+                AssembleBuildpackDirectoryError::WriteAdditionalBinary(
+                    additional_binaries_dir.join(binary_target_name),
+                    e,
+                )
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+/// TODO
+/// ## Errors
+pub fn assemble_meta_buildpack_directory(
+    destination_path: impl AsRef<Path>,
+    buildpack_source_dir: impl AsRef<Path>,
+    buildpack_path: impl AsRef<Path>,
+    buildpackage: Option<&Buildpackage>,
+    buildpack_output_directory_locator: &BuildpackOutputDirectoryLocator,
+) -> Result<(), AssembleBuildpackDirectoryError> {
+    let default_buildpackage = Buildpackage::default();
+    let buildpackage = rewrite_buildpackage_local_dependencies(
+        buildpackage.unwrap_or(&default_buildpackage),
+        buildpack_output_directory_locator,
+    )
+    .map_err(AssembleBuildpackDirectoryError::RewriteLocalDependencies)
+    .and_then(|buildpackage| {
+        rewrite_buildpackage_relative_path_dependencies_to_absolute(
+            &buildpackage,
+            buildpack_source_dir.as_ref(),
+        )
+        .map_err(AssembleBuildpackDirectoryError::RewriteRelativePathDependencies)
+    })?;
+
+    fs::create_dir_all(destination_path.as_ref()).map_err(|e| {
+        AssembleBuildpackDirectoryError::CreateBuildpackDestinationDirectory(
+            destination_path.as_ref().to_path_buf(),
+            e,
+        )
+    })?;
+
+    let destination_path = destination_path.as_ref();
+
+    fs::copy(
+        buildpack_path.as_ref(),
+        destination_path.join("buildpack.toml"),
+    )
+    .map_err(|e| {
+        AssembleBuildpackDirectoryError::WriteBuildpack(destination_path.join("buildpack.toml"), e)
+    })?;
+
+    let buildpackage_content = toml::to_string(&buildpackage)
+        .map_err(AssembleBuildpackDirectoryError::SerializeBuildpackage)?;
+
+    fs::write(destination_path.join("package.toml"), buildpackage_content).map_err(|e| {
+        AssembleBuildpackDirectoryError::WriteBuildpackage(destination_path.join("package.toml"), e)
+    })
+}
+
+#[cfg(target_family = "unix")]
+fn create_file_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
+    original: P,
+    link: Q,
+) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(original.as_ref(), link.as_ref())
+}
+
+#[cfg(target_family = "windows")]
+fn create_file_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
+    original: P,
+    link: Q,
+) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_file(original.as_ref(), link.as_ref())
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use crate::get_buildpack_target_dir;
+//     use libcnb_data::buildpack_id;
+//     use std::path::PathBuf;
+//
+//     #[test]
+//     fn test_get_buildpack_target_dir() {
+//         let buildpack_id = buildpack_id!("some-org/with-buildpack");
+//         let target_dir = PathBuf::from("/target");
+//         let target_triple = "x86_64-unknown-linux-musl";
+//
+//         assert_eq!(
+//             get_buildpack_target_dir(&buildpack_id, &target_dir, false, target_triple),
+//             PathBuf::from(
+//                 "/target/buildpack/x86_64-unknown-linux-musl/debug/some-org_with-buildpack"
+//             )
+//         );
+//         assert_eq!(
+//             get_buildpack_target_dir(&buildpack_id, &target_dir, true, target_triple),
+//             PathBuf::from(
+//                 "/target/buildpack/x86_64-unknown-linux-musl/release/some-org_with-buildpack"
+//             )
+//         );
+//     }
+// }

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -13,7 +13,6 @@ include = ["src/**/*", "LICENSE", "README.md"]
 
 [dependencies]
 bollard = "0.14.0"
-cargo_metadata = "0.15.4"
 fastrand = "2.0.0"
 fs_extra = "1.3.0"
 libcnb-data.workspace = true

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -53,11 +53,8 @@ pub(crate) fn package_buildpack(
 
     let workspace_dir = find_cargo_workspace(&buildpack_dir).unwrap();
 
-    let output_dir =
-        tempdir().map_err(PackageCrateBuildpackError::CannotCreateBuildpackTempDirectory)?;
-
     let buildpack_dirs =
-        find_buildpack_dirs(&workspace_dir, &[output_dir.path().to_path_buf()]).unwrap();
+        find_buildpack_dirs(&workspace_dir, &[workspace_dir.join("target")]).unwrap();
 
     let buildpack_packages = buildpack_dirs
         .into_iter()
@@ -75,8 +72,11 @@ pub(crate) fn package_buildpack(
     let build_order =
         get_dependencies(&buildpack_packages_graph, &buildpack_packages_requested).unwrap();
 
+    let root_output_dir =
+        tempdir().map_err(PackageCrateBuildpackError::CannotCreateBuildpackTempDirectory)?;
+
     let buildpack_output_directory_locator = BuildpackOutputDirectoryLocator::new(
-        output_dir.path().to_path_buf(),
+        root_output_dir.path().to_path_buf(),
         cargo_profile,
         target_triple.as_ref().to_string(),
     );

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -1,25 +1,47 @@
-use cargo_metadata::MetadataCommand;
-use libcnb_package::build::{build_buildpack_binaries, BuildBinariesError};
+use crate::pack;
+use crate::pack::PackBuildpackPackageCommand;
+use libcnb_data::buildpack::BuildpackDescriptor;
+use libcnb_package::build::build_buildpack_binaries;
+use libcnb_package::buildpack_package::{read_buildpack_package, BuildpackPackage};
 use libcnb_package::cross_compile::{cross_compile_assistance, CrossCompileAssistance};
-use libcnb_package::{assemble_buildpack_directory, CargoProfile};
-use std::path::PathBuf;
-use tempfile::{tempdir, TempDir};
+use libcnb_package::dependency_graph::{create_dependency_graph, get_dependencies, DependencyNode};
+use libcnb_package::output::{
+    assemble_meta_buildpack_directory, assemble_single_buildpack_directory,
+    BuildpackOutputDirectoryLocator,
+};
+use libcnb_package::{find_buildpack_dirs, find_cargo_workspace, CargoProfile};
+use std::ffi::OsString;
+use std::iter::repeat_with;
+use std::path::{Path, PathBuf};
+use tempfile::tempdir;
 
 /// Packages the current crate as a buildpack into a temporary directory.
 pub(crate) fn package_crate_buildpack(
     cargo_profile: CargoProfile,
     target_triple: impl AsRef<str>,
-) -> Result<TempDir, PackageCrateBuildpackError> {
+) -> Result<String, PackageCrateBuildpackError> {
     let cargo_manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
         .map(PathBuf::from)
         .map_err(PackageCrateBuildpackError::CannotDetermineCrateDirectory)?;
+    package_buildpack(&cargo_manifest_dir, cargo_profile, target_triple)
+}
 
-    let cargo_metadata = MetadataCommand::new()
-        .manifest_path(&cargo_manifest_dir.join("Cargo.toml"))
-        .exec()
-        .map_err(PackageCrateBuildpackError::CargoMetadataError)?;
+pub(crate) fn package_buildpack(
+    buildpack_dir: &Path,
+    cargo_profile: CargoProfile,
+    target_triple: impl AsRef<str>,
+) -> Result<String, PackageCrateBuildpackError> {
+    let buildpack_dir = if buildpack_dir.is_relative() {
+        std::env::current_dir()
+            .unwrap()
+            .join(buildpack_dir)
+            .canonicalize()
+            .unwrap()
+    } else {
+        buildpack_dir.to_path_buf()
+    };
 
-    let cargo_env = match cross_compile_assistance(target_triple.as_ref()) {
+    let cargo_build_env = match cross_compile_assistance(target_triple.as_ref()) {
         CrossCompileAssistance::HelpText(help_text) => {
             return Err(PackageCrateBuildpackError::CrossCompileConfigurationError(
                 help_text,
@@ -29,34 +51,128 @@ pub(crate) fn package_crate_buildpack(
         CrossCompileAssistance::Configuration { cargo_env } => cargo_env,
     };
 
-    let buildpack_dir =
+    let workspace_dir = find_cargo_workspace(&buildpack_dir).unwrap();
+
+    let output_dir =
         tempdir().map_err(PackageCrateBuildpackError::CannotCreateBuildpackTempDirectory)?;
 
-    let buildpack_binaries = build_buildpack_binaries(
-        &cargo_manifest_dir,
-        &cargo_metadata,
-        cargo_profile,
-        &cargo_env,
-        target_triple.as_ref(),
-    )
-    .map_err(PackageCrateBuildpackError::BuildBinariesError)?;
+    let buildpack_dirs =
+        find_buildpack_dirs(&workspace_dir, &[output_dir.path().to_path_buf()]).unwrap();
 
-    assemble_buildpack_directory(
-        buildpack_dir.path(),
-        cargo_manifest_dir.join("buildpack.toml"),
+    let buildpack_packages = buildpack_dirs
+        .into_iter()
+        .map(read_buildpack_package)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    let buildpack_packages_graph = create_dependency_graph(buildpack_packages).unwrap();
+
+    let buildpack_packages_requested = buildpack_packages_graph
+        .node_weights()
+        .filter(|buildpack_package| buildpack_package.path == buildpack_dir)
+        .collect::<Vec<_>>();
+
+    let build_order =
+        get_dependencies(&buildpack_packages_graph, &buildpack_packages_requested).unwrap();
+
+    let buildpack_output_directory_locator = BuildpackOutputDirectoryLocator::new(
+        output_dir.path().to_path_buf(),
+        cargo_profile,
+        target_triple.as_ref().to_string(),
+    );
+
+    for buildpack_package in &build_order {
+        let target_dir = buildpack_output_directory_locator.get(&buildpack_package.id());
+        match buildpack_package.buildpack_data.buildpack_descriptor {
+            BuildpackDescriptor::Single(_) => {
+                package_single_buildpack(
+                    buildpack_package,
+                    &target_dir,
+                    cargo_profile,
+                    &cargo_build_env,
+                    target_triple.as_ref(),
+                );
+            }
+            BuildpackDescriptor::Meta(_) => {
+                package_meta_buildpack(
+                    buildpack_package,
+                    &target_dir,
+                    &buildpack_output_directory_locator,
+                );
+            }
+        }
+    }
+
+    let target_buildpack_id = buildpack_packages_requested
+        .iter()
+        .map(|buildpack_package| buildpack_package.buildpack_id())
+        .next()
+        .unwrap();
+
+    let output_dir = buildpack_output_directory_locator.get(target_buildpack_id);
+
+    let buildpack_image = format!(
+        "{target_buildpack_id}_{}",
+        repeat_with(fastrand::lowercase)
+            .take(30)
+            .collect::<String>()
+    );
+
+    let buildpack_package_command =
+        PackBuildpackPackageCommand::new(&buildpack_image, output_dir.join("package.toml"));
+
+    pack::run_buildpack_package_command(buildpack_package_command);
+
+    Ok(buildpack_image)
+}
+
+fn package_single_buildpack(
+    buildpack_package: &BuildpackPackage,
+    target_dir: &Path,
+    cargo_profile: CargoProfile,
+    cargo_build_env: &[(OsString, OsString)],
+    target_triple: &str,
+) {
+    let buildpack_binaries = build_buildpack_binaries(
+        &buildpack_package.path,
+        cargo_profile,
+        cargo_build_env,
+        target_triple,
+    )
+    .unwrap();
+    assemble_single_buildpack_directory(
+        target_dir,
+        &buildpack_package.buildpack_data.buildpack_descriptor_path,
+        buildpack_package
+            .buildpackage_data
+            .as_ref()
+            .map(|data| &data.buildpackage_descriptor),
         &buildpack_binaries,
     )
-    .map_err(PackageCrateBuildpackError::CannotAssembleBuildpackDirectory)?;
+    .unwrap();
+}
 
-    Ok(buildpack_dir)
+fn package_meta_buildpack(
+    buildpack_package: &BuildpackPackage,
+    target_dir: &Path,
+    buildpack_output_directory_locator: &BuildpackOutputDirectoryLocator,
+) {
+    assemble_meta_buildpack_directory(
+        target_dir,
+        &buildpack_package.path,
+        &buildpack_package.buildpack_data.buildpack_descriptor_path,
+        buildpack_package
+            .buildpackage_data
+            .as_ref()
+            .map(|data| &data.buildpackage_descriptor),
+        buildpack_output_directory_locator,
+    )
+    .unwrap();
 }
 
 #[derive(Debug)]
 pub(crate) enum PackageCrateBuildpackError {
-    BuildBinariesError(BuildBinariesError),
-    CannotAssembleBuildpackDirectory(std::io::Error),
     CannotCreateBuildpackTempDirectory(std::io::Error),
     CannotDetermineCrateDirectory(std::env::VarError),
-    CargoMetadataError(cargo_metadata::Error),
     CrossCompileConfigurationError(String),
 }

--- a/libcnb-test/src/build_config.rs
+++ b/libcnb-test/src/build_config.rs
@@ -251,6 +251,8 @@ pub enum BuildpackReference {
     Crate,
     /// References another buildpack by id, local directory or tarball.
     Other(String),
+
+    Local(PathBuf),
 }
 
 /// Result of a pack execution.

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -303,6 +303,47 @@ fn app_dir_invalid_path_checked_before_applying_preprocessor() {
     );
 }
 
+#[test]
+#[ignore = "integration test"]
+fn basic_build_with_local_reference_to_single_buildpack() {
+    TestRunner::default().build(
+        BuildConfig::new("heroku/builder:22", "test-fixtures/procfile").buildpacks(vec![
+            BuildpackReference::Local(PathBuf::from("../libcnb-cargo/fixtures/single_buildpack")),
+        ]),
+        |context| {
+            assert_empty!(context.pack_stderr);
+            assert_contains!(
+                context.pack_stdout,
+                indoc! {"
+                    Single buildpack
+                "}
+            );
+        },
+    );
+}
+
+#[test]
+#[ignore = "integration test"]
+fn basic_build_with_local_reference_to_meta_buildpack() {
+    TestRunner::default().build(
+        BuildConfig::new("heroku/builder:22", "test-fixtures/procfile").buildpacks(vec![
+            BuildpackReference::Local(PathBuf::from(
+                "../libcnb-cargo/fixtures/multiple_buildpacks/meta-buildpacks/meta-two",
+            )),
+        ]),
+        |context| {
+            assert_empty!(context.pack_stderr);
+            assert_contains!(
+                context.pack_stdout,
+                indoc! {"
+                    One buildpack
+                    Two buildpack
+                "}
+            );
+        },
+    );
+}
+
 // We're referencing the procfile buildpack via Docker URL to pin the version for the tests. This also
 // prevents issues when the builder contains multiple heroku/procfile versions. We don't use CNB
 // registry URLs since, as of August 2022, pack fails when another pack instance is resolving such


### PR DESCRIPTION
The following changes have made to support local testing of buildpacks and meta-buildpacks:

- refactored shared functionality between `libcnb-cargo` and `libcnb-test` into `libcnb-package`
- modified the test runner to support a `BuildpackReference::Local` variant which is similar to `BuildpackReference::Crate` because both represent buildpacks on the file-system which need to be compiled
- after local and crate references are compiled, they are packaged into Docker images to get around an issue with pack not handling meta-buildpacks correctly (https://github.com/buildpacks/pack/issues/1320)
- all the images created during the test are then cleaned up afterwards

> Note:
> This is still rough around the edges.  A lot of the result error handling in `libcnb-test` is being skipped, documentation is missing, and some tests are still commented out.  Still, I'm putting this up now in case anyone wants to make comments or modifications
>
> If you want to try this out locally in a buildpack project:
> - check out this branch
> - use a path references for the `libcnb-test` dependency
> ```toml
>  libcnb-test = { path = "/Users/ccasey/Projects/heroku/libcnb.rs/libcnb-test" }
> ```
> - use the `BuildpackReference::Local` variant to specify a path to a buildpack or meta-buildpack
> ```rust
> TestRunner::default().build(
>   BuildConfig::new("heroku/builder:22", "/path/to/app")
>     .buildpacks(vec![
>       BuildpackReference::Local(PathBuf::from("../../meta-buildpacks/nodejs"))
>   ]), 
>   |ctx| {
>     // test body
>   }
> )
> ```