### PR TITLE
Consistent error enum style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `libcnb-package`:
-    - Added `find_cargo_workspace_root_dir` which provides a convenient starting point for locating buildpacks for packaging and testing purposes. ([#629](https://github.com/heroku/libcnb.rs/pull/629))
+  - Added `find_cargo_workspace_root_dir` which provides a convenient starting point for locating buildpacks for packaging and testing purposes. ([#629](https://github.com/heroku/libcnb.rs/pull/629))
+  - Changed the `ReadBuildpackDataError` and `ReadBuildpackageDataError` enums from struct to tuple format to be consistent with other error enums in the package. ([#631](https://github.com/heroku/libcnb.rs/pull/631))
 
 ## [0.14.0] - 2023-08-18
 

--- a/libcnb-package/src/lib.rs
+++ b/libcnb-package/src/lib.rs
@@ -51,14 +51,10 @@ pub fn read_buildpack_data(
     let dir = project_path.as_ref();
     let buildpack_descriptor_path = dir.join("buildpack.toml");
     fs::read_to_string(&buildpack_descriptor_path)
-        .map_err(|e| ReadBuildpackDataError::ReadingBuildpack {
-            path: buildpack_descriptor_path.clone(),
-            source: e,
-        })
+        .map_err(|e| ReadBuildpackDataError::ReadingBuildpack(buildpack_descriptor_path.clone(), e))
         .and_then(|file_contents| {
-            toml::from_str(&file_contents).map_err(|e| ReadBuildpackDataError::ParsingBuildpack {
-                path: buildpack_descriptor_path.clone(),
-                source: e,
+            toml::from_str(&file_contents).map_err(|e| {
+                ReadBuildpackDataError::ParsingBuildpack(buildpack_descriptor_path.clone(), e)
             })
         })
         .map(|buildpack_descriptor| BuildpackData {
@@ -70,14 +66,8 @@ pub fn read_buildpack_data(
 /// An error from [`read_buildpack_data`]
 #[derive(Debug)]
 pub enum ReadBuildpackDataError {
-    ReadingBuildpack {
-        path: PathBuf,
-        source: std::io::Error,
-    },
-    ParsingBuildpack {
-        path: PathBuf,
-        source: toml::de::Error,
-    },
+    ReadingBuildpack(PathBuf, std::io::Error),
+    ParsingBuildpack(PathBuf, toml::de::Error),
 }
 
 /// A parsed buildpackage descriptor and it's path.
@@ -102,16 +92,15 @@ pub fn read_buildpackage_data(
     }
 
     fs::read_to_string(&buildpackage_descriptor_path)
-        .map_err(|e| ReadBuildpackageDataError::ReadingBuildpackage {
-            path: buildpackage_descriptor_path.clone(),
-            source: e,
+        .map_err(|e| {
+            ReadBuildpackageDataError::ReadingBuildpackage(buildpackage_descriptor_path.clone(), e)
         })
         .and_then(|file_contents| {
             toml::from_str(&file_contents).map_err(|e| {
-                ReadBuildpackageDataError::ParsingBuildpackage {
-                    path: buildpackage_descriptor_path.clone(),
-                    source: e,
-                }
+                ReadBuildpackageDataError::ParsingBuildpackage(
+                    buildpackage_descriptor_path.clone(),
+                    e,
+                )
             })
         })
         .map(|buildpackage_descriptor| {
@@ -125,14 +114,8 @@ pub fn read_buildpackage_data(
 /// An error from [`read_buildpackage_data`]
 #[derive(Debug)]
 pub enum ReadBuildpackageDataError {
-    ReadingBuildpackage {
-        path: PathBuf,
-        source: std::io::Error,
-    },
-    ParsingBuildpackage {
-        path: PathBuf,
-        source: toml::de::Error,
-    },
+    ReadingBuildpackage(PathBuf, std::io::Error),
+    ParsingBuildpackage(PathBuf, toml::de::Error),
 }
 
 /// Creates a buildpack directory and copies all buildpack assets to it.


### PR DESCRIPTION
This is a general cleanup PR to make the error enums in `libcnb-package` and `libcnb-cargo` consistent with the tuple-style used elsewhere in the codebase.