### PR TITLE
libcnb-test: Implement `fmt::Display` for `LogOutput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ separate changelogs for each crate were used. If you need to refer to these old 
 ### Added
 
 - `libcnb-package`: Add cross-compilation assistance for Linux `aarch64-unknown-linux-musl`. ([#577](https://github.com/heroku/libcnb.rs/pull/577))
+- `libcnb-test`: `LogOutput` now implements `std::fmt::Display`. ([#635](https://github.com/heroku/libcnb.rs/pull/635))
 
 ### Changed
 

--- a/libcnb-test/src/log.rs
+++ b/libcnb-test/src/log.rs
@@ -1,6 +1,15 @@
+use std::fmt::Display;
+
 /// Log output from a command.
 #[derive(Debug, Default)]
 pub struct LogOutput {
     pub stdout: String,
     pub stderr: String,
+}
+
+impl Display for LogOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let LogOutput { stdout, stderr } = self;
+        write!(f, "## stderr:\n\n{stderr}\n## stdout:\n\n{stdout}\n")
+    }
 }


### PR DESCRIPTION
Since:
- There was already duplication of formatting stderr/stdout output, which was otherwise going to get worse after #636.
- It may also be useful for end users when debugging, to save them having to manually print both stderr and stdout manually.

Prep for #482.
GUS-W-13966399.