### PR TITLE
libcnb-test: Prevent integration tests from hanging when offline

### DIFF
--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -67,12 +67,9 @@ fn rebuild() {
     expected = "Could not package current crate as buildpack: BuildBinariesError(ConfigError(NoBinTargetsFound))"
 )]
 fn buildpack_packaging_failure() {
-    TestRunner::default().build(
-        BuildConfig::new("libcnb/invalid-builder", "test-fixtures/empty"),
-        |_| {
-            unreachable!("The test should panic prior to the TestContext being invoked.");
-        },
-    );
+    TestRunner::default().build(BuildConfig::new("invalid!", "test-fixtures/empty"), |_| {
+        unreachable!("The test should panic prior to the TestContext being invoked.");
+    });
 }
 
 #[test]
@@ -83,10 +80,10 @@ pack command failed with exit code 1!
 
 ## stderr:
 
-ERROR: failed to build: failed to fetch builder image 'index.docker.io/libcnb/invalid-builder:latest'")]
+ERROR: failed to build: invalid builder 'invalid!'")]
 fn unexpected_pack_failure() {
     TestRunner::default().build(
-        BuildConfig::new("libcnb/invalid-builder", "test-fixtures/empty").buildpacks(Vec::new()),
+        BuildConfig::new("invalid!", "test-fixtures/empty").buildpacks(Vec::new()),
         |_| {
             unreachable!("The test should panic prior to the TestContext being invoked.");
         },
@@ -119,14 +116,14 @@ fn unexpected_pack_success() {
 #[ignore = "integration test"]
 fn expected_pack_failure() {
     TestRunner::default().build(
-        BuildConfig::new("libcnb/invalid-builder", "test-fixtures/empty")
+        BuildConfig::new("invalid!", "test-fixtures/empty")
             .buildpacks(Vec::new())
             .expected_pack_result(PackResult::Failure),
         |context| {
             assert_empty!(context.pack_stdout);
             assert_contains!(
                 context.pack_stderr,
-                "ERROR: failed to build: failed to fetch builder image 'index.docker.io/libcnb/invalid-builder:latest'"
+                "ERROR: failed to build: invalid builder 'invalid!'"
             );
         },
     );
@@ -139,7 +136,7 @@ fn expected_pack_failure() {
 )]
 fn expected_pack_failure_still_panics_for_non_pack_failure() {
     TestRunner::default().build(
-        BuildConfig::new("libcnb/invalid-builder", "test-fixtures/empty")
+        BuildConfig::new("invalid!", "test-fixtures/empty")
             .expected_pack_result(PackResult::Failure),
         |_| {},
     );


### PR DESCRIPTION
Previously a number of `libcnb-test`'s own integration tests used an intentionally-invalid builder of `libcnb/invalid-builder` in order to test the handling of various failure modes.

Since the previous builder name parsed as a valid builder name, it caused `pack build` to make requests to Docker Hub for the non-existent builder, which meant:
- When offline, it means Pack would hang for 20-30s whilst it attempts to retry the builder image pull.
- If someone were ever to publish an actual image at `libcnb/invalid-builder` our tests would start to fail, and we'd execute whatever that image was.

Now, the tests use a builder name that fails parsing, which still allows testing of `libcnb-test`'s error handling, but means no requests are ever made to Docker Hub.

GUS-W-13903458.