### PR TITLE
libcnb-test: Shorten the random Docker image/container name

### DIFF
--- a/libcnb-test/src/util.rs
+++ b/libcnb-test/src/util.rs
@@ -9,7 +9,7 @@ pub(crate) fn random_docker_identifier() -> String {
     format!(
         "libcnbtest_{}",
         repeat_with(fastrand::lowercase)
-            .take(30)
+            .take(12)
             .collect::<String>()
     )
 }


### PR DESCRIPTION
Recently I've been looking at a lot of test output logs, and the current randomly generated Docker image/container name is quite verbose.

This shortens the random characters component from 30 to 12 characters, which still gives plenty (26^12) of permutations.

Before:

```
Saving libcnbtest_ewohznkighgzkyzsggfbqulyiroxsu...
*** Images (a9893ef9b2ca):
      libcnbtest_ewohznkighgzkyzsggfbqulyiroxsu
Successfully built image 'libcnbtest_ewohznkighgzkyzsggfbqulyiroxsu'
```

```
$ docker images
REPOSITORY                                  TAG       IMAGE ID       CREATED        SIZE
heroku/heroku                               22-cnb    25d47f055e03   7 days ago     647MB
heroku/procfile-cnb                         2.0.0     50bf5a8215a8   43 years ago   2.32MB
heroku/builder                              22        79d921410650   43 years ago   1.12GB
libcnbtest_pjkbpqhuxmgzyjkgvkvnacvatwrkqm   latest    a9893ef9b2ca   43 years ago   650MB
```

After:

```
Saving libcnbtest_zjqvkjwpynqt...
*** Images (a9893ef9b2ca):
      libcnbtest_zjqvkjwpynqt
Successfully built image 'libcnbtest_zjqvkjwpynqt'
```

```
$ docker images
REPOSITORY                TAG       IMAGE ID       CREATED        SIZE
heroku/heroku             22-cnb    25d47f055e03   7 days ago     647MB
heroku/procfile-cnb       2.0.0     50bf5a8215a8   43 years ago   2.32MB
heroku/builder            22        79d921410650   43 years ago   1.12GB
libcnbtest_azhdraqrdech   latest    a9893ef9b2ca   43 years ago   650MB
```