### PR TITLE
Use HashSet instead of Vec for ContainerConfig's `exposed_ports`

### DIFF
--- a/libcnb-test/src/container_config.rs
+++ b/libcnb-test/src/container_config.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Config used when starting a container.
 ///
@@ -28,7 +28,7 @@ pub struct ContainerConfig {
     pub(crate) entrypoint: Option<Vec<String>>,
     pub(crate) command: Option<Vec<String>>,
     pub(crate) env: HashMap<String, String>,
-    pub(crate) exposed_ports: Vec<u16>,
+    pub(crate) exposed_ports: HashSet<u16>,
 }
 
 impl ContainerConfig {
@@ -136,7 +136,7 @@ impl ContainerConfig {
     /// );
     /// ```
     pub fn expose_port(&mut self, port: u16) -> &mut Self {
-        self.exposed_ports.push(port);
+        self.exposed_ports.insert(port);
         self
     }
 

--- a/libcnb-test/src/container_port_mapping.rs
+++ b/libcnb-test/src/container_port_mapping.rs
@@ -1,6 +1,6 @@
 use bollard::container::Config;
 use bollard::models::{HostConfig, PortBinding, PortMap};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::{AddrParseError, SocketAddr};
 use std::num::ParseIntError;
 
@@ -67,7 +67,9 @@ fn parse_port_map_entry(
 /// Create a new Bollard container config with the given exposed ports.
 ///
 /// The exposed ports will be forwarded to random ports on the host.
-pub(crate) fn port_mapped_container_config(ports: &[u16]) -> bollard::container::Config<String> {
+pub(crate) fn port_mapped_container_config(
+    ports: &HashSet<u16>,
+) -> bollard::container::Config<String> {
     Config {
         host_config: Some(HostConfig {
             port_bindings: Some(
@@ -174,7 +176,7 @@ mod tests {
 
     #[test]
     fn port_mapped_container_config_simple() {
-        let config = port_mapped_container_config(&[80, 443, 22]);
+        let config = port_mapped_container_config(&HashSet::from([80, 443, 22]));
 
         assert_eq!(
             config.exposed_ports,


### PR DESCRIPTION
Since a port can only be exposed once, so a set is a more accurate representation than a vector.

This field is private, so this is not a breaking change.