### PR TITLE
Update tests to Procfile CNB v2.0.1

### DIFF
--- a/libcnb-cargo/fixtures/multiple_buildpacks/meta-buildpacks/meta-one/buildpack.toml
+++ b/libcnb-cargo/fixtures/multiple_buildpacks/meta-buildpacks/meta-one/buildpack.toml
@@ -26,8 +26,8 @@ id = "multiple-buildpacks/not-libcnb"
 version = "0.0.0"
 
 [[order.group]]
-id = "heroku/procfile"
-version = "2.0.0"
+id = "heroku/example"
+version = "1.2.3"
 optional = true
 
 [metadata]

--- a/libcnb-cargo/fixtures/multiple_buildpacks/meta-buildpacks/meta-one/package.toml
+++ b/libcnb-cargo/fixtures/multiple_buildpacks/meta-buildpacks/meta-one/package.toml
@@ -11,4 +11,4 @@ uri = "libcnb:multiple-buildpacks/two"
 uri = "../../buildpacks/not_libcnb"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb:2.0.0"
+uri = "docker://docker.io/heroku/example:1.2.3"

--- a/libcnb-cargo/tests/integration_test.rs
+++ b/libcnb-cargo/tests/integration_test.rs
@@ -79,7 +79,7 @@ fn package_single_meta_buildpack_in_monorepo_buildpack_project() {
                     .path()
                     .join("meta-buildpacks/meta-one/../../buildpacks/not_libcnb"),
             ),
-            BuildpackageDependency::try_from("docker://docker.io/heroku/procfile-cnb:2.0.0"),
+            BuildpackageDependency::try_from("docker://docker.io/heroku/example:1.2.3"),
         ]
         .into_iter()
         .collect::<Result<Vec<_>, _>>()
@@ -175,7 +175,7 @@ fn package_all_buildpacks_in_monorepo_buildpack_project() {
                     .path()
                     .join("meta-buildpacks/meta-one/../../buildpacks/not_libcnb"),
             ),
-            BuildpackageDependency::try_from("docker://docker.io/heroku/procfile-cnb:2.0.0"),
+            BuildpackageDependency::try_from("docker://docker.io/heroku/example:1.2.3"),
         ]
         .into_iter()
         .collect::<Result<Vec<_>, _>>()

--- a/libcnb-data/src/buildpackage.rs
+++ b/libcnb-data/src/buildpackage.rs
@@ -25,7 +25,7 @@ use uriparse::{URIReference, URIReferenceError};
 /// uri = "/absolute/path"
 ///
 /// [[dependencies]]
-/// uri = "docker://docker.io/heroku/procfile-cnb:2.0.0"
+/// uri = "docker://docker.io/heroku/example:1.2.3"
 ///
 /// [platform]
 /// os = "windows"
@@ -205,7 +205,7 @@ uri = "../relative/path"
 uri = "/absolute/path"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb:2.0.0"
+uri = "docker://docker.io/heroku/example:1.2.3"
 
 [platform]
 os = "windows"
@@ -223,7 +223,7 @@ os = "windows"
                 BuildpackageDependency::try_from("libcnb:buildpack-id").unwrap(),
                 BuildpackageDependency::try_from("../relative/path").unwrap(),
                 BuildpackageDependency::try_from("/absolute/path").unwrap(),
-                BuildpackageDependency::try_from("docker://docker.io/heroku/procfile-cnb:2.0.0")
+                BuildpackageDependency::try_from("docker://docker.io/heroku/example:1.2.3")
                     .unwrap()
             ]
         );
@@ -237,7 +237,7 @@ os = "windows"
                 BuildpackageDependency::try_from("libcnb:buildpack-id").unwrap(),
                 BuildpackageDependency::try_from("../relative/path").unwrap(),
                 BuildpackageDependency::try_from("/absolute/path").unwrap(),
-                BuildpackageDependency::try_from("docker://docker.io/heroku/procfile-cnb:2.0.0")
+                BuildpackageDependency::try_from("docker://docker.io/heroku/example:1.2.3")
                     .unwrap(),
             ],
             platform: Platform::default(),
@@ -260,7 +260,7 @@ uri = "../relative/path"
 uri = "/absolute/path"
 
 [[dependencies]]
-uri = "docker://docker.io/heroku/procfile-cnb:2.0.0"
+uri = "docker://docker.io/heroku/example:1.2.3"
 
 [platform]
 os = "linux"

--- a/libcnb-package/src/buildpack_dependency.rs
+++ b/libcnb-package/src/buildpack_dependency.rs
@@ -237,7 +237,7 @@ mod tests {
             "libcnb:buildpack-id",
             "../relative/path",
             "/absolute/path",
-            "docker://docker.io/heroku/procfile-cnb:2.0.0",
+            "docker://docker.io/heroku/example:1.2.3",
         ])
     }
 

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -20,7 +20,7 @@ use std::{env, fs, thread};
 // prevents issues when the builder contains multiple heroku/procfile versions. We don't use CNB
 // registry URLs since, as of August 2022, pack fails when another pack instance is resolving such
 // an URL in parallel.
-const PROCFILE_URL: &str = "docker://docker.io/heroku/procfile-cnb:2.0.0";
+const PROCFILE_URL: &str = "docker://docker.io/heroku/procfile-cnb:2.0.1";
 const TEST_PORT: u16 = 12345;
 
 #[test]


### PR DESCRIPTION
Since there has been a new Procfile CNB release:
https://github.com/heroku/procfile-cnb/releases/tag/v2.0.1

Plus adjust any example buildpack URIs to be more obviously examples, so we don't think we need to keep them up to date too.

GUS-W-13982566.