### PR TITLE
libcnb-test: Only expose ports to localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ libcnb package` will refer to the new locations. ([#580](https://github.com/hero
 - `libherokubuildpack`: Switch the `flate2` decompression backend from `miniz_oxide` to `zlib`. ([#593](https://github.com/heroku/libcnb.rs/pull/593))
 - Bump minimum external dependency versions. ([#587](https://github.com/heroku/libcnb.rs/pull/587))
 
+### Fixed
+
+- `libcnb-test`: `ContainerContext::expose_port` now only exposes the port to localhost. ([#610](https://github.com/heroku/libcnb.rs/pull/610))
+
 ## [0.13.0] 2023-06-21
 
 The highlight of this release is the `cargo libcnb package` changes to support compilation of both buildpacks and meta-buildpacks.

--- a/libcnb-test/src/container_port_mapping.rs
+++ b/libcnb-test/src/container_port_mapping.rs
@@ -79,7 +79,7 @@ pub(crate) fn port_mapped_container_config(
                         (
                             format!("{port}/tcp"),
                             Some(vec![PortBinding {
-                                host_ip: None,
+                                host_ip: Some(String::from("127.0.0.1")),
                                 host_port: None,
                             }]),
                         )
@@ -205,21 +205,21 @@ mod tests {
                 (
                     String::from("80/tcp"),
                     Some(vec![PortBinding {
-                        host_ip: None,
+                        host_ip: Some(String::from("127.0.0.1")),
                         host_port: None,
                     }]),
                 ),
                 (
                     String::from("443/tcp"),
                     Some(vec![PortBinding {
-                        host_ip: None,
+                        host_ip: Some(String::from("127.0.0.1")),
                         host_port: None,
                     }]),
                 ),
                 (
                     String::from("22/tcp"),
                     Some(vec![PortBinding {
-                        host_ip: None,
+                        host_ip: Some(String::from("127.0.0.1")),
                         host_port: None,
                     }]),
                 )


### PR DESCRIPTION
Previously ports exposed using `ContainerConfig::expose_port` would be exposed to the internet, rather than just localhost.

Sadly the Bollard docs don't mention this pitfall:
https://docs.rs/bollard/latest/bollard/models/struct.PortBinding.html

See:
https://docs.docker.com/engine/reference/commandline/run/#publish
https://docs.docker.com/network/#published-ports

Fixes #609.
GUS-W-13812521.