### PR TITLE
Pin to an older version of the example alpine builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,4 +71,6 @@ jobs:
         working-directory: ./examples/basics
       - name: Pack build using examples/basics
         # Uses a non-libc image to validate the static musl cross-compilation.
-        run: pack build example-basics --builder cnbs/sample-builder:alpine --buildpack target/buildpack/x86_64-unknown-linux-musl/debug/libcnb-examples_basics --path examples/
+        # TODO: Switch this back to using the `alpine` tag once the stable Pack CLI release supports
+        # image extensions (currently newer sample alpine images fail to build with stable Pack).
+        run: pack build example-basics --builder cnbs/sample-builder@sha256:da5ff69191919f1ff30d5e28859affff8e39f23038137c7751e24a42e919c1ab --trust-builder --buildpack target/buildpack/x86_64-unknown-linux-musl/debug/libcnb-examples_basics --path examples/


### PR DESCRIPTION
In CI a `pack build` is performed using one of libcnb's example CNBs and the upstream `cnb/sample-builder:alpine` builder, in order to test that our static MUSL compile works with non-libc base images.

However, CI has just started failing with:

```
ERROR: failed to build: experimental features must be enabled when builder contains image extensions
```
(https://github.com/heroku/libcnb.rs/actions/runs/5530837180/jobs/10090742723?pr=592#step:10:107)

This is due to the upstream images having been rebuilt with extension support, which is an experimental feature until the next stable Pack CLI release:
https://github.com/buildpacks/samples/pull/149
https://github.com/buildpacks/samples/pull/142
https://github.com/buildpacks/pack/releases/tag/v0.30.0-pre3

As such until Pack CLI v0.30 is released as stable, we'll have to pin to an older `alpine` image by SHA256 ref.

GUS-W-13746154.