### PR TITLE
Ignore file support when finding buildpacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `libcnb-cargo`:
   - No longer outputs paths for non-libcnb.rs and non-meta buildpacks. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
   - Build output for humans changed slightly, output intended for machines/scripting didn't change. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
-- `libcnb-package`
-  - dropped `ignore` argument from `find_buildpack_dirs` that allowed for paths to be filtered out of the directory traversal. This function will now respect standard ignore files (like `.gitignore`) while traversing. 
+  - When performing buildpack detection, standard ignore files (`.ignore` and `.gitignore`) will be respected 
 
 ## [0.14.0] - 2023-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `libcnb-cargo`:
   - No longer outputs paths for non-libcnb.rs and non-meta buildpacks. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
   - Build output for humans changed slightly, output intended for machines/scripting didn't change. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
+- `libcnb-package`
+  - dropped `ignore` argument from `find_buildpack_dirs` that allowed for paths to be filtered out of the directory traversal. This function will now respect standard ignore files (like `.gitignore`) while traversing. 
 
 ## [0.14.0] - 2023-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `libcnb-cargo`:
   - No longer outputs paths for non-libcnb.rs and non-meta buildpacks. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
   - Build output for humans changed slightly, output intended for machines/scripting didn't change. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
-  - When performing buildpack detection, standard ignore files (`.ignore` and `.gitignore`) will be respected 
+  - When performing buildpack detection, standard ignore files (`.ignore` and `.gitignore`) will be respected. ([#673](https://github.com/heroku/libcnb.rs/pull/673))
 
 ## [0.14.0] - 2023-08-18
 

--- a/libcnb-cargo/src/package/command.rs
+++ b/libcnb-cargo/src/package/command.rs
@@ -61,9 +61,8 @@ pub(crate) fn execute(args: &PackageArgs) -> Result<(), Error> {
     };
 
     eprintln!("🏗️ Building buildpack dependency graph...");
-    let buildpack_dependency_graph =
-        build_libcnb_buildpacks_dependency_graph(&workspace_root_path, &[&package_dir])
-            .map_err(Error::CannotBuildBuildpackDependencyGraph)?;
+    let buildpack_dependency_graph = build_libcnb_buildpacks_dependency_graph(&workspace_root_path)
+        .map_err(Error::CannotBuildBuildpackDependencyGraph)?;
 
     eprintln!("🔀 Determining build order...");
     let root_nodes = buildpack_dependency_graph

--- a/libcnb-cargo/tests/integration_test.rs
+++ b/libcnb-cargo/tests/integration_test.rs
@@ -224,7 +224,8 @@ fn package_command_error_when_run_in_project_with_no_buildpacks() {
 fn package_command_respects_ignore_files() {
     let fixture_dir = copy_fixture_to_temp_dir("multiple_buildpacks").unwrap();
 
-    // when a git folder is not present, .ignore should be used
+    // The `ignore` crate supports `.ignore` files. So this first `cargo libcnb package` execution
+    // just sanity checks that our ignore rules will be respected.
     let ignore_file = fixture_dir.path().join(".ignore");
     fs::write(&ignore_file, "meta-buildpacks\nbuildpacks\n").unwrap();
 
@@ -242,7 +243,12 @@ fn package_command_respects_ignore_files() {
 
     fs::remove_file(ignore_file).unwrap();
 
-    // when a git folder is not present, .gitignore can be used
+    // The `ignore` crate supports `.gitignore` files but only if the folder is within a git repository
+    // which is the default configuration used in our directory traversal.
+    // https://docs.rs/ignore/latest/ignore/struct.WalkBuilder.html#method.require_git
+    //
+    // So this second `cargo libcnb package` execution just sanity checks that our gitignore rules
+    // in a git repository will be respected.
     fs::create_dir(fixture_dir.path().join(".git")).unwrap();
     let ignore_file = fixture_dir.path().join(".gitignore");
     fs::write(ignore_file, "meta-buildpacks\nbuildpacks\n").unwrap();

--- a/libcnb-cargo/tests/integration_test.rs
+++ b/libcnb-cargo/tests/integration_test.rs
@@ -234,7 +234,7 @@ fn package_command_respects_ignore_files() {
         .output()
         .unwrap();
 
-    //assert_ne!(output.status.code(), Some(0));
+    assert_ne!(output.status.code(), Some(0));
     assert_eq!(
         String::from_utf8_lossy(&output.stderr),
         "🚚 Preparing package directory...\n🖥\u{fe0f} Gathering Cargo configuration (for x86_64-unknown-linux-musl)\n🏗\u{fe0f} Building buildpack dependency graph...\n🔀 Determining build order...\n❌ No buildpacks found!\n"
@@ -253,7 +253,7 @@ fn package_command_respects_ignore_files() {
         .output()
         .unwrap();
 
-    //assert_ne!(output.status.code(), Some(0));
+    assert_ne!(output.status.code(), Some(0));
     assert_eq!(
         String::from_utf8_lossy(&output.stderr),
         "🚚 Preparing package directory...\n🖥\u{fe0f} Gathering Cargo configuration (for x86_64-unknown-linux-musl)\n🏗\u{fe0f} Building buildpack dependency graph...\n🔀 Determining build order...\n❌ No buildpacks found!\n"

--- a/libcnb-package/Cargo.toml
+++ b/libcnb-package/Cargo.toml
@@ -13,6 +13,7 @@ include = ["src/**/*", "LICENSE", "README.md"]
 
 [dependencies]
 cargo_metadata = "0.17.0"
+ignore = "0.4"
 libcnb-common.workspace = true
 libcnb-data.workspace = true
 petgraph = { version = "0.6.3", default-features = false }

--- a/libcnb-package/src/buildpack_dependency_graph.rs
+++ b/libcnb-package/src/buildpack_dependency_graph.rs
@@ -84,7 +84,7 @@ fn build_libcnb_buildpack_dependency_graph_node(
 
 #[derive(thiserror::Error, Debug)]
 pub enum BuildBuildpackDependencyGraphError {
-    #[error("IO error while finding buildpack directories: {0}")]
+    #[error("Error while finding buildpack directories: {0}")]
     FindBuildpackDirectories(ignore::Error),
     #[error("Cannot read buildpack descriptor: {0}")]
     ReadBuildpackDescriptorError(TomlFileError),

--- a/libcnb-package/src/buildpack_dependency_graph.rs
+++ b/libcnb-package/src/buildpack_dependency_graph.rs
@@ -27,9 +27,8 @@ use std::path::{Path, PathBuf};
 /// package.toml or an IO error occurred while traversing the given directory.
 pub fn build_libcnb_buildpacks_dependency_graph(
     cargo_workspace_root: &Path,
-    ignore: &[&Path],
 ) -> Result<Graph<BuildpackDependencyGraphNode, ()>, BuildBuildpackDependencyGraphError> {
-    find_buildpack_dirs(cargo_workspace_root, ignore)
+    find_buildpack_dirs(cargo_workspace_root)
         .map_err(BuildBuildpackDependencyGraphError::FindBuildpackDirectories)
         .and_then(|buildpack_directories| {
             buildpack_directories
@@ -86,7 +85,7 @@ fn build_libcnb_buildpack_dependency_graph_node(
 #[derive(thiserror::Error, Debug)]
 pub enum BuildBuildpackDependencyGraphError {
     #[error("IO error while finding buildpack directories: {0}")]
-    FindBuildpackDirectories(std::io::Error),
+    FindBuildpackDirectories(ignore::Error),
     #[error("Cannot read buildpack descriptor: {0}")]
     ReadBuildpackDescriptorError(TomlFileError),
     #[error("Cannot read package descriptor: {0}")]


### PR DESCRIPTION
Previously we could rely on knowing that packaged buildpacks would be written to a location within the `target` directory configured in Crate. This was easy to determine through program code and could be supplied to `find_buildpack_dirs` so that packaged buildpacks weren't accidentally included when searching for buildpacks.

With the changes introduced in [#583](https://github.com/heroku/libcnb.rs/pull/583) it is no longer possible to easily determine the output location for packaged buildpacks. This PR adds the [ignore](https://crates.io/crates/ignore) crate to provide directory iteration that respects standard ignore files. This will give the user the ability to configure where we search within a project for buildpacks.

Related to #666 