### PR TITLE
Refactor libcnb-cargo integration tests

### DIFF
--- a/libcnb-cargo/Cargo.toml
+++ b/libcnb-cargo/Cargo.toml
@@ -31,5 +31,4 @@ thiserror = "1.0.41"
 toml.workspace = true
 
 [dev-dependencies]
-fs_extra = "1.3.0"
 tempfile = "3.6.0"

--- a/libcnb-cargo/src/main.rs
+++ b/libcnb-cargo/src/main.rs
@@ -9,8 +9,6 @@ mod package;
 
 // Suppress warnings due to the `unused_crate_dependencies` lint not handling integration tests well.
 #[cfg(test)]
-use fs_extra as _;
-#[cfg(test)]
 use tempfile as _;
 
 use crate::cli::{Cli, LibcnbSubcommand};


### PR DESCRIPTION
The current tests are quite rigid, hard to work with and tricky to extend. I noticed this when the tests became the major blocker to get #583 off the ground. This PR refactors the tests to fix the issues mentioned. 

Some extra improvements have landed as well:

- Removed `fs_extra`
- Pedantic lints are now enabled (and passing)

Ref: GUS-W-13966683