### PR TITLE
libcnb-proc-macros: Re-enable the `full` sym crate feature

### DIFF
--- a/libcnb-proc-macros/Cargo.toml
+++ b/libcnb-proc-macros/Cargo.toml
@@ -17,4 +17,4 @@ proc-macro = true
 cargo_metadata = "0.17.0"
 fancy-regex = { version = "0.11.0", default-features = false }
 quote = "1.0.29"
-syn = "2.0.23"
+syn = { version = "2.0.23", features = ["full"] }


### PR DESCRIPTION
This feature was removed from `main` recently in #592.

It turns out that `libcnb-proc-macros` does use the `full` feature, but this was hidden by the fact that `libcnb-test`'s dependencies enable the feature in their own use of sym, so Cargo compiles sym with the feature enabled regardless, since all crates are in the same workspace.

Adding back the explicit feature ensures `libcnb-proc-macros` will work (a) for projects that don't use `libcnb-tests`, (b) when Bollard is removed from `libcnb-test` (since it appears that it's one of Bollard or Tokio's transitive dependencies that enable the `full` feature of sym currently).

No changelog entry has been added, since #592 (which this partially reverts) is only present on `main` and not an actual released version.

GUS-W-13745698.