### PR TITLE
Implement `Ord`, `PartialOrd` for newtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `libcnb-package`:
   - Added the `output::create_packaged_buildpack_dir_resolver` helper which contains all the information on how compiled buildpack directories are structured returns a function that can be invoked with `BuildpackId` to produce the output path for a buildpack. ([#632](https://github.com/heroku/libcnb.rs/pull/632))
   - `std::fmt::Display` and `std::error::Error` implementations for all error values. ([#652](https://github.com/heroku/libcnb.rs/pull/652))
+- `libcnb-data`:
+  - `ExecDProgramOutputKey`, `ProcessType`, `LayerName`, `BuildpackId` and `StackId` now implement `Ord` and `PartialOrd`. ([#658](https://github.com/heroku/libcnb.rs/pull/658))
 
 ### Changed
 

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -6,7 +6,9 @@
 /// - [`Display`](std::fmt::Display)
 /// - [`Eq`]
 /// - [`Hash`]
+/// - [`Ord`]
 /// - [`PartialEq`]
+/// - [`PartialOrd`]
 /// - [`serde::Deserialize`]
 /// - [`serde::Serialize`]
 /// - [`FromStr`](std::str::FromStr)
@@ -134,6 +136,18 @@ macro_rules! libcnb_newtype {
             }
         }
 
+        impl ::std::cmp::Ord for $name {
+           fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
+                self.0.cmp(&other.0)
+            }
+        }
+
+        impl ::std::cmp::PartialOrd for $name {
+           fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
+                Some(self.cmp(&other))
+            }
+        }
+
         impl $name {
             /// Construct an instance of this type without performing validation.
             ///
@@ -230,6 +244,25 @@ mod tests {
     fn join() {
         let names = vec![capitalized_name!("A"), capitalized_name!("B")];
         assert_eq!("A, B", names.join(", "));
+    }
+
+    #[test]
+    fn ord() {
+        let mut names = vec![
+            capitalized_name!("A"),
+            capitalized_name!("C"),
+            capitalized_name!("B"),
+        ];
+        names.sort();
+
+        assert_eq!(
+            vec![
+                capitalized_name!("A"),
+                capitalized_name!("B"),
+                capitalized_name!("C")
+            ],
+            names
+        );
     }
 
     #[test]


### PR DESCRIPTION
Broken out from #657 where we use `BuildpackId` as a key for a `BTreeMap`.

Ref: GUS-W-14026630