### PR TITLE
Clean up formatting of Rust code in markdown

### DIFF
--- a/libcnb-data/src/buildpack/id.rs
+++ b/libcnb-data/src/buildpack/id.rs
@@ -8,8 +8,8 @@ libcnb_newtype!(
     ///
     /// # Examples:
     /// ```
-    /// use libcnb_data::buildpack_id;
     /// use libcnb_data::buildpack::BuildpackId;
+    /// use libcnb_data::buildpack_id;
     ///
     /// let buildpack_id: BuildpackId = buildpack_id!("heroku/java");
     /// ```

--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -44,10 +44,16 @@ pub use version::*;
 /// id = "*"
 /// "#;
 ///
-/// let buildpack_descriptor = toml::from_str::<BuildpackDescriptor<Option<toml::value::Table>>>(toml_str).expect("buildpack.toml did not match a known type!");
+/// let buildpack_descriptor =
+///     toml::from_str::<BuildpackDescriptor<Option<toml::value::Table>>>(toml_str)
+///         .expect("buildpack.toml did not match a known type!");
 /// match buildpack_descriptor {
-///     BuildpackDescriptor::Single(buildpack) => println!("Found buildpack: {}", buildpack.buildpack.id),
-///     BuildpackDescriptor::Meta(buildpack) => println!("Found meta-buildpack: {}", buildpack.buildpack.id),
+///     BuildpackDescriptor::Single(buildpack) => {
+///         println!("Found buildpack: {}", buildpack.buildpack.id);
+///     }
+///     BuildpackDescriptor::Meta(buildpack) => {
+///         println!("Found meta-buildpack: {}", buildpack.buildpack.id);
+///     }
 /// };
 /// ```
 #[derive(Deserialize, Debug)]
@@ -75,8 +81,8 @@ impl<BM> BuildpackDescriptor<BM> {
 ///
 /// # Example:
 /// ```
-/// use libcnb_data::buildpack_id;
 /// use libcnb_data::buildpack::{SingleBuildpackDescriptor, Stack};
+/// use libcnb_data::buildpack_id;
 ///
 /// let toml_str = r#"
 /// api = "0.9"
@@ -97,7 +103,8 @@ impl<BM> BuildpackDescriptor<BM> {
 /// id = "*"
 /// "#;
 ///
-/// let buildpack_descriptor = toml::from_str::<SingleBuildpackDescriptor<Option<toml::value::Table>>>(toml_str).unwrap();
+/// let buildpack_descriptor =
+///     toml::from_str::<SingleBuildpackDescriptor<Option<toml::value::Table>>>(toml_str).unwrap();
 /// assert_eq!(buildpack_descriptor.buildpack.id, buildpack_id!("foo/bar"));
 /// assert_eq!(buildpack_descriptor.stacks, vec![Stack::Any]);
 /// ```
@@ -119,8 +126,8 @@ pub struct SingleBuildpackDescriptor<BM> {
 ///
 /// # Example:
 /// ```
-/// use libcnb_data::buildpack_id;
 /// use libcnb_data::buildpack::MetaBuildpackDescriptor;
+/// use libcnb_data::buildpack_id;
 ///
 /// let toml_str = r#"
 /// api = "0.9"
@@ -144,7 +151,8 @@ pub struct SingleBuildpackDescriptor<BM> {
 /// version = "0.0.1"
 /// "#;
 ///
-/// let buildpack_descriptor = toml::from_str::<MetaBuildpackDescriptor<Option<toml::value::Table>>>(toml_str).unwrap();
+/// let buildpack_descriptor =
+///     toml::from_str::<MetaBuildpackDescriptor<Option<toml::value::Table>>>(toml_str).unwrap();
 /// assert_eq!(buildpack_descriptor.buildpack.id, buildpack_id!("foo/bar"));
 /// ```
 #[derive(Deserialize, Debug)]

--- a/libcnb-data/src/buildpack/stack_id.rs
+++ b/libcnb-data/src/buildpack/stack_id.rs
@@ -8,8 +8,8 @@ libcnb_newtype!(
     ///
     /// # Examples:
     /// ```
-    /// use libcnb_data::stack_id;
     /// use libcnb_data::buildpack::StackId;
+    /// use libcnb_data::stack_id;
     ///
     /// let stack_id: StackId = stack_id!("heroku-20");
     /// ```

--- a/libcnb-data/src/layer.rs
+++ b/libcnb-data/src/layer.rs
@@ -8,8 +8,8 @@ libcnb_newtype!(
     ///
     /// # Examples:
     /// ```
-    /// use libcnb_data::layer_name;
     /// use libcnb_data::layer::LayerName;
+    /// use libcnb_data::layer_name;
     ///
     /// let layer_name: LayerName = layer_name!("foobar");
     /// ```

--- a/libcnb-proc-macros/src/lib.rs
+++ b/libcnb-proc-macros/src/lib.rs
@@ -17,7 +17,12 @@ use syn::Token;
 /// doesn't match but it might work for other use-cases as well.
 ///
 /// ```
-/// libcnb_proc_macros::verify_regex!("^A-Z+$", "foobar", println!("It did match!"), println!("It did not match!"));
+/// libcnb_proc_macros::verify_regex!(
+///     "^A-Z+$",
+///     "foobar",
+///     println!("It did match!"),
+///     println!("It did not match!")
+/// );
 /// ```
 #[proc_macro]
 pub fn verify_regex(input: TokenStream) -> TokenStream {

--- a/libcnb-test/src/build_config.rs
+++ b/libcnb-test/src/build_config.rs
@@ -179,9 +179,11 @@ impl BuildConfig {
     /// use libcnb_test::{BuildConfig, TestRunner};
     ///
     /// TestRunner::default().build(
-    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app").app_dir_preprocessor(|app_dir| {
-    ///         std::fs::remove_file(app_dir.join("Procfile")).unwrap();
-    ///     }),
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app").app_dir_preprocessor(
+    ///         |app_dir| {
+    ///             std::fs::remove_file(app_dir.join("Procfile")).unwrap();
+    ///         },
+    ///     ),
     ///     |context| {
     ///         // ...
     ///     },

--- a/libcnb-test/src/container_config.rs
+++ b/libcnb-test/src/container_config.rs
@@ -15,7 +15,9 @@ use std::collections::HashMap;
 ///     |context| {
 ///         // ...
 ///         context.start_container(
-///             ContainerConfig::new().env("PORT", "12345").expose_port(12345),
+///             ContainerConfig::new()
+///                 .env("PORT", "12345")
+///                 .expose_port(12345),
 ///             |container| {
 ///                 // ...
 ///             },
@@ -47,7 +49,9 @@ impl ContainerConfig {
     ///     |context| {
     ///         // ...
     ///         context.start_container(
-    ///             ContainerConfig::new().env("PORT", "12345").expose_port(12345),
+    ///             ContainerConfig::new()
+    ///                 .env("PORT", "12345")
+    ///                 .expose_port(12345),
     ///             |container| {
     ///                 // ...
     ///             },
@@ -126,7 +130,9 @@ impl ContainerConfig {
     ///     |context| {
     ///         // ...
     ///         context.start_container(
-    ///             ContainerConfig::new().env("PORT", "12345").expose_port(12345),
+    ///             ContainerConfig::new()
+    ///                 .env("PORT", "12345")
+    ///                 .expose_port(12345),
     ///             |container| {
     ///                 let address_on_host = container.address_for_port(12345).unwrap();
     ///                 // ...

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -111,7 +111,9 @@ impl<'a> ContainerContext<'a> {
     ///     |context| {
     ///         // ...
     ///         context.start_container(
-    ///             ContainerConfig::new().env("PORT", "12345").expose_port(12345),
+    ///             ContainerConfig::new()
+    ///                 .env("PORT", "12345")
+    ///                 .expose_port(12345),
     ///             |container| {
     ///                 let address_on_host = container.address_for_port(12345).unwrap();
     ///                 // ...

--- a/libcnb-test/src/test_context.rs
+++ b/libcnb-test/src/test_context.rs
@@ -132,7 +132,8 @@ impl<'a> TestContext<'a> {
     ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),
     ///     |context| {
     ///         // ...
-    ///         let command_output = context.run_shell_command("for i in {1..3}; do echo \"${i}\"; done");
+    ///         let command_output =
+    ///             context.run_shell_command("for i in {1..3}; do echo \"${i}\"; done");
     ///         assert_eq!(command_output.stdout, "1\n2\n3\n");
     ///     },
     /// );
@@ -178,9 +179,9 @@ impl<'a> TestContext<'a> {
     ///
     /// # Example
     /// ```no_run
+    /// use libcnb_data::buildpack_id;
     /// use libcnb_data::sbom::SbomFormat;
     /// use libcnb_test::{BuildConfig, ContainerConfig, SbomType, TestRunner};
-    /// use libcnb_data::buildpack_id;
     ///
     /// TestRunner::default().build(
     ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app"),

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -136,10 +136,10 @@ pub(crate) enum InnerBuildResult {
 ///
 /// # Examples:
 /// ```
-/// use libcnb::build::{BuildResultBuilder, BuildResult};
+/// use libcnb::build::{BuildResult, BuildResultBuilder};
 /// use libcnb::data::launch::LaunchBuilder;
-/// use libcnb::data::process_type;
 /// use libcnb::data::launch::ProcessBuilder;
+/// use libcnb::data::process_type;
 ///
 /// let simple: Result<BuildResult, ()> = BuildResultBuilder::new().build();
 ///

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -33,15 +33,15 @@ pub(crate) enum InnerDetectResult {
 ///
 /// # Examples:
 /// ```
-/// use libcnb::detect::{DetectResultBuilder, DetectResult};
+/// use libcnb::detect::{DetectResult, DetectResultBuilder};
 /// use libcnb_data::build_plan::BuildPlanBuilder;
 ///
 /// let simple_pass: Result<DetectResult, ()> = DetectResultBuilder::pass().build();
 /// let simple_fail: Result<DetectResult, ()> = DetectResultBuilder::fail().build();
 ///
 /// let with_build_plan: Result<DetectResult, ()> = DetectResultBuilder::pass()
-///    .build_plan(BuildPlanBuilder::new().provides("something").build())
-///    .build();
+///     .build_plan(BuildPlanBuilder::new().provides("something").build())
+///     .build();
 /// ```
 #[must_use]
 pub struct DetectResultBuilder;

--- a/libcnb/src/env.rs
+++ b/libcnb/src/env.rs
@@ -7,8 +7,8 @@ use std::ffi::{OsStr, OsString};
 ///
 /// # Examples
 /// ```
-/// use std::process::Command;
 /// use libcnb::Env;
+/// use std::process::Command;
 ///
 /// let mut env = Env::new();
 /// env.insert("FOO", "BAR");

--- a/libcnb/src/layer/public_interface.rs
+++ b/libcnb/src/layer/public_interface.rs
@@ -230,11 +230,11 @@ impl<M> LayerResultBuilder<M> {
     /// # Example
     ///
     /// ```no_run
-    /// use std::path::PathBuf;
+    /// use libcnb::data::sbom::SbomFormat;
     /// use libcnb::generic::GenericMetadata;
     /// use libcnb::layer::LayerResultBuilder;
     /// use libcnb::sbom::Sbom;
-    /// use libcnb::data::sbom::SbomFormat;
+    /// use std::path::PathBuf;
     ///
     /// # fn wrapper() -> std::io::Result<libcnb::layer::LayerResult<GenericMetadata>> {
     /// LayerResultBuilder::new(GenericMetadata::default())

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 ///
 /// To apply a `LayerEnv` delta to a given `Env`, use [`LayerEnv::apply`] like so:
 /// ```
-/// use libcnb::layer_env::{LayerEnv, Scope, ModificationBehavior};
+/// use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 /// use libcnb::Env;
 ///
 /// let mut layer_env = LayerEnv::new();
@@ -63,8 +63,8 @@ use std::path::Path;
 /// from disk:
 /// ```
 /// use libcnb::layer_env::{LayerEnv, Scope};
-/// use tempfile::tempdir;
 /// use std::fs;
+/// use tempfile::tempdir;
 ///
 /// // Create a bogus layer directory
 /// let temp_dir = tempdir().unwrap();
@@ -120,7 +120,7 @@ impl LayerEnv {
     ///
     /// # Example:
     /// ```
-    /// use libcnb::layer_env::{LayerEnv, Scope, ModificationBehavior};
+    /// use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
     /// use libcnb::Env;
     ///
     /// let mut layer_env = LayerEnv::new();
@@ -171,7 +171,7 @@ impl LayerEnv {
     ///
     /// # Example:
     /// ```
-    /// use libcnb::layer_env::{LayerEnv, Scope, ModificationBehavior};
+    /// use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
     ///
     /// let mut layer_env = LayerEnv::new();
     /// layer_env.insert(Scope::All, ModificationBehavior::Default, "VAR", "hello");
@@ -224,18 +224,8 @@ impl LayerEnv {
     ///
     /// something_that_needs_layer_env(
     ///     LayerEnv::new()
-    ///         .chainable_insert(
-    ///             Scope::All,
-    ///             ModificationBehavior::Default,
-    ///             "VAR",
-    ///             "hello",
-    ///         )
-    ///         .chainable_insert(
-    ///             Scope::All,
-    ///             ModificationBehavior::Append,
-    ///             "VAR2",
-    ///             "bar",
-    ///         ),
+    ///         .chainable_insert(Scope::All, ModificationBehavior::Default, "VAR", "hello")
+    ///         .chainable_insert(Scope::All, ModificationBehavior::Append, "VAR2", "bar"),
     /// );
     /// ```
     #[must_use]
@@ -261,8 +251,8 @@ impl LayerEnv {
     /// # Example:
     /// ```
     /// use libcnb::layer_env::{LayerEnv, Scope};
-    /// use tempfile::tempdir;
     /// use std::fs;
+    /// use tempfile::tempdir;
     ///
     /// // Create a bogus layer directory
     /// let temp_dir = tempdir().unwrap();
@@ -271,13 +261,20 @@ impl LayerEnv {
     ///
     /// let layer_env_dir = layer_dir.join("env");
     /// fs::create_dir_all(&layer_env_dir).unwrap();
-    /// fs::write(layer_env_dir.join("ZERO_WING.default"), "ALL_YOUR_BASE_ARE_BELONG_TO_US").unwrap();
+    /// fs::write(
+    ///     layer_env_dir.join("ZERO_WING.default"),
+    ///     "ALL_YOUR_BASE_ARE_BELONG_TO_US",
+    /// )
+    /// .unwrap();
     ///
     /// let layer_env = LayerEnv::read_from_layer_dir(&layer_dir).unwrap();
     /// let env = layer_env.apply_to_empty(Scope::Launch);
     ///
     /// assert_eq!(env.get("PATH").cloned().unwrap(), layer_dir.join("bin"));
-    /// assert_eq!(env.get("ZERO_WING").cloned().unwrap(), "ALL_YOUR_BASE_ARE_BELONG_TO_US");
+    /// assert_eq!(
+    ///     env.get("ZERO_WING").cloned().unwrap(),
+    ///     "ALL_YOUR_BASE_ARE_BELONG_TO_US"
+    /// );
     /// ```
     pub fn read_from_layer_dir(layer_dir: impl AsRef<Path>) -> Result<Self, std::io::Error> {
         let mut result_layer_env = Self::new();
@@ -338,19 +335,30 @@ impl LayerEnv {
     ///
     /// Example:
     /// ```
-    /// use libcnb::layer_env::{LayerEnv, Scope, ModificationBehavior};
-    /// use tempfile::tempdir;
+    /// use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
     /// use std::fs;
+    /// use tempfile::tempdir;
     ///
     /// let mut layer_env = LayerEnv::new();
     /// layer_env.insert(Scope::Build, ModificationBehavior::Default, "FOO", "bar");
-    /// layer_env.insert(Scope::All, ModificationBehavior::Append, "PATH", "some-path");
+    /// layer_env.insert(
+    ///     Scope::All,
+    ///     ModificationBehavior::Append,
+    ///     "PATH",
+    ///     "some-path",
+    /// );
     ///
     /// let temp_dir = tempdir().unwrap();
     /// layer_env.write_to_layer_dir(&temp_dir).unwrap();
     ///
-    /// assert_eq!(fs::read_to_string(temp_dir.path().join("env.build").join("FOO.default")).unwrap(), "bar");
-    /// assert_eq!(fs::read_to_string(temp_dir.path().join("env").join("PATH.append")).unwrap(), "some-path");
+    /// assert_eq!(
+    ///     fs::read_to_string(temp_dir.path().join("env.build").join("FOO.default")).unwrap(),
+    ///     "bar"
+    /// );
+    /// assert_eq!(
+    ///     fs::read_to_string(temp_dir.path().join("env").join("PATH.append")).unwrap(),
+    ///     "some-path"
+    /// );
     /// ```
     pub fn write_to_layer_dir(&self, layer_dir: impl AsRef<Path>) -> std::io::Result<()> {
         self.all.write_to_env_dir(layer_dir.as_ref().join("env"))?;

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -59,7 +59,10 @@ const LIBCNB_SUPPORTED_BUILDPACK_API: data::buildpack::BuildpackApi =
 ///     type Metadata = GenericMetadata;
 ///     type Error = GenericError;
 ///
-///     fn detect(&self, context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
+///     fn detect(
+///         &self,
+///         context: DetectContext<Self>,
+///     ) -> libcnb::Result<DetectResult, Self::Error> {
 ///         DetectResultBuilder::pass().build()
 ///     }
 ///

--- a/libcnb/src/platform.rs
+++ b/libcnb/src/platform.rs
@@ -22,8 +22,8 @@ where
     ///
     /// # Examples
     /// ```no_run
-    /// use libcnb::Platform;
     /// use libcnb::generic::GenericPlatform;
+    /// use libcnb::Platform;
     /// let platform = GenericPlatform::from_path("/platform").unwrap();
     /// ```
     fn from_path(platform_dir: impl AsRef<Path>) -> io::Result<Self>;

--- a/libherokubuildpack/src/digest.rs
+++ b/libherokubuildpack/src/digest.rs
@@ -17,7 +17,10 @@ use sha2::{Digest, Sha256};
 ///
 /// write(&temp_file, "Hello World!").unwrap();
 /// let sha256_sum = sha256(&temp_file).unwrap();
-/// assert_eq!(sha256_sum, "7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069");
+/// assert_eq!(
+///     sha256_sum,
+///     "7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069"
+/// );
 /// ```
 pub fn sha256(path: impl AsRef<Path>) -> Result<String, std::io::Error> {
     let mut file = fs::File::open(path.as_ref())?;

--- a/libherokubuildpack/src/download.rs
+++ b/libherokubuildpack/src/download.rs
@@ -14,15 +14,18 @@ pub enum DownloadError {
 ///
 /// # Examples
 /// ```
-/// use libherokubuildpack::download::download_file;
 /// use libherokubuildpack::digest::sha256;
+/// use libherokubuildpack::download::download_file;
 /// use tempfile::tempdir;
 ///
 /// let temp_dir = tempdir().unwrap();
 /// let temp_file = temp_dir.path().join("result.bin");
 ///
 /// download_file("https://example.com/", &temp_file).unwrap();
-/// assert_eq!(sha256(&temp_file).unwrap(), "ea8fac7c65fb589b0d53560f5251f74f9e9b243478dcb6b3ea79b5e36449c8d9");
+/// assert_eq!(
+///     sha256(&temp_file).unwrap(),
+///     "ea8fac7c65fb589b0d53560f5251f74f9e9b243478dcb6b3ea79b5e36449c8d9"
+/// );
 /// ```
 pub fn download_file(
     uri: impl AsRef<str>,

--- a/libherokubuildpack/src/toml.rs
+++ b/libherokubuildpack/src/toml.rs
@@ -8,17 +8,20 @@ use std::ops::Deref;
 ///
 /// Example:
 /// ```
-/// use toml::toml;
 /// use libherokubuildpack::toml::toml_select_value;
+/// use toml::toml;
 ///
-/// let toml = toml!{
+/// let toml = toml! {
 ///     [config]
 ///     [config.net]
 ///     port = 12345
 ///     host = "localhost"
 /// };
 ///
-/// assert_eq!(toml_select_value(vec!["config", "net", "port"], &toml.into()), Some(&toml::Value::from(12345)));
+/// assert_eq!(
+///     toml_select_value(vec!["config", "net", "port"], &toml.into()),
+///     Some(&toml::Value::from(12345))
+/// );
 /// ```
 pub fn toml_select_value<S: AsRef<str>, K: Deref<Target = [S]>>(
     keys: K,

--- a/libherokubuildpack/src/write.rs
+++ b/libherokubuildpack/src/write.rs
@@ -152,17 +152,14 @@ pub mod mappers {
     ///
     /// # Example
     /// ```no_run
+    /// use libherokubuildpack::command::CommandExt;
     /// use libherokubuildpack::write::line_mapped;
     /// use libherokubuildpack::write::mappers::add_prefix;
-    /// use libherokubuildpack::command::CommandExt;
     /// use std::process::Command;
     ///
     /// Command::new("date")
     ///     .spawn_and_write_streams(
-    ///         line_mapped(
-    ///             std::io::stdout(),
-    ///             add_prefix("date stdout> "),
-    ///         ),
+    ///         line_mapped(std::io::stdout(), add_prefix("date stdout> ")),
     ///         std::io::stderr(),
     ///     )
     ///     .and_then(|mut child| child.wait())
@@ -182,9 +179,9 @@ pub mod mappers {
     ///
     /// # Example
     /// ```no_run
+    /// use libherokubuildpack::command::CommandExt;
     /// use libherokubuildpack::write::line_mapped;
     /// use libherokubuildpack::write::mappers::map_utf8_lossy;
-    /// use libherokubuildpack::command::CommandExt;
     /// use std::process::Command;
     ///
     /// Command::new("date")


### PR DESCRIPTION
Sadly by default rustfmt doesn't format Rust code inside markdown in docs, and instead requires that the Nightly-only `format_code_in_doc_comments` feature be enabled:
https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=#format_code_in_doc_comments 

We don't want to run Nightly in CI so cannot enable this permanently, however, I ran it as a one-off locally to clean up our docs slightly.

The `.rustfmt.toml` used was:

```
unstable_features = true
format_code_in_doc_comments = true
```