### PR TITLE
Switch to the zlib flate2 decompression backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ separate changelogs for each crate were used. If you need to refer to these old 
 
 - `libcnb-package`: buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need to adapt. The output of `cargo 
 libcnb package` will refer to the new locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
+- `libherokubuildpack`: Switch the `flate2` decompression backend from `miniz_oxide` to `zlib`. ([#593](https://github.com/heroku/libcnb.rs/pull/593))
 - Bump minimum external dependency versions. ([#587](https://github.com/heroku/libcnb.rs/pull/587))
 
 ## [0.13.0] 2023-06-21

--- a/examples/ruby-sample/Cargo.toml
+++ b/examples/ruby-sample/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-flate2 = "1.0.26"
+flate2 = { version = "1.0.26", default-features = false, features = ["zlib"] }
 libcnb.workspace = true
 serde = "1.0.166"
 sha2 = "0.10.7"

--- a/libherokubuildpack/Cargo.toml
+++ b/libherokubuildpack/Cargo.toml
@@ -28,7 +28,12 @@ write = []
 
 [dependencies]
 crossbeam-utils = { version = "0.8.16", optional = true }
-flate2 = { version = "1.0.26", optional = true }
+# The default `miniz_oxide` flate2 backend has poor performance in debug/under QEMU:
+# https://github.com/rust-lang/flate2-rs/issues/297
+# Ideally we'd use the fastest `zlib-ng` backend, however it fails to cross-compile:
+# https://github.com/rust-lang/libz-sys/issues/93
+# As such we have to use the next best alternate backend, which is `zlib`.
+flate2 = { version = "1.0.26", default-features = false, features = ["zlib"], optional = true }
 libcnb = { workspace = true, optional = true }
 pathdiff = { version = "0.2.1", optional = true }
 sha2 = { version = "0.10.7", optional = true }


### PR DESCRIPTION
The `flate2` crate supports multiple backends for performing decompression:
https://github.com/rust-lang/flate2-rs#backends

The default `miniz_oxide` flate2 backend has poor performance in debug builds/under QEMU:
https://github.com/rust-lang/flate2-rs/issues/297

Ideally we'd use the fastest `zlib-ng` backend, however it fails to cross-compile:
https://github.com/rust-lang/libz-sys/issues/93

As such we have to use the next best alternate backend, which is the `zlib` backend.

(This is the backend that the Python CNB already uses.)

GUS-W-13745779.