### PR TITLE
Rename `Buildpackage` to `PackageDescriptor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed `libcnb-data`'s `Buildpackage` to `PackageDescriptor`. This required changes in many other names across multiple libcnb.rs crates for consistency. See the PR diff for details, but renames should be straightforward and unsurprising. ([#656](https://github.com/heroku/libcnb.rs/pull/656))
 - `libcnb-package`:
   - Added `find_cargo_workspace_root_dir` which provides a convenient starting point for locating buildpacks for packaging and testing purposes. ([#629](https://github.com/heroku/libcnb.rs/pull/629))
   - Changed the `ReadBuildpackDataError` and `ReadBuildpackageDataError` enums from struct to tuple format to be consistent with other error enums in the package. ([#631](https://github.com/heroku/libcnb.rs/pull/631))

--- a/libcnb-cargo/src/package/command.rs
+++ b/libcnb-cargo/src/package/command.rs
@@ -2,7 +2,7 @@ use crate::cli::PackageArgs;
 use crate::package::error::Error;
 use cargo_metadata::MetadataCommand;
 use libcnb_data::buildpack::{BuildpackDescriptor, BuildpackId};
-use libcnb_data::buildpackage::PackageDescriptor;
+use libcnb_data::package_descriptor::PackageDescriptor;
 use libcnb_package::build::build_buildpack_binaries;
 use libcnb_package::buildpack_dependency::{
     rewrite_package_descriptor_local_dependencies,
@@ -172,8 +172,8 @@ fn package_single_buildpack(
     )
     .map_err(|e| Error::AssembleBuildpackDirectory(target_dir.to_path_buf(), e))?;
 
-    let package_descriptor_content =
-        toml::to_string(&PackageDescriptor::default()).map_err(Error::SerializePackageDescriptor)?;
+    let package_descriptor_content = toml::to_string(&PackageDescriptor::default())
+        .map_err(Error::SerializePackageDescriptor)?;
 
     std::fs::write(target_dir.join("package.toml"), package_descriptor_content)
         .map_err(|e| Error::WritePackageDescriptor(target_dir.to_path_buf(), e))?;

--- a/libcnb-cargo/src/package/error.rs
+++ b/libcnb-cargo/src/package/error.rs
@@ -29,20 +29,20 @@ pub(crate) enum Error {
     #[error("Failed to build buildpack binaries: {0}")]
     BuildBinaries(#[source] BuildBinariesError),
     #[error("Failed to serialize package.toml: {0}")]
-    SerializeBuildpackage(#[source] toml::ser::Error),
+    SerializePackageDescriptor(#[source] toml::ser::Error),
     #[error("Failed to write package.toml to {0}: {1}")]
-    WriteBuildpackage(PathBuf, #[source] std::io::Error),
+    WritePackageDescriptor(PathBuf, #[source] std::io::Error),
     #[error("Failed to create buildpack target directory {0}: {1}")]
     CreateBuildpackTargetDirectory(PathBuf, #[source] std::io::Error),
     #[error("Failed to copy buildpack.toml to {0}: {1}")]
     CopyBuildpackToml(PathBuf, #[source] std::io::Error),
     #[error("Buildpack does not contain a package.toml file")]
-    MissingBuildpackageData,
+    MissingPackageDescriptorData,
     #[error("Failed to rewrite package.toml: {0}")]
-    RewriteBuildpackageLocalDependencies(#[source] libcnb_package::buildpack_dependency::RewriteBuildpackageLocalDependenciesError),
+    RewritePackageDescriptorLocalDependencies(#[source] libcnb_package::buildpack_dependency::RewritePackageDescriptorLocalDependenciesError),
     #[error("Failed to rewrite package.toml: {0}")]
-    RewriteBuildpackageRelativePathDependenciesToAbsolute(
-        #[source] libcnb_package::buildpack_dependency::RewriteBuildpackageRelativePathDependenciesToAbsoluteError,
+    RewritePackageDescriptorRelativePathDependenciesToAbsolute(
+        #[source] libcnb_package::buildpack_dependency::RewritePackageDescriptorRelativePathDependenciesToAbsoluteError,
     ),
     #[error("Failed to clean buildpack target directory {0}: {1}")]
     CleanBuildpackTargetDirectory(PathBuf, #[source] std::io::Error),

--- a/libcnb-cargo/tests/integration_test.rs
+++ b/libcnb-cargo/tests/integration_test.rs
@@ -4,7 +4,7 @@
 
 use libcnb_data::buildpack::BuildpackId;
 use libcnb_data::buildpack_id;
-use libcnb_data::buildpackage::PackageDescriptorDependency;
+use libcnb_data::package_descriptor::PackageDescriptorDependency;
 use libcnb_package::output::create_packaged_buildpack_dir_resolver;
 use libcnb_package::{read_buildpack_data, read_package_descriptor_data, CargoProfile};
 use std::io::ErrorKind;

--- a/libcnb-cargo/tests/integration_test.rs
+++ b/libcnb-cargo/tests/integration_test.rs
@@ -4,9 +4,9 @@
 
 use libcnb_data::buildpack::BuildpackId;
 use libcnb_data::buildpack_id;
-use libcnb_data::buildpackage::BuildpackageDependency;
+use libcnb_data::buildpackage::PackageDescriptorDependency;
 use libcnb_package::output::create_packaged_buildpack_dir_resolver;
-use libcnb_package::{read_buildpack_data, read_buildpackage_data, CargoProfile};
+use libcnb_package::{read_buildpack_data, read_package_descriptor_data, CargoProfile};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -69,18 +69,18 @@ fn package_single_meta_buildpack_in_monorepo_buildpack_project() {
         &packaged_buildpack_dir_resolver(&buildpack_id!("multiple-buildpacks/meta-one")),
         &buildpack_id!("multiple-buildpacks/meta-one"),
         &[
-            BuildpackageDependency::try_from(packaged_buildpack_dir_resolver(&buildpack_id!(
+            PackageDescriptorDependency::try_from(packaged_buildpack_dir_resolver(&buildpack_id!(
                 "multiple-buildpacks/one"
             ))),
-            BuildpackageDependency::try_from(packaged_buildpack_dir_resolver(&buildpack_id!(
+            PackageDescriptorDependency::try_from(packaged_buildpack_dir_resolver(&buildpack_id!(
                 "multiple-buildpacks/two"
             ))),
-            BuildpackageDependency::try_from(
+            PackageDescriptorDependency::try_from(
                 fixture_dir
                     .path()
                     .join("meta-buildpacks/meta-one/../../buildpacks/not_libcnb"),
             ),
-            BuildpackageDependency::try_from("docker://docker.io/heroku/example:1.2.3"),
+            PackageDescriptorDependency::try_from("docker://docker.io/heroku/example:1.2.3"),
         ]
         .into_iter()
         .collect::<Result<Vec<_>, _>>()
@@ -165,18 +165,18 @@ fn package_all_buildpacks_in_monorepo_buildpack_project() {
         &packaged_buildpack_dir_resolver(&buildpack_id!("multiple-buildpacks/meta-one")),
         &buildpack_id!("multiple-buildpacks/meta-one"),
         &[
-            BuildpackageDependency::try_from(packaged_buildpack_dir_resolver(&buildpack_id!(
+            PackageDescriptorDependency::try_from(packaged_buildpack_dir_resolver(&buildpack_id!(
                 "multiple-buildpacks/one"
             ))),
-            BuildpackageDependency::try_from(packaged_buildpack_dir_resolver(&buildpack_id!(
+            PackageDescriptorDependency::try_from(packaged_buildpack_dir_resolver(&buildpack_id!(
                 "multiple-buildpacks/two"
             ))),
-            BuildpackageDependency::try_from(
+            PackageDescriptorDependency::try_from(
                 fixture_dir
                     .path()
                     .join("meta-buildpacks/meta-one/../../buildpacks/not_libcnb"),
             ),
-            BuildpackageDependency::try_from("docker://docker.io/heroku/example:1.2.3"),
+            PackageDescriptorDependency::try_from("docker://docker.io/heroku/example:1.2.3"),
         ]
         .into_iter()
         .collect::<Result<Vec<_>, _>>()
@@ -251,7 +251,7 @@ fn validate_packaged_buildpack(packaged_buildpack_dir: &Path, buildpack_id: &Bui
 fn validate_packaged_meta_buildpack(
     packaged_buildpack_dir: &Path,
     buildpack_id: &BuildpackId,
-    expected_buildpackage_dependencies: &[BuildpackageDependency],
+    expected_package_descriptor_dependencies: &[PackageDescriptorDependency],
 ) {
     assert!(packaged_buildpack_dir.join("buildpack.toml").exists());
     assert!(packaged_buildpack_dir.join("package.toml").exists());
@@ -266,12 +266,12 @@ fn validate_packaged_meta_buildpack(
     );
 
     assert_eq!(
-        read_buildpackage_data(packaged_buildpack_dir)
+        read_package_descriptor_data(packaged_buildpack_dir)
             .unwrap()
             .unwrap()
-            .buildpackage_descriptor
+            .package_descriptor
             .dependencies,
-        expected_buildpackage_dependencies
+        expected_package_descriptor_dependencies
     );
 }
 

--- a/libcnb-data/src/lib.rs
+++ b/libcnb-data/src/lib.rs
@@ -8,11 +8,11 @@ pub mod build;
 pub mod build_plan;
 pub mod buildpack;
 pub mod buildpack_plan;
-pub mod buildpackage;
 pub mod exec_d;
 pub mod launch;
 pub mod layer;
 pub mod layer_content_metadata;
+pub mod package_descriptor;
 pub mod sbom;
 pub mod store;
 

--- a/libcnb-data/src/package_descriptor.rs
+++ b/libcnb-data/src/package_descriptor.rs
@@ -1,4 +1,4 @@
-use crate::buildpackage::PlatformOs::Linux;
+use crate::package_descriptor::PlatformOs::Linux;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::path::PathBuf;
 use uriparse::{URIReference, URIReferenceError};
@@ -7,7 +7,7 @@ use uriparse::{URIReference, URIReferenceError};
 ///
 /// # Example
 /// ```
-/// use libcnb_data::buildpackage::PackageDescriptor;
+/// use libcnb_data::package_descriptor::PackageDescriptor;
 ///
 /// let toml_str = r#"
 /// [buildpack]
@@ -170,7 +170,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::buildpackage::PlatformOs::Windows;
+    use crate::package_descriptor::PlatformOs::Windows;
 
     #[test]
     fn it_parses_minimal() {

--- a/libcnb-package/src/buildpack_dependency.rs
+++ b/libcnb-package/src/buildpack_dependency.rs
@@ -1,5 +1,5 @@
 use libcnb_data::buildpack::{BuildpackId, BuildpackIdError};
-use libcnb_data::buildpackage::{PackageDescriptor, PackageDescriptorDependency};
+use libcnb_data::package_descriptor::{PackageDescriptor, PackageDescriptorDependency};
 use std::path::{Path, PathBuf};
 
 /// Buildpack dependency type
@@ -189,7 +189,7 @@ mod tests {
     use crate::output::create_packaged_buildpack_dir_resolver;
     use crate::CargoProfile;
     use libcnb_data::buildpack_id;
-    use libcnb_data::buildpackage::{
+    use libcnb_data::package_descriptor::{
         PackageDescriptor, PackageDescriptorBuildpackReference, PackageDescriptorDependency,
         Platform,
     };

--- a/libcnb-package/src/buildpack_dependency.rs
+++ b/libcnb-package/src/buildpack_dependency.rs
@@ -1,12 +1,12 @@
 use libcnb_data::buildpack::{BuildpackId, BuildpackIdError};
-use libcnb_data::buildpackage::{Buildpackage, BuildpackageDependency};
+use libcnb_data::buildpackage::{PackageDescriptor, PackageDescriptorDependency};
 use std::path::{Path, PathBuf};
 
 /// Buildpack dependency type
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum BuildpackDependency {
-    External(BuildpackageDependency),
-    Local(BuildpackId, BuildpackageDependency),
+    External(PackageDescriptorDependency),
+    Local(BuildpackId, PackageDescriptorDependency),
 }
 
 impl BuildpackDependency {
@@ -20,9 +20,9 @@ impl BuildpackDependency {
 }
 
 fn get_buildpack_dependencies(
-    buildpackage: &Buildpackage,
+    package_descriptor: &PackageDescriptor,
 ) -> Result<Vec<BuildpackDependency>, BuildpackIdError> {
-    buildpackage
+    package_descriptor
         .dependencies
         .iter()
         .map(|dependency| {
@@ -37,7 +37,7 @@ fn get_buildpack_dependencies(
 }
 
 fn buildpack_id_from_libcnb_dependency(
-    dependency: &BuildpackageDependency,
+    dependency: &PackageDescriptorDependency,
 ) -> Result<Option<BuildpackId>, BuildpackIdError> {
     Some(&dependency.uri)
         .filter(|uri| {
@@ -48,16 +48,16 @@ fn buildpack_id_from_libcnb_dependency(
         .transpose()
 }
 
-/// Reads the dependency URIs from the given `buildpackage` and returns any local libcnb project
+/// Reads the dependency URIs from the given [`PackageDescriptor`] and returns any local libcnb project
 /// references which should have the format `libcnb:{buildpack_id}`.
 ///
 /// # Errors
 ///
 /// Will return an `Err` if any of the local dependencies use an invalid [`BuildpackId`].
-pub fn get_local_buildpackage_dependencies(
-    buildpackage: &Buildpackage,
+pub fn get_local_package_descriptor_dependencies(
+    package_descriptor: &PackageDescriptor,
 ) -> Result<Vec<BuildpackId>, BuildpackIdError> {
-    get_buildpack_dependencies(buildpackage).map(|dependencies| {
+    get_buildpack_dependencies(package_descriptor).map(|dependencies| {
         dependencies
             .iter()
             .filter_map(BuildpackDependency::get_local_buildpack_id)
@@ -65,7 +65,7 @@ pub fn get_local_buildpackage_dependencies(
     })
 }
 
-/// Creates a new [`Buildpackage`] value by replacing each local libcnb dependency with the
+/// Creates a new [`PackageDescriptor`] value by replacing each local libcnb dependency with the
 /// file path where the compiled dependency is located.
 ///
 /// This assumes that each libcnb dependency has already been compiled and the given
@@ -75,27 +75,27 @@ pub fn get_local_buildpackage_dependencies(
 /// # Errors
 ///
 /// Will return an `Err` if:
-/// * the given `buildpackage` contains a local dependency with an invalid [`BuildpackId`]
+/// * the given [`PackageDescriptor`] contains a local dependency with an invalid [`BuildpackId`]
 /// * there is no entry found in `buildpack_ids_to_target_dir` for a local dependency's [`BuildpackId`]
 /// * the target path for a local dependency is an invalid URI
-pub fn rewrite_buildpackage_local_dependencies(
-    buildpackage: &Buildpackage,
+pub fn rewrite_package_descriptor_local_dependencies(
+    package_descriptor: &PackageDescriptor,
     packaged_buildpack_dir_resolver: &impl Fn(&BuildpackId) -> PathBuf,
-) -> Result<Buildpackage, RewriteBuildpackageLocalDependenciesError> {
+) -> Result<PackageDescriptor, RewritePackageDescriptorLocalDependenciesError> {
     let local_dependency_to_target_dir = |target_dir: &PathBuf| {
-        BuildpackageDependency::try_from(target_dir.clone()).map_err(|_| {
-            RewriteBuildpackageLocalDependenciesError::InvalidDependency(target_dir.clone())
+        PackageDescriptorDependency::try_from(target_dir.clone()).map_err(|_| {
+            RewritePackageDescriptorLocalDependenciesError::InvalidDependency(target_dir.clone())
         })
     };
 
-    get_buildpack_dependencies(buildpackage)
-        .map_err(RewriteBuildpackageLocalDependenciesError::InvalidBuildpackIdReference)
+    get_buildpack_dependencies(package_descriptor)
+        .map_err(RewritePackageDescriptorLocalDependenciesError::InvalidBuildpackIdReference)
         .and_then(|dependencies| {
             dependencies
                 .into_iter()
                 .map(|dependency| match dependency {
-                    BuildpackDependency::External(buildpackage_dependency) => {
-                        Ok(buildpackage_dependency)
+                    BuildpackDependency::External(package_descriptor_dependency) => {
+                        Ok(package_descriptor_dependency)
                     }
                     BuildpackDependency::Local(buildpack_id, _) => {
                         let output_dir = packaged_buildpack_dir_resolver(&buildpack_id);
@@ -104,138 +104,143 @@ pub fn rewrite_buildpackage_local_dependencies(
                 })
                 .collect()
         })
-        .map(|dependencies| Buildpackage {
+        .map(|dependencies| PackageDescriptor {
             dependencies,
-            buildpack: buildpackage.buildpack.clone(),
-            platform: buildpackage.platform.clone(),
+            buildpack: package_descriptor.buildpack.clone(),
+            platform: package_descriptor.platform.clone(),
         })
 }
 
-/// An error for [`rewrite_buildpackage_local_dependencies`]
+/// An error for [`rewrite_package_descriptor_local_dependencies`]
 #[derive(thiserror::Error, Debug)]
-pub enum RewriteBuildpackageLocalDependenciesError {
+pub enum RewritePackageDescriptorLocalDependenciesError {
     #[error("Path {0} cannot be treated as a buildpack dependency")]
     InvalidDependency(PathBuf),
-    #[error("Buildpackage references another buildpack with an invalid id: {0}")]
+    #[error("Package descriptor references another buildpack with an invalid id: {0}")]
     InvalidBuildpackIdReference(#[source] BuildpackIdError),
 }
 
-/// Creates a new [`Buildpackage`] value by replacing each relative URI with it's absolute path using
+/// Creates a new [`PackageDescriptor`] value by replacing each relative URI with it's absolute path using
 /// the given `source_path`.
 ///
 /// # Errors
 ///
 /// Will return an `Err` if:
-/// * the given `buildpackage` contains a local dependency with an invalid [`BuildpackId`]
+/// * the given [`PackageDescriptor`] contains a local dependency with an invalid [`BuildpackId`]
 /// * the constructed absolute path is an invalid URI
-pub fn rewrite_buildpackage_relative_path_dependencies_to_absolute(
-    buildpackage: &Buildpackage,
+pub fn rewrite_package_descriptor_relative_path_dependencies_to_absolute(
+    package_descriptor: &PackageDescriptor,
     source_dir: &Path,
-) -> Result<Buildpackage, RewriteBuildpackageRelativePathDependenciesToAbsoluteError> {
+) -> Result<PackageDescriptor, RewritePackageDescriptorRelativePathDependenciesToAbsoluteError> {
     let relative_dependency_to_absolute =
-        |source_dir: &Path, buildpackage_dependency: BuildpackageDependency| {
-            let absolute_path = source_dir.join(buildpackage_dependency.uri.path().to_string());
-            BuildpackageDependency::try_from(absolute_path.clone()).map_err(|_| {
-                RewriteBuildpackageRelativePathDependenciesToAbsoluteError::InvalidDependency(
+        |source_dir: &Path, package_descriptor_dependency: PackageDescriptorDependency| {
+            let absolute_path =
+                source_dir.join(package_descriptor_dependency.uri.path().to_string());
+            PackageDescriptorDependency::try_from(absolute_path.clone()).map_err(|_| {
+                RewritePackageDescriptorRelativePathDependenciesToAbsoluteError::InvalidDependency(
                     absolute_path,
                 )
             })
         };
 
-    get_buildpack_dependencies(buildpackage)
+    get_buildpack_dependencies(package_descriptor)
         .map_err(
-            RewriteBuildpackageRelativePathDependenciesToAbsoluteError::InvalidBuildpackIdReference,
+            RewritePackageDescriptorRelativePathDependenciesToAbsoluteError::InvalidBuildpackIdReference,
         )
         .and_then(|dependencies| {
             dependencies
                 .into_iter()
                 .map(|dependency| match dependency {
-                    BuildpackDependency::External(buildpackage_dependency) => {
-                        if buildpackage_dependency.uri.is_relative_path_reference() {
-                            relative_dependency_to_absolute(source_dir, buildpackage_dependency)
+                    BuildpackDependency::External(package_descriptor_dependency) => {
+                        if package_descriptor_dependency.uri.is_relative_path_reference() {
+                            relative_dependency_to_absolute(source_dir, package_descriptor_dependency)
                         } else {
-                            Ok(buildpackage_dependency)
+                            Ok(package_descriptor_dependency)
                         }
                     }
-                    BuildpackDependency::Local(_, buildpackage_dependency) => {
-                        Ok(buildpackage_dependency)
+                    BuildpackDependency::Local(_, package_descriptor_dependency) => {
+                        Ok(package_descriptor_dependency)
                     }
                 })
                 .collect()
         })
-        .map(|dependencies| Buildpackage {
+        .map(|dependencies| PackageDescriptor {
             dependencies,
-            buildpack: buildpackage.buildpack.clone(),
-            platform: buildpackage.platform.clone(),
+            buildpack: package_descriptor.buildpack.clone(),
+            platform: package_descriptor.platform.clone(),
         })
 }
 
-/// An error for [`rewrite_buildpackage_relative_path_dependencies_to_absolute`]
+/// An error for [`rewrite_package_descriptor_relative_path_dependencies_to_absolute`]
 #[derive(thiserror::Error, Debug)]
-pub enum RewriteBuildpackageRelativePathDependenciesToAbsoluteError {
+pub enum RewritePackageDescriptorRelativePathDependenciesToAbsoluteError {
     #[error("Path {0} cannot be treated as a buildpack dependency")]
     InvalidDependency(PathBuf),
-    #[error("Buildpackage references another buildpack with an invalid id: {0}")]
+    #[error("Package descriptor references another buildpack with an invalid id: {0}")]
     InvalidBuildpackIdReference(#[source] BuildpackIdError),
 }
 
 #[cfg(test)]
 mod tests {
     use crate::buildpack_dependency::{
-        get_local_buildpackage_dependencies, rewrite_buildpackage_local_dependencies,
-        rewrite_buildpackage_relative_path_dependencies_to_absolute,
+        get_local_package_descriptor_dependencies, rewrite_package_descriptor_local_dependencies,
+        rewrite_package_descriptor_relative_path_dependencies_to_absolute,
     };
     use crate::output::create_packaged_buildpack_dir_resolver;
     use crate::CargoProfile;
     use libcnb_data::buildpack_id;
     use libcnb_data::buildpackage::{
-        Buildpackage, BuildpackageBuildpackReference, BuildpackageDependency, Platform,
+        PackageDescriptor, PackageDescriptorBuildpackReference, PackageDescriptorDependency,
+        Platform,
     };
     use std::path::PathBuf;
 
     #[test]
-    fn test_rewrite_buildpackage_relative_path_dependencies() {
-        let buildpackage = create_buildpackage();
+    fn test_rewrite_package_descriptor_relative_path_dependencies() {
+        let package_descriptor = create_package_descriptor();
         let source_dir = PathBuf::from("/test/source/path");
-        let new_buildpackage =
-            rewrite_buildpackage_relative_path_dependencies_to_absolute(&buildpackage, &source_dir)
-                .unwrap();
+        let new_package_descriptor =
+            rewrite_package_descriptor_relative_path_dependencies_to_absolute(
+                &package_descriptor,
+                &source_dir,
+            )
+            .unwrap();
         assert_eq!(
-            new_buildpackage.dependencies[1].uri.to_string(),
+            new_package_descriptor.dependencies[1].uri.to_string(),
             "/test/source/path/../relative/path"
         );
     }
 
     #[test]
-    fn test_rewrite_buildpackage_local_dependencies() {
-        let buildpackage = create_buildpackage();
+    fn test_rewrite_package_descriptor_local_dependencies() {
+        let package_descriptor = create_package_descriptor();
         let packaged_buildpack_dir_resolver = create_packaged_buildpack_dir_resolver(
             &PathBuf::from("/path/to/target"),
             CargoProfile::Dev,
             "arch",
         );
-        let new_buildpackage = rewrite_buildpackage_local_dependencies(
-            &buildpackage,
+        let new_package_descriptor = rewrite_package_descriptor_local_dependencies(
+            &package_descriptor,
             &packaged_buildpack_dir_resolver,
         )
         .unwrap();
         assert_eq!(
-            new_buildpackage.dependencies[0].uri.to_string(),
+            new_package_descriptor.dependencies[0].uri.to_string(),
             "/path/to/target/arch/debug/buildpack-id"
         );
     }
 
     #[test]
-    fn test_get_local_buildpackage_dependencies() {
-        let buildpackage = create_buildpackage();
+    fn test_get_local_package_descriptor_dependencies() {
+        let package_descriptor = create_package_descriptor();
         assert_eq!(
-            get_local_buildpackage_dependencies(&buildpackage).unwrap(),
+            get_local_package_descriptor_dependencies(&package_descriptor).unwrap(),
             vec![buildpack_id!("buildpack-id")]
         );
     }
 
-    fn create_buildpackage() -> Buildpackage {
-        create_buildpackage_with_dependencies(vec![
+    fn create_package_descriptor() -> PackageDescriptor {
+        create_package_descriptor_with_dependencies(vec![
             "libcnb:buildpack-id",
             "../relative/path",
             "/absolute/path",
@@ -243,15 +248,15 @@ mod tests {
         ])
     }
 
-    fn create_buildpackage_with_dependencies<S>(dependencies: Vec<S>) -> Buildpackage
+    fn create_package_descriptor_with_dependencies<S>(dependencies: Vec<S>) -> PackageDescriptor
     where
         S: Into<String>,
     {
-        Buildpackage {
-            buildpack: BuildpackageBuildpackReference::try_from(".").unwrap(),
+        PackageDescriptor {
+            buildpack: PackageDescriptorBuildpackReference::try_from(".").unwrap(),
             dependencies: dependencies
                 .into_iter()
-                .map(|v| BuildpackageDependency::try_from(v.into().as_ref()).unwrap())
+                .map(|v| PackageDescriptorDependency::try_from(v.into().as_ref()).unwrap())
                 .collect(),
             platform: Platform::default(),
         }

--- a/libcnb-package/src/buildpack_package.rs
+++ b/libcnb-package/src/buildpack_package.rs
@@ -1,8 +1,8 @@
-use crate::buildpack_dependency::get_local_buildpackage_dependencies;
+use crate::buildpack_dependency::get_local_package_descriptor_dependencies;
 use crate::dependency_graph::DependencyNode;
 use crate::{
-    read_buildpack_data, read_buildpackage_data, BuildpackData, BuildpackageData, GenericMetadata,
-    ReadBuildpackDataError, ReadBuildpackageDataError,
+    read_buildpack_data, read_package_descriptor_data, BuildpackData, GenericMetadata,
+    PackageDescriptorData, ReadBuildpackDataError, ReadPackageDescriptorDataError,
 };
 use libcnb_data::buildpack::{BuildpackId, BuildpackIdError};
 use std::path::PathBuf;
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 pub struct BuildpackPackage<T = GenericMetadata> {
     pub path: PathBuf,
     pub buildpack_data: BuildpackData<T>,
-    pub buildpackage_data: Option<BuildpackageData>,
+    pub package_descriptor_data: Option<PackageDescriptorData>,
 }
 
 impl BuildpackPackage {
@@ -32,38 +32,38 @@ impl DependencyNode<BuildpackId, BuildpackIdError> for BuildpackPackage {
     }
 
     fn dependencies(&self) -> Result<Vec<BuildpackId>, BuildpackIdError> {
-        self.buildpackage_data
+        self.package_descriptor_data
             .as_ref()
-            .map(|value| &value.buildpackage_descriptor)
-            .map_or(Ok(vec![]), get_local_buildpackage_dependencies)
+            .map(|value| &value.package_descriptor)
+            .map_or(Ok(vec![]), get_local_package_descriptor_dependencies)
     }
 }
 
-/// Reads both the buildpack and buildpackage data from a given project path.
+/// Reads both the buildpack and package descriptor data from a given project path.
 ///  
 /// # Errors
 ///
-/// Will return an `Err` if either the buildpack or buildpackage data could not be read.
+/// Will return an `Err` if either the buildpack or package descriptor data could not be read.
 pub fn read_buildpack_package<P: Into<PathBuf>>(
     project_path: P,
 ) -> Result<BuildpackPackage, ReadBuildpackPackageError> {
     let path = project_path.into();
     let buildpack_data =
         read_buildpack_data(&path).map_err(ReadBuildpackPackageError::ReadBuildpackDataError)?;
-    let buildpackage_data = read_buildpackage_data(&path)
-        .map_err(ReadBuildpackPackageError::ReadBuildpackageDataError)?;
+    let package_descriptor_data = read_package_descriptor_data(&path)
+        .map_err(ReadBuildpackPackageError::ReadPackageDescriptorDataError)?;
     Ok(BuildpackPackage {
         path,
         buildpack_data,
-        buildpackage_data,
+        package_descriptor_data,
     })
 }
 
 /// An error from [`read_buildpack_package`]
 #[derive(thiserror::Error, Debug)]
 pub enum ReadBuildpackPackageError {
-    #[error("Failed to read buildpack data: {0}")]
+    #[error("Failed to read package descriptor data: {0}")]
     ReadBuildpackDataError(#[source] ReadBuildpackDataError),
-    #[error("Failed to read buildpackage data: {0}")]
-    ReadBuildpackageDataError(#[source] ReadBuildpackageDataError),
+    #[error("Failed to read package descriptor data: {0}")]
+    ReadPackageDescriptorDataError(#[source] ReadPackageDescriptorDataError),
 }

--- a/libcnb-package/src/lib.rs
+++ b/libcnb-package/src/lib.rs
@@ -14,7 +14,7 @@ pub mod output;
 
 use crate::build::BuildpackBinaries;
 use libcnb_data::buildpack::{BuildpackDescriptor, BuildpackId};
-use libcnb_data::buildpackage::Buildpackage;
+use libcnb_data::buildpackage::PackageDescriptor;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -73,54 +73,57 @@ pub enum ReadBuildpackDataError {
     ParsingBuildpack(PathBuf, #[source] toml::de::Error),
 }
 
-/// A parsed buildpackage descriptor and it's path.
+/// A parsed package descriptor and it's path.
 #[derive(Debug, Clone)]
-pub struct BuildpackageData {
-    pub buildpackage_descriptor_path: PathBuf,
-    pub buildpackage_descriptor: Buildpackage,
+pub struct PackageDescriptorData {
+    pub package_descriptor_path: PathBuf,
+    pub package_descriptor: PackageDescriptor,
 }
 
-/// Reads buildpackage data from the given project path.
+/// Reads package descriptor data from the given project path.
 ///
 /// # Errors
 ///
-/// Will return `Err` if the buildpackage data could not be read successfully.
-pub fn read_buildpackage_data(
+/// Will return `Err` if the package descriptor data could not be read successfully.
+pub fn read_package_descriptor_data(
     project_path: impl AsRef<Path>,
-) -> Result<Option<BuildpackageData>, ReadBuildpackageDataError> {
-    let buildpackage_descriptor_path = project_path.as_ref().join("package.toml");
+) -> Result<Option<PackageDescriptorData>, ReadPackageDescriptorDataError> {
+    let package_descriptor_path = project_path.as_ref().join("package.toml");
 
-    if !buildpackage_descriptor_path.exists() {
+    if !package_descriptor_path.exists() {
         return Ok(None);
     }
 
-    fs::read_to_string(&buildpackage_descriptor_path)
+    fs::read_to_string(&package_descriptor_path)
         .map_err(|e| {
-            ReadBuildpackageDataError::ReadingBuildpackage(buildpackage_descriptor_path.clone(), e)
+            ReadPackageDescriptorDataError::ReadingPackageDescriptor(
+                package_descriptor_path.clone(),
+                e,
+            )
         })
         .and_then(|file_contents| {
             toml::from_str(&file_contents).map_err(|e| {
-                ReadBuildpackageDataError::ParsingBuildpackage(
-                    buildpackage_descriptor_path.clone(),
+                ReadPackageDescriptorDataError::ParsingPackageDescriptor(
+                    package_descriptor_path.clone(),
                     e,
                 )
             })
         })
-        .map(|buildpackage_descriptor| {
-            Some(BuildpackageData {
-                buildpackage_descriptor_path,
-                buildpackage_descriptor,
+        .map(|package_descriptor| {
+            Some(PackageDescriptorData {
+                package_descriptor_path,
+                package_descriptor,
             })
         })
 }
 
-/// An error from [`read_buildpackage_data`]
+/// An error from [`read_package_descriptor_data`]
 #[derive(thiserror::Error, Debug)]
-pub enum ReadBuildpackageDataError {
-    #[error("Failed to read buildpackage data from {0}: {1}")]
-    ReadingBuildpackage(PathBuf, #[source] std::io::Error),
-    #[error("Failed to parse buildpackage data from {0}: {1}")]
-    ParsingBuildpackage(PathBuf, #[source] toml::de::Error),
+pub enum ReadPackageDescriptorDataError {
+    #[error("Failed to read package descriptor data from {0}: {1}")]
+    ReadingPackageDescriptor(PathBuf, #[source] std::io::Error),
+    #[error("Failed to parse package descriptor data from {0}: {1}")]
+    ParsingPackageDescriptor(PathBuf, #[source] toml::de::Error),
 }
 
 /// Creates a buildpack directory and copies all buildpack assets to it.

--- a/libcnb-package/src/lib.rs
+++ b/libcnb-package/src/lib.rs
@@ -14,7 +14,7 @@ pub mod output;
 
 use crate::build::BuildpackBinaries;
 use libcnb_data::buildpack::{BuildpackDescriptor, BuildpackId};
-use libcnb_data::buildpackage::PackageDescriptor;
+use libcnb_data::package_descriptor::PackageDescriptor;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;


### PR DESCRIPTION
While https://buildpacks.io refers to `package.toml` as a "buildpackage" once, it is usually referred to as `package.toml` which is what we also use in our day-to-day conversations. I think `Buildpackage` is a poor name to use within libcnb for the following reasons:

- It starts with "buildpack", so it turns up in searches for "buildpack".
- We also currently have `BuildpackPackage`, it's very easy to confuse the two.
- The name in general is quite similar to other names we have since it starts with "build".

I wanted to avoid renaming it to `PackageToml`. Even though it might be the first thing that comes to mind as better name, I don't think its a good one. The `Toml` suffix would imply it is TOML data which is not the case for the parsed representation. It can be created via code and never be (de)serialized from or to TOML and the serialised representation is irrelevant when we work with the data in code. We have a similar situation with `buildpack.toml` which we named `BuildpackDescriptor` for similar reasons.

Thus, I went with `PackageDescriptor` to align with `BuildpackDescriptor`. I think readability of the code already improved after this rename.

I have other changes in mind with regard to `PackageDescriptor` that should simplify the code a bunch, but these are out of scope for this PR. This is strictly just a rename.

Ref: GUS-W-14007685