### PR TITLE
Env helper layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - `libherokubuildpack`: Add `env::DefaultEnvLayer` and `env::ConfigureEnvLayer` structs for setting environment variables ([#598](https://github.com/heroku/libcnb.rs/pull/598))
 
 ## [0.17.0] - 2023-12-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `libherokubuildpack`: Add `env::DefaultEnvLayer` and `env::ConfigureEnvLayer` structs for setting environment variables ([#598](https://github.com/heroku/libcnb.rs/pull/598))
 
 ## [0.17.0] - 2023-12-06
 

--- a/libherokubuildpack/Cargo.toml
+++ b/libherokubuildpack/Cargo.toml
@@ -18,10 +18,10 @@ all-features = true
 workspace = true
 
 [features]
-default = ["command", "download", "digest", "error", "env", "log", "tar", "toml", "fs", "write"]
+default = ["command", "download", "digest", "error", "env_layer", "log", "tar", "toml", "fs", "write"]
 download = ["dep:ureq", "dep:thiserror"]
 digest = ["dep:sha2"]
-env = ["dep:libcnb"]
+env_layer = ["dep:libcnb"]
 error = ["log", "dep:libcnb"]
 log = ["dep:termcolor"]
 tar = ["dep:tar", "dep:flate2"]

--- a/libherokubuildpack/Cargo.toml
+++ b/libherokubuildpack/Cargo.toml
@@ -18,9 +18,10 @@ all-features = true
 workspace = true
 
 [features]
-default = ["command", "download", "digest", "error", "log", "tar", "toml", "fs", "write"]
+default = ["command", "download", "digest", "error", "env", "log", "tar", "toml", "fs", "write"]
 download = ["dep:ureq", "dep:thiserror"]
 digest = ["dep:sha2"]
+env = ["dep:libcnb"]
 error = ["log", "dep:libcnb"]
 log = ["dep:termcolor"]
 tar = ["dep:tar", "dep:flate2"]

--- a/libherokubuildpack/src/env.rs
+++ b/libherokubuildpack/src/env.rs
@@ -1,0 +1,209 @@
+use libcnb::build::BuildContext;
+use libcnb::data::layer_content_metadata::LayerTypes;
+use libcnb::generic::GenericMetadata;
+use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
+use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
+use std::ffi::OsString;
+use std::marker::PhantomData;
+use std::path::Path;
+
+/// Set default environment variables
+///
+/// If all you need to do is set default environment values, you can use
+/// the `DefaultEnvLayer::new` function to set those values without having
+/// to create a struct from scratch.
+///
+/// ```no_run
+///# use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
+///# use libcnb::data::launch::{LaunchBuilder, ProcessBuilder};
+///# use libcnb::data::process_type;
+///# use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
+///# use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
+///# use libcnb::{buildpack_main, Buildpack};
+///# use libcnb::data::layer::LayerName;
+///
+///# pub(crate) struct HelloWorldBuildpack;
+///
+/// use libcnb::Env;
+/// use libcnb::data::layer_name;
+/// use libcnb::layer_env::Scope;
+/// use libherokubuildpack::env::DefaultEnvLayer;
+///
+///# impl Buildpack for HelloWorldBuildpack {
+///#     type Platform = GenericPlatform;
+///#     type Metadata = GenericMetadata;
+///#     type Error = GenericError;
+///
+///#     fn detect(&self, _context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
+///#         todo!()
+///#     }
+///
+///#     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
+///         let env = Env::from_current();
+///         // Don't forget to apply context.platform.env() too;
+///
+///         let layer = context //
+///             .handle_layer(
+///                 layer_name!("default_env"),
+///                 DefaultEnvLayer::new(
+///                     [
+///                         ("JRUBY_OPTS", "-Xcompile.invokedynamic=false"),
+///                         ("RACK_ENV", "production"),
+///                         ("RAILS_ENV", "production"),
+///                         ("RAILS_SERVE_STATIC_FILES", "enabled"),
+///                         ("RAILS_LOG_TO_STDOUT", "enabled"),
+///                         ("MALLOC_ARENA_MAX", "2"),
+///                         ("DISABLE_SPRING", "1"),
+///                     ]
+///                     .into_iter(),
+///                 ),
+///             )?;
+///         let env = layer.env.apply(Scope::Build, &env);
+///
+///#        todo!()
+///#     }
+///# }
+///
+/// ```
+pub struct DefaultEnvLayer;
+
+impl DefaultEnvLayer {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<E, K, V, B>(env: E) -> ConfigureEnvLayer<B>
+    where
+        E: IntoIterator<Item = (K, V)> + Clone,
+        K: Into<OsString>,
+        V: Into<OsString>,
+        B: libcnb::Buildpack,
+    {
+        let mut layer_env = LayerEnv::new();
+        for (key, value) in env {
+            layer_env =
+                layer_env.chainable_insert(Scope::All, ModificationBehavior::Default, key, value);
+        }
+
+        ConfigureEnvLayer {
+            data: layer_env,
+            _buildpack: PhantomData,
+        }
+    }
+}
+
+/// Set environment variables
+///
+/// If you want to set many default environment variables you can use
+/// `DefaultEnvLayer`. If you need to set different types of environment
+/// variables you can use this struct `ConfigureEnvLayer`
+///
+/// Example:
+///
+/// ```no_run
+///# use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
+///# use libcnb::data::launch::{LaunchBuilder, ProcessBuilder};
+///# use libcnb::data::process_type;
+///# use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
+///# use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
+///# use libcnb::{buildpack_main, Buildpack};
+///# use libcnb::data::layer::LayerName;
+///
+///# pub(crate) struct HelloWorldBuildpack;
+///
+/// use libcnb::Env;
+/// use libcnb::data::layer_name;
+/// use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
+/// use libherokubuildpack::env::ConfigureEnvLayer;
+///
+///# impl Buildpack for HelloWorldBuildpack {
+///#     type Platform = GenericPlatform;
+///#     type Metadata = GenericMetadata;
+///#     type Error = GenericError;
+///
+///#     fn detect(&self, _context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
+///#         todo!()
+///#     }
+///
+///#     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
+///         let env = Env::from_current();
+///         // Don't forget to apply context.platform.env() too;
+///
+///         let layer = context //
+///             .handle_layer(
+///                 layer_name!("configure_env"),
+///                 ConfigureEnvLayer::new(
+///                     LayerEnv::new()
+///                         .chainable_insert(
+///                             Scope::All,
+///                             ModificationBehavior::Override,
+///                             "BUNDLE_GEMFILE", // Tells bundler where to find the `Gemfile`
+///                             context.app_dir.join("Gemfile"),
+///                         )
+///                         .chainable_insert(
+///                             Scope::All,
+///                             ModificationBehavior::Override,
+///                             "BUNDLE_CLEAN", // After successful `bundle install` bundler will automatically run `bundle clean`
+///                             "1",
+///                         )
+///                         .chainable_insert(
+///                             Scope::All,
+///                             ModificationBehavior::Override,
+///                             "BUNDLE_DEPLOYMENT", // Requires the `Gemfile.lock` to be in sync with the current `Gemfile`.
+///                             "1",
+///                         )
+///                         .chainable_insert(
+///                             Scope::All,
+///                             ModificationBehavior::Default,
+///                             "MY_ENV_VAR",
+///                             "Whatever I want"
+///                         )
+///                 ),
+///             )?;
+///         let env = layer.env.apply(Scope::Build, &env);
+///
+///#        todo!()
+///#     }
+///# }
+///
+/// ```
+pub struct ConfigureEnvLayer<B: libcnb::Buildpack> {
+    pub(crate) data: LayerEnv,
+    pub(crate) _buildpack: std::marker::PhantomData<B>,
+}
+
+impl<B> ConfigureEnvLayer<B>
+where
+    B: libcnb::Buildpack,
+{
+    #[must_use]
+    pub fn new(env: LayerEnv) -> Self {
+        ConfigureEnvLayer {
+            data: env,
+            _buildpack: PhantomData,
+        }
+    }
+}
+
+impl<B> Layer for ConfigureEnvLayer<B>
+where
+    B: libcnb::Buildpack,
+{
+    type Buildpack = B;
+    type Metadata = GenericMetadata;
+
+    fn types(&self) -> LayerTypes {
+        LayerTypes {
+            build: true,
+            launch: true,
+            cache: false,
+        }
+    }
+
+    fn create(
+        &self,
+        _context: &BuildContext<Self::Buildpack>,
+        _layer_path: &Path,
+    ) -> Result<LayerResult<Self::Metadata>, B::Error> {
+        LayerResultBuilder::new(GenericMetadata::default())
+            .env(self.data.clone())
+            .build()
+    }
+}

--- a/libherokubuildpack/src/env_layer.rs
+++ b/libherokubuildpack/src/env_layer.rs
@@ -1,114 +1,18 @@
 use libcnb::build::BuildContext;
-use libcnb::data::layer::LayerName;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::generic::GenericMetadata;
-use libcnb::layer::{Layer, LayerData, LayerResult, LayerResultBuilder};
-use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
-use libcnb::Buildpack;
-use std::ffi::OsString;
+use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
+use libcnb::layer_env::LayerEnv;
 use std::marker::PhantomData;
 use std::path::Path;
 
-/// Set default environment variables
+/// Convenience layer for setting environment variables
 ///
-/// If all you need to do is set default environment values, you can use
-/// the `env_layer::set_default` function to set those values without having
-/// to create a struct from scratch. Example:
+/// If you do not need to modify files on disk or cache metadata, you can use this layer along with
+/// [`BuildContext::handle_layer`] to apply results of [`LayerEnv::chainable_insert`] to build and
+/// launch (runtime) environments.
 ///
-/// ```no_run
-///# use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
-///# use libcnb::data::launch::{LaunchBuilder, ProcessBuilder};
-///# use libcnb::data::process_type;
-///# use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
-///# use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
-///# use libcnb::{buildpack_main, Buildpack};
-///# use libcnb::data::layer::LayerName;
-///
-///# pub(crate) struct HelloWorldBuildpack;
-///
-/// use libcnb::Env;
-/// use libcnb::data::layer_name;
-/// use libcnb::layer_env::Scope;
-/// use libherokubuildpack::env_layer;
-///
-///# impl Buildpack for HelloWorldBuildpack {
-///#     type Platform = GenericPlatform;
-///#     type Metadata = GenericMetadata;
-///#     type Error = GenericError;
-///
-///#     fn detect(&self, _context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
-///#         todo!()
-///#     }
-///
-///#     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
-///         // Don't forget to apply context.platform.env() in addition to current envs;
-///         let env = Env::from_current();
-///
-///         let layer = env_layer::set_default(&context, layer_name!("default_env"),
-///             [
-///                 ("JRUBY_OPTS", "-Xcompile.invokedynamic=false"),
-///                 ("RACK_ENV", "production"),
-///                 ("RAILS_ENV", "production"),
-///                 ("RAILS_SERVE_STATIC_FILES", "enabled"),
-///                 ("RAILS_LOG_TO_STDOUT", "enabled"),
-///                 ("MALLOC_ARENA_MAX", "2"),
-///                 ("DISABLE_SPRING", "1"),
-///             ]
-///             .into_iter(),
-///         )?;
-///         let env = layer.env.apply(Scope::Build, &env);
-///
-///#        todo!()
-///#     }
-///# }
-/// ```
-pub fn set_default<B, E, K, V>(
-    context: &BuildContext<B>,
-    layer_name: LayerName,
-    envs: E,
-) -> libcnb::Result<LayerData<GenericMetadata>, <B as Buildpack>::Error>
-where
-    B: Buildpack,
-    E: IntoIterator<Item = (K, V)> + Clone,
-    K: Into<OsString>,
-    V: Into<OsString>,
-{
-    context.handle_layer(layer_name, DefaultEnvLayer::new(envs))
-}
-
-/// Set default environment variables in a layer
-///
-/// This struct is used by the helper function `set_default`. You can also use it directly with
-/// with [`BuildContext::handle_layer`] to set default environment variables.
-pub struct DefaultEnvLayer;
-
-impl DefaultEnvLayer {
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new<E, K, V, B>(env: E) -> ConfigureEnvLayer<B>
-    where
-        E: IntoIterator<Item = (K, V)> + Clone,
-        K: Into<OsString>,
-        V: Into<OsString>,
-        B: libcnb::Buildpack,
-    {
-        let mut layer_env = LayerEnv::new();
-        for (key, value) in env {
-            layer_env =
-                layer_env.chainable_insert(Scope::All, ModificationBehavior::Default, key, value);
-        }
-
-        ConfigureEnvLayer {
-            data: layer_env,
-            _buildpack: PhantomData,
-        }
-    }
-}
-
-/// Set environment variables
-///
-/// If you want to set many default environment variables you can use the
-/// `env_layer::set_default` function. If you need to set different types of environment
-/// variables you can use the `env_layer::set_envs` function. Example:
+/// Example:
 ///
 /// ```no_run
 ///# use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
@@ -136,38 +40,38 @@ impl DefaultEnvLayer {
 ///#     }
 ///
 ///#     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
-///         // Don't forget to apply context.platform.env() too;
 ///         let env = Env::from_current();
 ///
 ///         let env = {
-///             let layer = env_layer::set_envs(
-///                 &context,
+///             let layer = context.handle_layer(
 ///                 layer_name!("configure_env"),
-///                 LayerEnv::new()
-///                     .chainable_insert(
-///                         Scope::All,
-///                         ModificationBehavior::Override,
-///                         "BUNDLE_GEMFILE", // Tells bundler where to find the `Gemfile`
-///                         context.app_dir.join("Gemfile"),
-///                     )
-///                     .chainable_insert(
-///                         Scope::All,
-///                         ModificationBehavior::Override,
-///                         "BUNDLE_CLEAN", // After successful `bundle install` bundler will automatically run `bundle clean`
-///                         "1",
-///                     )
-///                     .chainable_insert(
-///                         Scope::All,
-///                         ModificationBehavior::Override,
-///                         "BUNDLE_DEPLOYMENT", // Requires the `Gemfile.lock` to be in sync with the current `Gemfile`.
-///                         "1",
-///                     )
-///                     .chainable_insert(
-///                         Scope::All,
-///                         ModificationBehavior::Default,
-///                         "MY_ENV_VAR",
-///                         "Whatever I want"
-///                     )
+///                 env_layer::ConfigureEnvLayer::new(
+///                     LayerEnv::new()
+///                         .chainable_insert(
+///                             Scope::All,
+///                             ModificationBehavior::Override,
+///                             "BUNDLE_GEMFILE", // Tells bundler where to find the `Gemfile`
+///                             context.app_dir.join("Gemfile"),
+///                         )
+///                         .chainable_insert(
+///                             Scope::All,
+///                             ModificationBehavior::Override,
+///                             "BUNDLE_CLEAN", // After successful `bundle install` bundler will automatically run `bundle clean`
+///                             "1",
+///                         )
+///                         .chainable_insert(
+///                             Scope::All,
+///                             ModificationBehavior::Override,
+///                             "BUNDLE_DEPLOYMENT", // Requires the `Gemfile.lock` to be in sync with the current `Gemfile`.
+///                             "1",
+///                         )
+///                         .chainable_insert(
+///                             Scope::All,
+///                             ModificationBehavior::Default,
+///                             "MY_ENV_VAR",
+///                             "Whatever I want",
+///                         ),
+///                 ),
 ///             )?;
 ///             layer.env.apply(Scope::Build, &env)
 ///         };
@@ -176,21 +80,6 @@ impl DefaultEnvLayer {
 ///#     }
 ///# }
 /// ```
-pub fn set_envs<B>(
-    context: &BuildContext<B>,
-    layer_name: LayerName,
-    envs: LayerEnv,
-) -> libcnb::Result<LayerData<GenericMetadata>, <B as Buildpack>::Error>
-where
-    B: Buildpack,
-{
-    context.handle_layer(layer_name, ConfigureEnvLayer::new(envs))
-}
-
-/// Set custom environment variables in a layer
-///
-/// This struct is used by the helper function `set_envs`. You can also use it directly with
-/// use directly with [`BuildContext::handle_layer`] to set specific environment variables.
 pub struct ConfigureEnvLayer<B: libcnb::Buildpack> {
     pub(crate) data: LayerEnv,
     pub(crate) _buildpack: std::marker::PhantomData<B>,

--- a/libherokubuildpack/src/env_layer.rs
+++ b/libherokubuildpack/src/env_layer.rs
@@ -1,8 +1,10 @@
 use libcnb::build::BuildContext;
+use libcnb::data::layer::LayerName;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::generic::GenericMetadata;
-use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
+use libcnb::layer::{Layer, LayerData, LayerResult, LayerResultBuilder};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
+use libcnb::Buildpack;
 use std::ffi::OsString;
 use std::marker::PhantomData;
 use std::path::Path;
@@ -10,8 +12,8 @@ use std::path::Path;
 /// Set default environment variables
 ///
 /// If all you need to do is set default environment values, you can use
-/// the `DefaultEnvLayer::new` function to set those values without having
-/// to create a struct from scratch.
+/// the `env_layer::set_default` function to set those values without having
+/// to create a struct from scratch. Example:
 ///
 /// ```no_run
 ///# use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
@@ -27,7 +29,7 @@ use std::path::Path;
 /// use libcnb::Env;
 /// use libcnb::data::layer_name;
 /// use libcnb::layer_env::Scope;
-/// use libherokubuildpack::env::DefaultEnvLayer;
+/// use libherokubuildpack::env_layer;
 ///
 ///# impl Buildpack for HelloWorldBuildpack {
 ///#     type Platform = GenericPlatform;
@@ -39,32 +41,45 @@ use std::path::Path;
 ///#     }
 ///
 ///#     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
+///         // Don't forget to apply context.platform.env() in addition to current envs;
 ///         let env = Env::from_current();
-///         // Don't forget to apply context.platform.env() too;
 ///
-///         let layer = context //
-///             .handle_layer(
-///                 layer_name!("default_env"),
-///                 DefaultEnvLayer::new(
-///                     [
-///                         ("JRUBY_OPTS", "-Xcompile.invokedynamic=false"),
-///                         ("RACK_ENV", "production"),
-///                         ("RAILS_ENV", "production"),
-///                         ("RAILS_SERVE_STATIC_FILES", "enabled"),
-///                         ("RAILS_LOG_TO_STDOUT", "enabled"),
-///                         ("MALLOC_ARENA_MAX", "2"),
-///                         ("DISABLE_SPRING", "1"),
-///                     ]
-///                     .into_iter(),
-///                 ),
-///             )?;
+///         let layer = env_layer::set_default(&context, layer_name!("default_env"),
+///             [
+///                 ("JRUBY_OPTS", "-Xcompile.invokedynamic=false"),
+///                 ("RACK_ENV", "production"),
+///                 ("RAILS_ENV", "production"),
+///                 ("RAILS_SERVE_STATIC_FILES", "enabled"),
+///                 ("RAILS_LOG_TO_STDOUT", "enabled"),
+///                 ("MALLOC_ARENA_MAX", "2"),
+///                 ("DISABLE_SPRING", "1"),
+///             ]
+///             .into_iter(),
+///         )?;
 ///         let env = layer.env.apply(Scope::Build, &env);
 ///
 ///#        todo!()
 ///#     }
 ///# }
-///
 /// ```
+pub fn set_default<B, E, K, V>(
+    context: &BuildContext<B>,
+    layer_name: LayerName,
+    envs: E,
+) -> libcnb::Result<LayerData<GenericMetadata>, <B as Buildpack>::Error>
+where
+    B: Buildpack,
+    E: IntoIterator<Item = (K, V)> + Clone,
+    K: Into<OsString>,
+    V: Into<OsString>,
+{
+    context.handle_layer(layer_name, DefaultEnvLayer::new(envs))
+}
+
+/// Set default environment variables in a layer
+///
+/// This struct is used by the helper function `set_default`. You can also use it directly with
+/// with [`BuildContext::handle_layer`] to set default environment variables.
 pub struct DefaultEnvLayer;
 
 impl DefaultEnvLayer {
@@ -91,11 +106,9 @@ impl DefaultEnvLayer {
 
 /// Set environment variables
 ///
-/// If you want to set many default environment variables you can use
-/// `DefaultEnvLayer`. If you need to set different types of environment
-/// variables you can use this struct `ConfigureEnvLayer`
-///
-/// Example:
+/// If you want to set many default environment variables you can use the
+/// `env_layer::set_default` function. If you need to set different types of environment
+/// variables you can use the `env_layer::set_envs` function. Example:
 ///
 /// ```no_run
 ///# use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
@@ -111,7 +124,7 @@ impl DefaultEnvLayer {
 /// use libcnb::Env;
 /// use libcnb::data::layer_name;
 /// use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
-/// use libherokubuildpack::env::ConfigureEnvLayer;
+/// use libherokubuildpack::env_layer;
 ///
 ///# impl Buildpack for HelloWorldBuildpack {
 ///#     type Platform = GenericPlatform;
@@ -123,47 +136,61 @@ impl DefaultEnvLayer {
 ///#     }
 ///
 ///#     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
-///         let env = Env::from_current();
 ///         // Don't forget to apply context.platform.env() too;
+///         let env = Env::from_current();
 ///
-///         let layer = context //
-///             .handle_layer(
+///         let env = {
+///             let layer = env_layer::set_envs(
+///                 &context,
 ///                 layer_name!("configure_env"),
-///                 ConfigureEnvLayer::new(
-///                     LayerEnv::new()
-///                         .chainable_insert(
-///                             Scope::All,
-///                             ModificationBehavior::Override,
-///                             "BUNDLE_GEMFILE", // Tells bundler where to find the `Gemfile`
-///                             context.app_dir.join("Gemfile"),
-///                         )
-///                         .chainable_insert(
-///                             Scope::All,
-///                             ModificationBehavior::Override,
-///                             "BUNDLE_CLEAN", // After successful `bundle install` bundler will automatically run `bundle clean`
-///                             "1",
-///                         )
-///                         .chainable_insert(
-///                             Scope::All,
-///                             ModificationBehavior::Override,
-///                             "BUNDLE_DEPLOYMENT", // Requires the `Gemfile.lock` to be in sync with the current `Gemfile`.
-///                             "1",
-///                         )
-///                         .chainable_insert(
-///                             Scope::All,
-///                             ModificationBehavior::Default,
-///                             "MY_ENV_VAR",
-///                             "Whatever I want"
-///                         )
-///                 ),
+///                 LayerEnv::new()
+///                     .chainable_insert(
+///                         Scope::All,
+///                         ModificationBehavior::Override,
+///                         "BUNDLE_GEMFILE", // Tells bundler where to find the `Gemfile`
+///                         context.app_dir.join("Gemfile"),
+///                     )
+///                     .chainable_insert(
+///                         Scope::All,
+///                         ModificationBehavior::Override,
+///                         "BUNDLE_CLEAN", // After successful `bundle install` bundler will automatically run `bundle clean`
+///                         "1",
+///                     )
+///                     .chainable_insert(
+///                         Scope::All,
+///                         ModificationBehavior::Override,
+///                         "BUNDLE_DEPLOYMENT", // Requires the `Gemfile.lock` to be in sync with the current `Gemfile`.
+///                         "1",
+///                     )
+///                     .chainable_insert(
+///                         Scope::All,
+///                         ModificationBehavior::Default,
+///                         "MY_ENV_VAR",
+///                         "Whatever I want"
+///                     )
 ///             )?;
-///         let env = layer.env.apply(Scope::Build, &env);
+///             layer.env.apply(Scope::Build, &env)
+///         };
 ///
 ///#        todo!()
 ///#     }
 ///# }
-///
 /// ```
+pub fn set_envs<B>(
+    context: &BuildContext<B>,
+    layer_name: LayerName,
+    envs: LayerEnv,
+) -> libcnb::Result<LayerData<GenericMetadata>, <B as Buildpack>::Error>
+where
+    B: Buildpack,
+{
+    context.handle_layer(layer_name, ConfigureEnvLayer::new(envs))
+}
+
+/// Set custom environment variables in a layer
+///
+/// This struct is used by the helper function `set_envs`. You can also use it directly with
+/// use directly with [`BuildContext::handle_layer`] to set specific environment variables.
 pub struct ConfigureEnvLayer<B: libcnb::Buildpack> {
     pub(crate) data: LayerEnv,
     pub(crate) _buildpack: std::marker::PhantomData<B>,

--- a/libherokubuildpack/src/lib.rs
+++ b/libherokubuildpack/src/lib.rs
@@ -6,6 +6,8 @@ pub mod command;
 pub mod digest;
 #[cfg(feature = "download")]
 pub mod download;
+#[cfg(feature = "env")]
+pub mod env;
 #[cfg(feature = "error")]
 pub mod error;
 #[cfg(feature = "fs")]

--- a/libherokubuildpack/src/lib.rs
+++ b/libherokubuildpack/src/lib.rs
@@ -6,8 +6,8 @@ pub mod command;
 pub mod digest;
 #[cfg(feature = "download")]
 pub mod download;
-#[cfg(feature = "env")]
-pub mod env;
+#[cfg(feature = "env_layer")]
+pub mod env_layer;
 #[cfg(feature = "error")]
 pub mod error;
 #[cfg(feature = "fs")]


### PR DESCRIPTION
When a developer needs to set environment variables only, they have to make a layer struct and pass it to `handle_layer`. Instead of forcing them to write a boilerplate struct, this commit provides two utility structs:

- `DefaultEnvLayer` - Used to set default environment variables
- `ConfigureEnvLayer` - Can be used with `LayerEnv::new()` to configure any environment variables (versus `DefaultEnvLayer` only creates default environment variables).

An alternative to providing structs could be to provide functions that accept a context and layer name in addition to the required env data.

GUS-W-13815854.