### PR TITLE
libcnb-test: Improve error messages for `address_for_port`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ separate changelogs for each crate were used. If you need to refer to these old 
 ### Added
 
 - `libcnb-package`: Add cross-compilation assistance for Linux `aarch64-unknown-linux-musl`. ([#577](https://github.com/heroku/libcnb.rs/pull/577))
-- `libcnb-test`: `LogOutput` now implements `std::fmt::Display`. ([#635](https://github.com/heroku/libcnb.rs/pull/635))
+- `libcnb-test`:
+  - `LogOutput` now implements `std::fmt::Display`. ([#635](https://github.com/heroku/libcnb.rs/pull/635))
+  - `ContainerConfig` now implements `Clone`. ([#636](https://github.com/heroku/libcnb.rs/pull/636))
 
 ### Changed
 
 - `libcnb-test`:
-  - `ContainerContext::address_for_port` now returns `SocketAddr` directly instead of `Option<SocketAddr>`. ([#605](https://github.com/heroku/libcnb.rs/pull/605))
+  - `ContainerContext::address_for_port` will now panic for all failure modes rather than just some, and so now returns `SocketAddr` directly instead of `Option<SocketAddr>`. This reduces test boilerplate due to the caller no longer needing to `.unwrap()` and improves debugging UX when containers crash after startup. ([#605](https://github.com/heroku/libcnb.rs/pull/605) and [#636](https://github.com/heroku/libcnb.rs/pull/636))
   - Docker commands are now run using the Docker CLI instead of Bollard and the Docker daemon API. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
   - `ContainerConfig::entrypoint` now accepts a String rather than a vector of strings. Any arguments to the entrypoint should be moved to `ContainerConfig::command`. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
   - `TestRunner::new` has been removed, since its only purpose was for advanced configuration that's no longer applicable. Use `TestRunner::default` instead. ([#620](https://github.com/heroku/libcnb.rs/pull/620))

--- a/libcnb-test/src/container_config.rs
+++ b/libcnb-test/src/container_config.rs
@@ -25,7 +25,7 @@ use std::collections::{HashMap, HashSet};
 ///     },
 /// );
 /// ```
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct ContainerConfig {
     pub(crate) entrypoint: Option<String>,
     pub(crate) command: Option<Vec<String>>,

--- a/libcnb-test/src/test_context.rs
+++ b/libcnb-test/src/test_context.rs
@@ -109,7 +109,10 @@ impl<'a> TestContext<'a> {
         util::run_command(docker_run_command)
             .unwrap_or_else(|command_err| panic!("Error starting container:\n\n{command_err}"));
 
-        f(ContainerContext { container_name });
+        f(ContainerContext {
+            container_name,
+            config: config.clone(),
+        });
     }
 
     /// Run the provided shell command.


### PR DESCRIPTION
Improves the debugging UX for several `ContainerContext::address_for_port` failure modes.

In particular, if containers crash after startup then the container logs are now included in the panic error message, rather than only the potentially confusing "No public port X published" message from Docker.

Example output with libcnb-test v0.13.0:

```
thread 'basic' panicked at 'called `Option::unwrap()` on a `None` value', examples/ruby-sample/tests/integration_test.rs:38:63
```

With libcnb-test from `main` (that includes #605 and #621):

```
thread 'basic' panicked at 'Error obtaining container port mapping:

docker command failed with exit code 1!

## stderr:

Error: No public port '12346' published for libcnbtest_tydfxdispzng

## stdout:


', libcnb-test/src/container_context.rs:117:17
```

After this PR:

```
thread 'basic' panicked at 'Error obtaining container port mapping:
Error: No public port '12346' published for libcnbtest_giidbduyppom

This normally means that the container crashed. Container logs:

## stderr:

app.rb:1:in `<main>': Example server startup crash error message... (RuntimeError)

## stdout:


', libcnb-test/src/container_context.rs:130:17
```

Fixes #482.