### PR TITLE
Apply rustfmt to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,14 @@ impl Buildpack for HelloWorldBuildpack {
 
         BuildResultBuilder::new()
             .launch(
-                LaunchBuilder::new().process(
-                    ProcessBuilder::new(process_type!("web"), ["echo"])
-                        .arg("Hello World!")
-                        .default(true)
-                        .build(),
-                )
-                .build(),
+                LaunchBuilder::new()
+                    .process(
+                        ProcessBuilder::new(process_type!("web"), ["echo"])
+                            .arg("Hello World!")
+                            .default(true)
+                            .build(),
+                    )
+                    .build(),
             )
             .build()
     }


### PR DESCRIPTION
Since as-is, pasting it into an IDE with format on save enabled cause the wrapping to change on first save.

GUS-W-14121433.