### PR TITLE
First pass refactoring `libcnb-cargo`/`libcnb-package` error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `libcnb-package`:
   - Added the `output::create_packaged_buildpack_dir_resolver` helper which contains all the information on how compiled buildpack directories are structured returns a function that can be invoked with `BuildpackId` to produce the output path for a buildpack. ([#632](https://github.com/heroku/libcnb.rs/pull/632))
+  - `std::fmt::Display` and `std::error::Error` implementations for all error values. ([#652](https://github.com/heroku/libcnb.rs/pull/652))
 
 ### Changed
 
@@ -21,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Changed the `ReadBuildpackDataError` and `ReadBuildpackageDataError` enums from struct to tuple format to be consistent with other error enums in the package. ([#631](https://github.com/heroku/libcnb.rs/pull/631))
   - Changed `buildpack_dependency::rewrite_buildpackage_local_dependencies` to accept a `&BuildpackOutputDirectoryLocator` instead of `&HashMap<&BuildpackId, PathBuf>`. ([#632](https://github.com/heroku/libcnb.rs/pull/632))
   - Moved `default_buildpack_directory_name` to `output::default_buildpack_directory_name`. ([#632](https://github.com/heroku/libcnb.rs/pull/632))
+  - Renamed `FindCargoWorkspaceError` to `FindCargoWorkspaceRootError`. ([#652](https://github.com/heroku/libcnb.rs/pull/652))
+  - Renamed `BuildError::IoError` to `BuildError::CargoProcessIoError`. ([#652](https://github.com/heroku/libcnb.rs/pull/652))
+  - Renamed `RewriteBuildpackageLocalDependenciesError::GetBuildpackDependenciesError` to `RewriteBuildpackageLocalDependenciesError::InvalidBuildpackIdReference`. ([#652](https://github.com/heroku/libcnb.rs/pull/652))
+  - Renamed `RewriteBuildpackageRelativePathDependenciesToAbsoluteError::GetBuildpackDependenciesError` to `RewriteBuildpackageRelativePathDependenciesToAbsoluteError::InvalidBuildpackIdReference`. ([#652](https://github.com/heroku/libcnb.rs/pull/652))
+  - Added type bound to `CreateDependencyGraphError<I, E>` to ensure `E` implements `std::error::Error`. ([#652](https://github.com/heroku/libcnb.rs/pull/652))
 
 ### Removed
 

--- a/libcnb-cargo/src/package/error.rs
+++ b/libcnb-cargo/src/package/error.rs
@@ -1,238 +1,55 @@
 use libcnb_data::buildpack::{BuildpackId, BuildpackIdError};
-use libcnb_package::build::{BuildBinariesError, BuildError};
-use libcnb_package::buildpack_dependency::{
-    RewriteBuildpackageLocalDependenciesError,
-    RewriteBuildpackageRelativePathDependenciesToAbsoluteError,
-};
-use libcnb_package::buildpack_package::ReadBuildpackPackageError;
-use libcnb_package::dependency_graph::{CreateDependencyGraphError, GetDependenciesError};
-use libcnb_package::FindCargoWorkspaceError;
-use libcnb_package::{ReadBuildpackDataError, ReadBuildpackageDataError};
+use libcnb_package::build::BuildBinariesError;
 use std::path::PathBuf;
-use std::process::ExitStatus;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(thiserror::Error, Debug)]
 pub(crate) enum Error {
-    #[error("Failed to get current dir\nError: {0}")]
-    GetCurrentDir(std::io::Error),
-
-    #[error("Could not locate a Cargo workspace within `{0}` or it's parent directories")]
-    GetWorkspaceDirectory(PathBuf),
-
-    #[error("Could not read Cargo.toml metadata in `{path}`\nError: {source}")]
-    ReadCargoMetadata {
-        path: PathBuf,
-        source: cargo_metadata::Error,
-    },
-
-    #[error("Could not create package directory: {0}\nError: {1}")]
-    CreatePackageDirectory(PathBuf, std::io::Error),
-
-    #[error("{0}")]
-    CrossCompilationHelp(String),
-
-    #[error("No environment variable named `CARGO` is set")]
-    GetCargoBin(#[from] std::env::VarError),
-
-    #[error("Meta-buildpack is missing expected package.toml file")]
-    MissingBuildpackageData,
-
-    #[error("Failed to serialize package.toml\nError: {0}")]
-    SerializeBuildpackage(toml::ser::Error),
-
-    #[error("Error while finding buildpack directories\nLocation: {0}\nError: {1}")]
-    FindBuildpackDirs(PathBuf, std::io::Error),
-
-    #[error("There was a problem with the build configuration")]
-    BinaryConfig,
-
-    #[error("I/O error while executing Cargo for target {0}\nError: {1}")]
-    BinaryBuildExecution(String, std::io::Error),
-
-    #[error("Unexpected Cargo exit status for target {0}\nExit Status: {}\nExamine Cargo output for details and potential compilation errors.", .exit_code_or_unknown(.1))]
-    BinaryBuildExitStatus(String, ExitStatus),
-
-    #[error("Configured buildpack target name {target} could not be found!")]
-    BinaryBuildMissingTarget { target: String },
-
-    #[error("Failed to read buildpack data\nLocation: {0}\nError: {1}")]
-    ReadBuildpackData(PathBuf, std::io::Error),
-
-    #[error("Failed to parse buildpack data\nLocation: {0}\nError: {1}")]
-    ParseBuildpackData(PathBuf, toml::de::Error),
-
-    #[error("Failed to read buildpackage data\nLocation: {0}\nError: {1}")]
-    ReadBuildpackageData(PathBuf, std::io::Error),
-
-    #[error("Failed to parse buildpackage data\nLocation: {0}\nError: {1}")]
-    ParseBuildpackageData(PathBuf, toml::de::Error),
-
-    #[error("Failed to lookup buildpack dependency with id `{0}`")]
-    BuildpackDependencyLookup(BuildpackId),
-
-    #[error("Buildpack has an invalid id\nError: `{0}`")]
-    BuildpackPackagesId(BuildpackIdError),
-
-    #[error("Failed to locate buildpack with id `{0}`")]
-    BuildpackPackagesLookup(BuildpackId),
-
-    #[error("Could not convert path into buildpackage file uri: {0}")]
-    InvalidPathDependency(PathBuf),
-
-    #[error("Unexpected error while getting buildpack dependencies\nError: {0}")]
-    GetBuildpackDependencies(BuildpackIdError),
-
+    #[error("Failed to get current dir: {0}")]
+    GetCurrentDir(#[source] std::io::Error),
+    #[error("Failed to find Cargo workspace root: {0}")]
+    FindCargoWorkspaceRoot(#[source] libcnb_package::FindCargoWorkspaceRootError),
+    #[error("Failed to create package directory: {0}")]
+    CreatePackageDirectory(PathBuf, #[source] std::io::Error),
+    #[error("Failed to find buildpack directories in path {0}: {1}")]
+    FindBuildpackDirs(PathBuf, #[source] std::io::Error),
+    #[error("Failed to read buildpack package: {0}")]
+    ReadBuildpackPackage(#[source] Box<libcnb_package::buildpack_package::ReadBuildpackPackageError>),
+    #[error("Failed to create buildpack dependency graph: {0}")]
+    CreateDependencyGraph(
+        #[source] libcnb_package::dependency_graph::CreateDependencyGraphError<BuildpackId, BuildpackIdError>,
+    ),
     #[error("No buildpacks found!")]
     NoBuildpacksFound,
-
-    #[error("Could not assemble buildpack directory\nPath: {0}\nError: {1}")]
-    AssembleBuildpackDirectory(PathBuf, std::io::Error),
-
-    #[error(
-        "Failed to write package.toml to the target buildpack directory\nPath: {0}\nError: {1}"
-    )]
-    WriteBuildpackage(PathBuf, std::io::Error),
-
-    #[error("I/O error while creating target buildpack directory\nPath: {0}\nError: {1}")]
-    CreateBuildpackTargetDirectory(PathBuf, std::io::Error),
-
-    #[error(
-        "Failed to write buildpack.toml to the target buildpack directory\nPath: {0}\nError: {1}"
-    )]
-    WriteBuildpack(PathBuf, std::io::Error),
-
-    #[error("Could not remove existing buildpack target directory\nPath: {0}\nError: {1}")]
-    CleanBuildpackTargetDirectory(PathBuf, std::io::Error),
-
-    #[error("I/O error while calculating directory size\nPath: {0}\nError: {1}")]
-    CalculateDirectorySize(PathBuf, std::io::Error),
-
-    #[error("Failed to spawn Cargo command\nError: {0}")]
-    SpawnCargoCommand(std::io::Error),
-
-    #[error("Unexpected Cargo exit status while attempting to read workspace root\nExit Status: {}\nExamine Cargo output for details and potential compilation errors.", exit_code_or_unknown(.0))]
-    CargoCommandFailure(ExitStatus),
-
-    #[error("Could not read Cargo.toml metadata from workspace\nPath: {0}\nError: {1}")]
-    GetBuildpackOutputDir(PathBuf, cargo_metadata::Error),
-}
-
-impl From<BuildBinariesError> for Error {
-    fn from(value: BuildBinariesError) -> Self {
-        match value {
-            BuildBinariesError::ConfigError(_) => Error::BinaryConfig,
-
-            BuildBinariesError::BuildError(target, BuildError::IoError(source)) => {
-                Error::BinaryBuildExecution(target, source)
-            }
-
-            BuildBinariesError::BuildError(
-                target,
-                BuildError::UnexpectedCargoExitStatus(exit_status),
-            ) => Error::BinaryBuildExitStatus(target, exit_status),
-
-            BuildBinariesError::MissingBuildpackTarget(target) => {
-                Error::BinaryBuildMissingTarget { target }
-            }
-        }
-    }
-}
-
-impl From<ReadBuildpackPackageError> for Error {
-    fn from(value: ReadBuildpackPackageError) -> Self {
-        match value {
-            ReadBuildpackPackageError::ReadBuildpackDataError(error) => error.into(),
-            ReadBuildpackPackageError::ReadBuildpackageDataError(error) => error.into(),
-        }
-    }
-}
-
-impl From<ReadBuildpackDataError> for Error {
-    fn from(value: ReadBuildpackDataError) -> Self {
-        match value {
-            ReadBuildpackDataError::ReadingBuildpack(path, source) => {
-                Error::ReadBuildpackData(path, source)
-            }
-            ReadBuildpackDataError::ParsingBuildpack(path, source) => {
-                Error::ParseBuildpackData(path, source)
-            }
-        }
-    }
-}
-
-impl From<ReadBuildpackageDataError> for Error {
-    fn from(value: ReadBuildpackageDataError) -> Self {
-        match value {
-            ReadBuildpackageDataError::ReadingBuildpackage(path, source) => {
-                Error::ReadBuildpackageData(path, source)
-            }
-            ReadBuildpackageDataError::ParsingBuildpackage(path, source) => {
-                Error::ParseBuildpackageData(path, source)
-            }
-        }
-    }
-}
-
-impl From<GetDependenciesError<BuildpackId>> for Error {
-    fn from(value: GetDependenciesError<BuildpackId>) -> Self {
-        match value {
-            GetDependenciesError::MissingDependency(buildpack_id) => {
-                Error::BuildpackDependencyLookup(buildpack_id)
-            }
-        }
-    }
-}
-
-impl From<CreateDependencyGraphError<BuildpackId, BuildpackIdError>> for Error {
-    fn from(value: CreateDependencyGraphError<BuildpackId, BuildpackIdError>) -> Self {
-        match value {
-            CreateDependencyGraphError::Dependencies(error) => Error::BuildpackPackagesId(error),
-            CreateDependencyGraphError::MissingDependency(id) => Error::BuildpackPackagesLookup(id),
-        }
-    }
-}
-
-impl From<RewriteBuildpackageLocalDependenciesError> for Error {
-    fn from(value: RewriteBuildpackageLocalDependenciesError) -> Self {
-        match value {
-            RewriteBuildpackageLocalDependenciesError::InvalidDependency(path) => {
-                Error::InvalidPathDependency(path)
-            }
-            RewriteBuildpackageLocalDependenciesError::GetBuildpackDependenciesError(error) => {
-                Error::GetBuildpackDependencies(error)
-            }
-        }
-    }
-}
-
-impl From<RewriteBuildpackageRelativePathDependenciesToAbsoluteError> for Error {
-    fn from(value: RewriteBuildpackageRelativePathDependenciesToAbsoluteError) -> Self {
-        match value {
-            RewriteBuildpackageRelativePathDependenciesToAbsoluteError::InvalidDependency(path) => Error::InvalidPathDependency(path),
-            RewriteBuildpackageRelativePathDependenciesToAbsoluteError::GetBuildpackDependenciesError(error) => Error::GetBuildpackDependencies(error)
-        }
-    }
-}
-
-impl From<FindCargoWorkspaceError> for Error {
-    fn from(value: FindCargoWorkspaceError) -> Self {
-        match value {
-            FindCargoWorkspaceError::GetCargoEnv(error) => Error::GetCargoBin(error),
-            FindCargoWorkspaceError::SpawnCommand(error) => Error::SpawnCargoCommand(error),
-            FindCargoWorkspaceError::CommandFailure(exit_status) => {
-                Error::CargoCommandFailure(exit_status)
-            }
-            FindCargoWorkspaceError::GetParentDirectory(path) => Error::GetWorkspaceDirectory(path),
-        }
-    }
-}
-
-// This function is used with the thiserror crate, where getting a value from an (error) enum
-// variant yields a reference. Since this is the only use-case for this function, we accept a
-// reference, even though ExitStatus is Copy.
-#[allow(clippy::trivially_copy_pass_by_ref)]
-fn exit_code_or_unknown(exit_status: &ExitStatus) -> String {
-    exit_status
-        .code()
-        .map_or_else(|| String::from("<unknown>"), |code| code.to_string())
+    #[error("Failed to get dependencies: {0}")]
+    GetDependencies(#[source] libcnb_package::dependency_graph::GetDependenciesError<BuildpackId>),
+    #[error("Failed to read Cargo metadata: {1}")]
+    ReadCargoMetadata(PathBuf, #[source] cargo_metadata::Error),
+    #[error("Failed to assemble buildpack directory in {0}: {1}")]
+    AssembleBuildpackDirectory(PathBuf, #[source] std::io::Error),
+    #[error("Failed to build buildpack binaries: {0}")]
+    BuildBinaries(#[source] BuildBinariesError),
+    #[error("Failed to serialize package.toml: {0}")]
+    SerializeBuildpackage(#[source] toml::ser::Error),
+    #[error("Failed to write package.toml to {0}: {1}")]
+    WriteBuildpackage(PathBuf, #[source] std::io::Error),
+    #[error("Failed to create buildpack target directory {0}: {1}")]
+    CreateBuildpackTargetDirectory(PathBuf, #[source] std::io::Error),
+    #[error("Failed to copy buildpack.toml to {0}: {1}")]
+    CopyBuildpackToml(PathBuf, #[source] std::io::Error),
+    #[error("Buildpack does not contain a package.toml file")]
+    MissingBuildpackageData,
+    #[error("Failed to rewrite package.toml: {0}")]
+    RewriteBuildpackageLocalDependencies(#[source] libcnb_package::buildpack_dependency::RewriteBuildpackageLocalDependenciesError),
+    #[error("Failed to rewrite package.toml: {0}")]
+    RewriteBuildpackageRelativePathDependenciesToAbsolute(
+        #[source] libcnb_package::buildpack_dependency::RewriteBuildpackageRelativePathDependenciesToAbsoluteError,
+    ),
+    #[error("Failed to clean buildpack target directory {0}: {1}")]
+    CleanBuildpackTargetDirectory(PathBuf, #[source] std::io::Error),
+    #[error("Failed to calculate directory size of {0}: {1}")]
+    CalculateDirectorySize(PathBuf, #[source] std::io::Error),
+    #[error("{0}")]
+    CrossCompilationHelp(String),
+    #[error("Failed to get buildpack output directory: {1}")]
+    GetBuildpackOutputDir(PathBuf, #[source] cargo_metadata::Error),
 }

--- a/libcnb-cargo/src/package/mod.rs
+++ b/libcnb-cargo/src/package/mod.rs
@@ -1,3 +1,3 @@
-mod command;
-mod error;
+pub(crate) mod command;
+pub(crate) mod error;
 pub(crate) use command::execute;

--- a/libcnb-package/Cargo.toml
+++ b/libcnb-package/Cargo.toml
@@ -15,6 +15,6 @@ include = ["src/**/*", "LICENSE", "README.md"]
 cargo_metadata = "0.17.0"
 libcnb-data.workspace = true
 petgraph = { version = "0.6.3", default-features = false }
+thiserror = "1.0.44"
 toml.workspace = true
 which = "4.4.0"
-thiserror = "1.0.44"

--- a/libcnb-package/Cargo.toml
+++ b/libcnb-package/Cargo.toml
@@ -17,3 +17,4 @@ libcnb-data.workspace = true
 petgraph = { version = "0.6.3", default-features = false }
 toml.workspace = true
 which = "4.4.0"
+thiserror = "1.0.44"

--- a/libcnb-package/src/buildpack_dependency.rs
+++ b/libcnb-package/src/buildpack_dependency.rs
@@ -89,7 +89,7 @@ pub fn rewrite_buildpackage_local_dependencies(
     };
 
     get_buildpack_dependencies(buildpackage)
-        .map_err(RewriteBuildpackageLocalDependenciesError::GetBuildpackDependenciesError)
+        .map_err(RewriteBuildpackageLocalDependenciesError::InvalidBuildpackIdReference)
         .and_then(|dependencies| {
             dependencies
                 .into_iter()
@@ -112,10 +112,12 @@ pub fn rewrite_buildpackage_local_dependencies(
 }
 
 /// An error for [`rewrite_buildpackage_local_dependencies`]
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum RewriteBuildpackageLocalDependenciesError {
+    #[error("Path {0} cannot be treated as a buildpack dependency")]
     InvalidDependency(PathBuf),
-    GetBuildpackDependenciesError(BuildpackIdError),
+    #[error("Buildpackage references another buildpack with an invalid id: {0}")]
+    InvalidBuildpackIdReference(#[source] BuildpackIdError),
 }
 
 /// Creates a new [`Buildpackage`] value by replacing each relative URI with it's absolute path using
@@ -141,7 +143,9 @@ pub fn rewrite_buildpackage_relative_path_dependencies_to_absolute(
         };
 
     get_buildpack_dependencies(buildpackage)
-        .map_err(RewriteBuildpackageRelativePathDependenciesToAbsoluteError::GetBuildpackDependenciesError)
+        .map_err(
+            RewriteBuildpackageRelativePathDependenciesToAbsoluteError::InvalidBuildpackIdReference,
+        )
         .and_then(|dependencies| {
             dependencies
                 .into_iter()
@@ -167,10 +171,12 @@ pub fn rewrite_buildpackage_relative_path_dependencies_to_absolute(
 }
 
 /// An error for [`rewrite_buildpackage_relative_path_dependencies_to_absolute`]
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum RewriteBuildpackageRelativePathDependenciesToAbsoluteError {
+    #[error("Path {0} cannot be treated as a buildpack dependency")]
     InvalidDependency(PathBuf),
-    GetBuildpackDependenciesError(BuildpackIdError),
+    #[error("Buildpackage references another buildpack with an invalid id: {0}")]
+    InvalidBuildpackIdReference(#[source] BuildpackIdError),
 }
 
 #[cfg(test)]

--- a/libcnb-package/src/buildpack_package.rs
+++ b/libcnb-package/src/buildpack_package.rs
@@ -60,8 +60,10 @@ pub fn read_buildpack_package<P: Into<PathBuf>>(
 }
 
 /// An error from [`read_buildpack_package`]
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum ReadBuildpackPackageError {
-    ReadBuildpackDataError(ReadBuildpackDataError),
-    ReadBuildpackageDataError(ReadBuildpackageDataError),
+    #[error("Failed to read buildpack data: {0}")]
+    ReadBuildpackDataError(#[source] ReadBuildpackDataError),
+    #[error("Failed to read buildpackage data: {0}")]
+    ReadBuildpackageDataError(#[source] ReadBuildpackageDataError),
 }

--- a/libcnb-package/src/config.rs
+++ b/libcnb-package/src/config.rs
@@ -37,9 +37,12 @@ pub(crate) fn config_from_metadata(cargo_metadata: &Metadata) -> Result<Config, 
     }
 }
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum ConfigError {
+    #[error("Cargo metadata does not contain a root package")]
     MissingRootPackage,
+    #[error("No binary targets could be found in Cargo metadata")]
     NoBinTargetsFound,
+    #[error("Multiple binary targets found in Cargo metadata")]
     MultipleBinTargetsFound,
 }

--- a/libcnb-package/src/dependency_graph.rs
+++ b/libcnb-package/src/dependency_graph.rs
@@ -1,5 +1,6 @@
 use petgraph::visit::DfsPostOrder;
 use petgraph::Graph;
+use std::error::Error;
 
 /// A node of a dependency graph.
 ///
@@ -30,6 +31,7 @@ pub fn create_dependency_graph<T, I, E>(
 where
     T: DependencyNode<I, E>,
     I: PartialEq,
+    E: Error,
 {
     let mut graph = Graph::new();
 
@@ -57,9 +59,11 @@ where
 }
 
 /// An error from [`create_dependency_graph`]
-#[derive(Debug)]
-pub enum CreateDependencyGraphError<I, E> {
-    Dependencies(E),
+#[derive(thiserror::Error, Debug)]
+pub enum CreateDependencyGraphError<I, E: Error> {
+    #[error("Cannot determine dependencies of a node: {0}")]
+    Dependencies(#[source] E),
+    #[error("Node references an unknown dependency: {0}")]
     MissingDependency(I),
 }
 
@@ -94,8 +98,9 @@ where
 }
 
 /// An error from [`get_dependencies`]
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum GetDependenciesError<I> {
+    #[error("Node references an unknown dependency: {0}")]
     MissingDependency(I),
 }
 


### PR DESCRIPTION
This PR is the first one in a series that cleans up the error handling in `libcnb-cargo` and `libcnb-package`. It is mostly about error structure.

- Removes unecesasry flattening (and duplication) of errors in `libcnb-cargo`
  - Closes #634
- Implement `std::error::Error` for all errors (via `thiserror`) in both crates.
  - Correctly annotate parent errors with thiserror's `#[source]` attribute.
- Rename some errors when the name wasn't good enough to get an idea what went wrong.
- Replaced some implicit error converions with explicit `.map_err()` calls.
- Replaced some `.map_err(std::convert::Into::into)` with explicit mappings.

Issues that this PR doesn't attempt to fix and will be fixed later:
- Error naming (there are many misleading or outright wrong names)
- Improving `Display`/`Debug` implementations for some errors
- Removal of new error values when "bubbling up" would've been good enough.
- Splitting errors that are re-used between (unrelated) functions

Ref: GUS-W-13999008