### PR TITLE
Mark Dependabot PRs as "skip changelog" by default

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "rust"
+      - "skip changelog"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "github actions"
+      - "skip changelog"

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -9,8 +9,8 @@ permissions:
 
 jobs:
   check-changelog:
-    runs-on: ubuntu-22.04
-    if: "!contains(github.event.pull_request.labels.*.name, 'skip changelog')"
+    runs-on: ubuntu-latest
+    if: (!contains(github.event.pull_request.labels.*.name, 'skip changelog'))
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Since virtually all dependency update PRs have not needed a changelog entry:
https://github.com/heroku/libcnb.rs/pulls?q=is%3Apr+label%3Adependencies

...and this saves us having to manually add the "skip changelog" label each time.

GUS-W-13787963.