### PR TITLE
Remove trailing whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ separate changelogs for each crate were used. If you need to refer to these old 
 ### Changed
 
 - `libcnb-test`: `ContainerContext::address_for_port` now returns `SocketAddr` directly instead of `Option<SocketAddr>`. ([#605](https://github.com/heroku/libcnb.rs/pull/605))
-- `libcnb-package`: buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need to adapt. The output of `cargo 
-libcnb package` will refer to the new locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
+- `libcnb-package`: buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
 - `libherokubuildpack`: Switch the `flate2` decompression backend from `miniz_oxide` to `zlib`. ([#593](https://github.com/heroku/libcnb.rs/pull/593))
 - Bump minimum external dependency versions. ([#587](https://github.com/heroku/libcnb.rs/pull/587))
 
@@ -27,7 +26,7 @@ libcnb package` will refer to the new locations. ([#580](https://github.com/hero
 The highlight of this release is the `cargo libcnb package` changes to support compilation of both buildpacks and meta-buildpacks.
 
 ### Changed
- 
+
 - `libcnb-cargo`: The `cargo libcnb package` command now supports compiling buildpacks and meta-buildpacks ([#575](https://github.com/heroku/libcnb.rs/pull/575)):
   - When used in a buildpack directory it will compile only that buildpack.
   - When used in a workspace directory it will compile all buildpacks found in subdirectories.
@@ -40,25 +39,25 @@ The highlight of this release is the `cargo libcnb package` changes to support c
 - `libcnb-data`
   - Serialization / deserialization of [package.toml](https://buildpacks.io/docs/reference/config/package-config/) files supported with the `Buildpackage` struct. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
 - `libcnb-package`
-  - Added 
-    `read_buildpackage_data`, 
-    `find_buildpack_dirs`, 
-    `get_buildpack_target_dir` 
+  - Added
+    `read_buildpackage_data`,
+    `find_buildpack_dirs`,
+    `get_buildpack_target_dir`
     to support packaging operations. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
   - Added
-    `buildpack_dependency::BuildpackDependency`, 
-    `buildpack_dependency::get_local_buildpackage_dependencies`, 
-    `buildpack_dependency::rewrite_buildpackage_local_dependencies`, 
-    `buildpack_dependency::rewrite_buildpackage_relative_path_dependencies_to_absolute` 
+    `buildpack_dependency::BuildpackDependency`,
+    `buildpack_dependency::get_local_buildpackage_dependencies`,
+    `buildpack_dependency::rewrite_buildpackage_local_dependencies`,
+    `buildpack_dependency::rewrite_buildpackage_relative_path_dependencies_to_absolute`
     to support Buildpack dependency handling and packaging operations. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
-  - Added 
-    `buildpack_package::BuildpackPackage`, 
-    `buildpack_package::read_buildpack_package` 
+  - Added
+    `buildpack_package::BuildpackPackage`,
+    `buildpack_package::read_buildpack_package`
     to support libcnb.rs-based Rust packages. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
-  - Added 
-    `dependency_graph::DependencyNode`, 
-    `dependency_graph::create_dependency_graph`, 
-    `dependency_graph::get_dependencies` 
+  - Added
+    `dependency_graph::DependencyNode`,
+    `dependency_graph::create_dependency_graph`,
+    `dependency_graph::get_dependencies`
     to support dependency ordering and resolution in libcnb.rs-based Rust packages. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
 
 ## [0.12.0] 2023-04-28
@@ -81,7 +80,7 @@ Highlight of this release is the bump to [Buildpack API 0.9](https://github.com/
 
 ### Changed
 
-- Update `toml` to `0.7.1`. If your buildpack interacts with TOML data directly, you probably want to bump 
+- Update `toml` to `0.7.1`. If your buildpack interacts with TOML data directly, you probably want to bump
 the `toml` version in your buildpack as well. ([#556](https://github.com/heroku/libcnb.rs/pull/556))
 
 ## [0.11.4] 2023-01-11


### PR DESCRIPTION
The trailing whitespace causes merge conflicts with anyone whose editor removes them automatically.