### PR TITLE
Switch back to the example alpine builder in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,5 @@ jobs:
         run: cargo run --package libcnb-cargo -- libcnb package
         working-directory: ./examples/basics
       - name: Pack build using examples/basics
-        # TODO: This test previously used a non-libc builder to validate the static musl cross-compilation.
-        # This image used the experimental image extensions feature which has to be explicitly enabled and doesn't
-        # work with `--trust-builder`. To unblock CI, the builder has been changed to `heroku/builder:22`. As soon as
-        # we can, we should use a non-libc builder again.
-        run: pack build example-basics --force-color --builder heroku/builder:22 --trust-builder --trust-extra-buildpacks --buildpack packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_basics --path examples/
+        # Uses a non-libc image to validate the static musl cross-compilation.
+        run: pack build example-basics --force-color --builder cnbs/sample-builder:alpine --trust-builder --trust-extra-buildpacks --buildpack packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_basics --path examples/


### PR DESCRIPTION
In CI a `pack build` is performed using one of libcnb's example CNBs and the upstream `cnb/sample-builder:alpine` builder, in order to test that our static MUSL compile works with non-libc base images.

However, in #594 the version of that builder had to be pinned to an older release, to work around a temporary incompatibility between the latest version of the builder and the latest stable Pack CLI:
https://github.com/buildpacks/samples/issues/170

In addition, in #775 the image was switched to our builder image since the example images didn't use a CNB lifecycle that was compatible with Buildpack API 0.13.

Both issues have since been resolved, so we can switch back to the latest version of the upstream example alpine builder, giving us musl coverage again.

GUS-W-14086879.
