### PR TITLE
Run `cargo upgrade` as part of preparing libcnb releases

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,9 @@ easier to gauge cross-crate compatibility.
 3. Update [CHANGELOG.md](./CHANGELOG.md)
    1. Move all content under `## [Unreleased]` to a new section that follows this pattern: `## [VERSION] YYYY-MM-DD`
    2. If appropriate, add a high-level summary of changes at the beginning of the new section
-4. Commit the changes, push them and open a PR targeting `main`
+4. Install the latest version of [cargo-edit](https://github.com/killercup/cargo-edit): `cargo install cargo-edit`
+5. Bump in-range dependency versions using: `cargo upgrade`
+6. Commit the changes, push them and open a PR targeting `main`
 
 ## Release
 


### PR DESCRIPTION
We've been previously doing these on an adhoc basis, but it makes sense to instead just do it as part of the release.

Bumping the in-range versions ensures that consumers of libcnb get updated transitive dependencies (without having to manually refresh their own `Cargo.lock`s) that match the dependency versions tested in CI here (since this repo correctly doesn't use a lockfile, so will be using these latest in-range versions in CI etc).

Eventually we can move all of these preparing release steps into a GitHub Actions workflow to reduce the toil of performing releases.