### PR TITLE
Add VSCode workspace configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["rust-lang.rust-analyzer"],
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.imports.granularity.enforce": true,
+  "rust-analyzer.imports.granularity.group": "module",
+  "rust-analyzer.imports.prefix": "crate",
+}


### PR DESCRIPTION
Of note, this makes VSCode run `cargo clippy` instead of just `cargo check` when performing inline file checking/linting. This helps prevent opening a PR only to find linting fails there due to Clippy errors.

This minimal configuration is identical to that used in the Python CNB:
https://github.com/heroku/buildpacks-python/blob/main/.vscode/settings.json

See:
https://code.visualstudio.com/docs/getstarted/settings#_workspace-settings
https://rust-analyzer.github.io/manual.html#configuration