### PR TITLE
libcnb-test: Refactor `run_pack_command` and improve panic messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ separate changelogs for each crate were used. If you need to refer to these old 
 - `libcnb-test`:
   - `ContainerContext::address_for_port` now returns `SocketAddr` directly instead of `Option<SocketAddr>`. ([#605](https://github.com/heroku/libcnb.rs/pull/605))
   - `LogOutput` no longer exposes `stdout_raw` and `stderr_raw`. ([#607](https://github.com/heroku/libcnb.rs/pull/607))
+  - Improved wording of panic error messages. ([#619](https://github.com/heroku/libcnb.rs/pull/619))
 - `libcnb-package`: buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
 - `libherokubuildpack`: Switch the `flate2` decompression backend from `miniz_oxide` to `zlib`. ([#593](https://github.com/heroku/libcnb.rs/pull/593))
 - Bump minimum external dependency versions. ([#587](https://github.com/heroku/libcnb.rs/pull/587))

--- a/libcnb-test/src/log.rs
+++ b/libcnb-test/src/log.rs
@@ -1,6 +1,6 @@
 use tokio_stream::{Stream, StreamExt};
 
-/// Container log output.
+/// Log output from a command.
 #[derive(Debug, Default)]
 pub struct LogOutput {
     pub stdout: String,

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -1,7 +1,6 @@
-use crate::PackResult;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::process::{Command, Output};
+use std::process::Command;
 use tempfile::TempDir;
 
 /// Represents a `pack build` command.
@@ -161,43 +160,6 @@ impl From<PackSbomDownloadCommand> for Command {
 
         command
     }
-}
-
-/// Runs the given pack command, panicking with user-friendly error messages when errors occur.
-pub(crate) fn run_pack_command<C: Into<Command>>(
-    command: C,
-    expected_result: &PackResult,
-) -> Output {
-    let output = command.into()
-        .output()
-        .unwrap_or_else(|io_error| {
-            if io_error.kind() == std::io::ErrorKind::NotFound {
-                panic!("External `pack` command not found. Install Pack CLI and ensure it is on PATH: https://buildpacks.io/docs/install-pack");
-            } else {
-                panic!("Could not spawn external `pack` process: {io_error}");
-            };
-        });
-
-    if (expected_result == &PackResult::Success && !output.status.success())
-        || (expected_result == &PackResult::Failure && output.status.success())
-    {
-        panic!(
-            "pack command unexpectedly {} with exit-code {}!\n\npack stdout:\n{}\n\npack stderr:\n{}",
-            if output.status.success() {
-                "succeeded"
-            } else {
-                "failed"
-            },
-            output
-                .status
-                .code()
-                .map_or(String::from("<unknown>"), |exit_code| exit_code.to_string()),
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    output
 }
 
 #[cfg(test)]

--- a/libcnb-test/src/test_context.rs
+++ b/libcnb-test/src/test_context.rs
@@ -1,7 +1,7 @@
-use crate::pack::{run_pack_command, PackSbomDownloadCommand};
+use crate::pack::PackSbomDownloadCommand;
 use crate::{
     container_port_mapping, util, BuildConfig, ContainerConfig, ContainerContext, LogOutput,
-    PackResult, TestRunner,
+    TestRunner,
 };
 use bollard::container::{Config, CreateContainerOptions, StartContainerOptions};
 use bollard::image::RemoveImageOptions;
@@ -222,7 +222,8 @@ impl<'a> TestContext<'a> {
         let mut command = PackSbomDownloadCommand::new(&self.image_name);
         command.output_dir(temp_dir.path());
 
-        run_pack_command(command, &PackResult::Success);
+        util::run_command(command)
+            .unwrap_or_else(|command_err| panic!("Error downloading SBOM files:\n\n{command_err}"));
 
         f(SbomFiles {
             sbom_files_directory: temp_dir.path().into(),

--- a/libcnb-test/src/util.rs
+++ b/libcnb-test/src/util.rs
@@ -1,4 +1,8 @@
+use crate::LogOutput;
+use std::fmt::Display;
+use std::io;
 use std::iter::repeat_with;
+use std::process::Command;
 
 /// Generate a random Docker identifier.
 ///
@@ -15,3 +19,133 @@ pub(crate) fn random_docker_identifier() -> String {
 }
 
 pub(crate) const CNB_LAUNCHER_BINARY: &str = "launcher";
+
+/// A helper for running an external process using [`Command`].
+pub(crate) fn run_command(command: impl Into<Command>) -> Result<LogOutput, CommandError> {
+    let mut command = command.into();
+    let program = command.get_program().to_string_lossy().to_string();
+
+    command
+        .output()
+        .map_err(|io_error| {
+            if io_error.kind() == std::io::ErrorKind::NotFound {
+                CommandError::NotFound {
+                    program: program.clone(),
+                }
+            } else {
+                CommandError::Io {
+                    io_error,
+                    program: program.clone(),
+                }
+            }
+        })
+        .and_then(|output| {
+            let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+            if output.status.success() {
+                Ok(LogOutput { stdout, stderr })
+            } else {
+                Err(CommandError::NonZeroExitCode {
+                    program,
+                    exit_code: output.status.code(),
+                    stdout,
+                    stderr,
+                })
+            }
+        })
+}
+
+/// Errors that can occur when running an external process using [`run_command`].
+#[derive(Debug)]
+pub(crate) enum CommandError {
+    Io {
+        io_error: io::Error,
+        program: String,
+    },
+    NotFound {
+        program: String,
+    },
+    NonZeroExitCode {
+        exit_code: Option<i32>,
+        program: String,
+        stdout: String,
+        stderr: String,
+    },
+}
+
+impl Display for CommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CommandError::Io { program, io_error } => {
+                write!(f, "Couldn't spawn external `{program}` process: {io_error}")
+            }
+            CommandError::NotFound { program } => {
+                write!(
+                    f,
+                    "Couldn't find external program `{program}`. Ensure it is installed and on PATH."
+                )
+            }
+            CommandError::NonZeroExitCode {
+                program,
+                exit_code,
+                stdout,
+                stderr,
+            } => write!(
+                f,
+                "{program} command failed with exit code {}!\n\n## stderr:\n\n{stderr}\n## stdout:\n\n{stdout}\n",
+                exit_code.map_or(String::from("<unknown>"), |exit_code| exit_code.to_string())
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+
+    #[test]
+    fn run_command_succeeded() {
+        let mut command = Command::new("bash");
+        command.args(["-c", "echo 'some stdout'; echo 'some stderr' >&2; exit 0"]);
+        let output = run_command(command).unwrap();
+
+        assert_eq!(output.stdout, "some stdout\n");
+        assert_eq!(output.stderr, "some stderr\n");
+    }
+
+    #[test]
+    fn run_command_nonzero_exit_code() {
+        let mut command = Command::new("bash");
+        command.args(["-c", "echo 'some stdout'; echo 'some stderr' >&2; exit 1"]);
+        let err = run_command(command).unwrap_err();
+
+        assert!(matches!(err, CommandError::NonZeroExitCode { .. }));
+        assert_eq!(
+            err.to_string(),
+            indoc! {"
+                bash command failed with exit code 1!
+                
+                ## stderr:
+                
+                some stderr
+                
+                ## stdout:
+                
+                some stdout
+                
+            "}
+        );
+    }
+
+    #[test]
+    fn run_command_program_not_found() {
+        let err = run_command(Command::new("nonexistent-program")).unwrap_err();
+        assert!(matches!(err, CommandError::NotFound { .. }));
+        assert_eq!(
+            err.to_string(),
+            "Couldn't find external program `nonexistent-program`. Ensure it is installed and on PATH."
+        );
+    }
+}

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -77,12 +77,12 @@ fn buildpack_packaging_failure() {
 
 #[test]
 #[ignore = "integration test"]
-#[should_panic(expected = "pack command unexpectedly failed with exit-code 1!
+#[should_panic(expected = "Error performing pack build:
 
-pack stdout:
+pack command failed with exit code 1!
 
+## stderr:
 
-pack stderr:
 ERROR: failed to build: failed to fetch builder image 'index.docker.io/libcnb/invalid-builder:latest'")]
 fn unexpected_pack_failure() {
     TestRunner::default().build(
@@ -95,9 +95,14 @@ fn unexpected_pack_failure() {
 
 #[test]
 #[ignore = "integration test"]
-#[should_panic(expected = "pack command unexpectedly succeeded with exit-code 0!
+#[should_panic(expected = "The pack build was expected to fail, but did not:
 
-pack stdout:
+## stderr:
+
+
+## stdout:
+
+===> ANALYZING
 ")]
 fn unexpected_pack_success() {
     TestRunner::default().build(
@@ -242,7 +247,13 @@ fn app_dir_invalid_path_checked_before_applying_preprocessor() {
 
 #[test]
 #[ignore = "integration test"]
-#[should_panic(expected = "cannot be found: not found")]
+#[should_panic(expected = "Error downloading SBOM files:
+
+pack command failed with exit code 1!
+
+## stderr:
+
+ERROR: image 'libcnbtest_")]
 fn download_sbom_files_failure() {
     TestRunner::default().build(
         BuildConfig::new("heroku/builder:22", "test-fixtures/empty")


### PR DESCRIPTION
This:
- Moves the internal `run_pack_command` to `utils` and makes it generic, so it can be used internally when calling other external processes (such as Docker CLI, in the upcoming Bollard migration).
- Makes `run_command` return a `Result` instead of panicing directly, so that the caller is both in control of the outcome and can add additional context to the panic error message.
- Moves the "expected failure" handling out of `run_command` and up to the single caller that requires that feature, to avoid adding boilerplate to all of the other call-sites (which will increase in number once `run_command` is used for Docker CLI after the Bollard migration).
- Adjusts the formatting of the panic error messages to improve readability (eg adds some additional whitespace, and adjusts the stdout/stderr order).

This has been split out of the Bollard migration PR to make it easier to review.

GUS-W-13841325.