### PR TITLE
Pin intra-libcnb* crate dependencies to exact versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ edition = "2021"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
-libcnb = { version = "0.13.0", path = "libcnb" }
-libcnb-data = { version = "0.13.0", path = "libcnb-data" }
-libcnb-package = { version = "0.13.0", path = "libcnb-package" }
-libcnb-proc-macros = { version = "0.13.0", path = "libcnb-proc-macros" }
-libcnb-test = { version = "0.13.0", path = "libcnb-test" }
+libcnb = { version = "=0.13.0", path = "libcnb" }
+libcnb-data = { version = "=0.13.0", path = "libcnb-data" }
+libcnb-package = { version = "=0.13.0", path = "libcnb-package" }
+libcnb-proc-macros = { version = "=0.13.0", path = "libcnb-proc-macros" }
+libcnb-test = { version = "=0.13.0", path = "libcnb-test" }
 toml = { version = "0.7.5" }


### PR DESCRIPTION
Cargo treats dependency version specifiers of form `X.Y.Z` the same as `^X.Y.Z`:
https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements

As such, previously if an end user of libcnb tried pinning to say `libcnb` 0.14.0, then its previous dependency on `libcnb-data` `0.14.0` would mean any patch releases to `libcnb-data` (such as `0.14.1`) would be automatically picked up.

This could be potentially confusing, especially since we only have one unified version number and changelog for libcnb now.

For example:
1. A buildpack maintainer has an issue with a libcnb upgrade, so pins `libcnb` to `=0.14.0` in their CNB's `Cargo.toml`.
2. However, Cargo when refreshing their CNB's `Cargo.lock` now records the `libcnb-data` version as `0.14.1`, since it's in-range.
3. Now their CNB is using a combination of 0.14.0 and 0.14.1, which confuses the buildpack maintainer, since as far as they are concerned they are using libcnb 0.14.0, and so they don't expect the changes documented under the `0.14.1` section of libcnb's unified changelog to be taking effect.