### PR TITLE
Remove unnecessary usages of the `vec!` macro

### DIFF
--- a/examples/ruby-sample/src/main.rs
+++ b/examples/ruby-sample/src/main.rs
@@ -51,13 +51,13 @@ impl Buildpack for RubyBuildpack {
                 LaunchBuilder::new()
                     .process(
                         ProcessBuilder::new(process_type!("web"), ["bundle"])
-                            .args(vec!["exec", "ruby", "app.rb"])
+                            .args(["exec", "ruby", "app.rb"])
                             .default(true)
                             .build(),
                     )
                     .process(
                         ProcessBuilder::new(process_type!("worker"), ["bundle"])
-                            .args(vec!["exec", "ruby", "worker.rb"])
+                            .args(["exec", "ruby", "worker.rb"])
                             .build(),
                     )
                     .build(),

--- a/examples/ruby-sample/tests/integration_test.rs
+++ b/examples/ruby-sample/tests/integration_test.rs
@@ -80,7 +80,7 @@ where
 
     stream.write_all(format!("{}\n", payload.as_ref()).as_bytes())?;
 
-    let mut buffer = vec![];
+    let mut buffer = Vec::new();
     stream.read_to_end(&mut buffer)?;
 
     Ok(String::from_utf8_lossy(&buffer).to_string())

--- a/libcnb-cargo/src/package/command.rs
+++ b/libcnb-cargo/src/package/command.rs
@@ -40,7 +40,7 @@ pub(crate) fn execute(args: &PackageArgs) -> Result<(), Error> {
 
     eprintln!("🖥️ Gathering Cargo configuration (for {})", args.target);
     let cargo_build_env = if args.no_cross_compile_assistance {
-        vec![]
+        Vec::new()
     } else {
         match cross_compile_assistance(&args.target) {
             CrossCompileAssistance::Configuration { cargo_env } => cargo_env,
@@ -51,7 +51,7 @@ pub(crate) fn execute(args: &PackageArgs) -> Result<(), Error> {
                 );
                 eprintln!("This is not an error, but without proper cross-compile settings in your Cargo manifest and locally installed toolchains, compilation might fail.");
                 eprintln!("To disable this warning, pass --no-cross-compile-assistance.");
-                vec![]
+                Vec::new()
             }
             CrossCompileAssistance::HelpText(help_text) => {
                 eprintln!("{help_text}");

--- a/libcnb-data/src/build_plan.rs
+++ b/libcnb-data/src/build_plan.rs
@@ -46,8 +46,8 @@ impl BuildPlanBuilder {
     pub fn or(mut self) -> Self {
         self.acc
             .push_back((self.current_provides, self.current_requires));
-        self.current_provides = vec![];
-        self.current_requires = vec![];
+        self.current_provides = Vec::new();
+        self.current_requires = Vec::new();
 
         self
     }

--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -107,7 +107,7 @@ impl<BM> BuildpackDescriptor<BM> {
 /// let buildpack_descriptor =
 ///     toml::from_str::<SingleBuildpackDescriptor>(toml_str).unwrap();
 /// assert_eq!(buildpack_descriptor.buildpack.id, buildpack_id!("foo/bar"));
-/// assert_eq!(buildpack_descriptor.stacks, vec![Stack::Any]);
+/// assert_eq!(buildpack_descriptor.stacks, [Stack::Any]);
 /// ```
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -290,11 +290,11 @@ checksum = "abc123"
         );
         assert_eq!(
             buildpack_descriptor.buildpack.keywords,
-            vec![String::from("foo"), String::from("bar")]
+            [String::from("foo"), String::from("bar")]
         );
         assert_eq!(
             buildpack_descriptor.buildpack.licenses,
-            vec![
+            [
                 License {
                     r#type: Some(String::from("BSD-3-Clause")),
                     uri: None
@@ -319,7 +319,7 @@ checksum = "abc123"
         );
         assert_eq!(
             buildpack_descriptor.stacks,
-            vec![
+            [
                 Stack::Specific {
                     // Cannot use the `stack_id!` macro due to: https://github.com/heroku/libcnb.rs/issues/179
                     id: "heroku-20".parse().unwrap(),
@@ -410,11 +410,11 @@ checksum = "abc123"
         );
         assert_eq!(
             buildpack_descriptor.buildpack.keywords,
-            vec![String::from("foo"), String::from("bar")]
+            [String::from("foo"), String::from("bar")]
         );
         assert_eq!(
             buildpack_descriptor.buildpack.licenses,
-            vec![
+            [
                 License {
                     r#type: Some(String::from("BSD-3-Clause")),
                     uri: None
@@ -431,7 +431,7 @@ checksum = "abc123"
         );
         assert_eq!(
             buildpack_descriptor.order,
-            vec![Order {
+            [Order {
                 group: vec![
                     Group {
                         id: "foo/bar".parse().unwrap(),
@@ -489,7 +489,7 @@ id = "*"
         );
         assert_eq!(buildpack_descriptor.buildpack.licenses, Vec::new());
         assert_eq!(buildpack_descriptor.buildpack.sbom_formats, HashSet::new());
-        assert_eq!(buildpack_descriptor.stacks, vec![Stack::Any]);
+        assert_eq!(buildpack_descriptor.stacks, [Stack::Any]);
         assert_eq!(buildpack_descriptor.metadata, None);
     }
 
@@ -534,7 +534,7 @@ version = "0.0.1"
         assert_eq!(buildpack_descriptor.buildpack.licenses, Vec::new());
         assert_eq!(
             buildpack_descriptor.order,
-            vec![Order {
+            [Order {
                 group: vec![Group {
                     id: "foo/bar".parse().unwrap(),
                     version: BuildpackVersion::new(0, 0, 1),

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -24,7 +24,7 @@ pub struct Launch {
 /// let launch_toml = LaunchBuilder::new()
 ///     .process(
 ///         ProcessBuilder::new(process_type!("web"), ["bundle"])
-///             .args(vec!["exec", "ruby", "app.rb"])
+///             .args(["exec", "ruby", "app.rb"])
 ///             .build(),
 ///     )
 ///     .build();
@@ -318,7 +318,7 @@ mod tests {
     fn launch_builder_add_processes() {
         let launch = LaunchBuilder::new()
             .process(ProcessBuilder::new(process_type!("web"), ["web_command"]).build())
-            .processes(vec![
+            .processes([
                 ProcessBuilder::new(process_type!("another"), ["another_command"]).build(),
                 ProcessBuilder::new(process_type!("worker"), ["worker_command"]).build(),
             ])
@@ -326,7 +326,7 @@ mod tests {
 
         assert_eq!(
             launch.processes,
-            vec![
+            [
                 ProcessBuilder::new(process_type!("web"), ["web_command"]).build(),
                 ProcessBuilder::new(process_type!("another"), ["another_command"]).build(),
                 ProcessBuilder::new(process_type!("worker"), ["worker_command"]).build(),
@@ -372,7 +372,7 @@ command = ["foo"]
             Ok(Process {
                 r#type: process_type!("web"),
                 command: vec![String::from("foo")],
-                args: vec![],
+                args: Vec::new(),
                 default: false,
                 working_directory: WorkingDirectory::App
             })
@@ -419,7 +419,7 @@ working-directory = "dist"
             Process {
                 r#type: process_type!("web"),
                 command: vec![String::from("java")],
-                args: vec![],
+                args: Vec::new(),
                 default: false,
                 working_directory: WorkingDirectory::App
             }
@@ -432,7 +432,7 @@ working-directory = "dist"
             Process {
                 r#type: process_type!("web"),
                 command: vec![String::from("java")],
-                args: vec![],
+                args: Vec::new(),
                 default: true,
                 working_directory: WorkingDirectory::App
             }
@@ -445,7 +445,7 @@ working-directory = "dist"
             Process {
                 r#type: process_type!("web"),
                 command: vec![String::from("java")],
-                args: vec![],
+                args: Vec::new(),
                 default: true,
                 working_directory: WorkingDirectory::Directory(PathBuf::from("dist"))
             }
@@ -457,7 +457,7 @@ working-directory = "dist"
         assert_eq!(
             ProcessBuilder::new(process_type!("web"), ["java"])
                 .arg("foo")
-                .args(vec!["baz", "eggs"])
+                .args(["baz", "eggs"])
                 .arg("bar")
                 .build(),
             Process {

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -242,13 +242,13 @@ mod tests {
 
     #[test]
     fn join() {
-        let names = vec![capitalized_name!("A"), capitalized_name!("B")];
+        let names = [capitalized_name!("A"), capitalized_name!("B")];
         assert_eq!("A, B", names.join(", "));
     }
 
     #[test]
     fn ord() {
-        let mut names = vec![
+        let mut names = [
             capitalized_name!("A"),
             capitalized_name!("C"),
             capitalized_name!("B"),
@@ -256,7 +256,7 @@ mod tests {
         names.sort();
 
         assert_eq!(
-            vec![
+            [
                 capitalized_name!("A"),
                 capitalized_name!("B"),
                 capitalized_name!("C")

--- a/libcnb-data/src/package_descriptor.rs
+++ b/libcnb-data/src/package_descriptor.rs
@@ -51,7 +51,7 @@ impl Default for PackageDescriptor {
         PackageDescriptor {
             buildpack: PackageDescriptorBuildpackReference::try_from(".")
                 .expect("a package.toml with buildpack.uri=\".\" should be valid"),
-            dependencies: vec![],
+            dependencies: Vec::new(),
             platform: Platform::default(),
         }
     }
@@ -218,7 +218,7 @@ os = "windows"
         assert_eq!(package_descriptor.platform.os, Windows);
         assert_eq!(
             package_descriptor.dependencies,
-            vec![
+            [
                 PackageDescriptorDependency::try_from("libcnb:buildpack-id").unwrap(),
                 PackageDescriptorDependency::try_from("../relative/path").unwrap(),
                 PackageDescriptorDependency::try_from("/absolute/path").unwrap(),

--- a/libcnb-package/src/buildpack_dependency_graph.rs
+++ b/libcnb-package/src/buildpack_dependency_graph.rs
@@ -72,7 +72,7 @@ fn build_libcnb_buildpack_dependency_graph_node(
                         )
                     })
             })
-            .unwrap_or(Ok(vec![]))
+            .unwrap_or(Ok(Vec::new()))
     }?;
 
     Ok(BuildpackDependencyGraphNode {

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -48,7 +48,9 @@ https://github.com/messense/homebrew-macos-cross-toolchains"#,
             })
     } else if target_triple.as_ref() == X86_64_UNKNOWN_LINUX_MUSL && cfg!(target_os = "linux") {
         match which("musl-gcc") {
-            Ok(_) => CrossCompileAssistance::Configuration { cargo_env: vec![] },
+            Ok(_) => CrossCompileAssistance::Configuration {
+                cargo_env: Vec::new(),
+            },
             Err(_) => CrossCompileAssistance::HelpText(String::from(
                 r#"For cross-compilation from Linux to x86_64-unknown-linux-musl, a C compiler and
 linker for the target platform must be installed on your computer.

--- a/libcnb-package/src/dependency_graph.rs
+++ b/libcnb-package/src/dependency_graph.rs
@@ -83,7 +83,7 @@ where
     T: DependencyNode<I, E>,
     I: PartialEq,
 {
-    let mut order: Vec<&T> = vec![];
+    let mut order: Vec<&T> = Vec::new();
     let mut dfs = DfsPostOrder::empty(&graph);
     for root_node in root_nodes {
         let idx = graph
@@ -128,8 +128,8 @@ mod tests {
 
     #[test]
     fn test_get_dependencies_one_level_deep() {
-        let a = ("a", vec![]);
-        let b = ("b", vec![]);
+        let a = ("a", Vec::new());
+        let b = ("b", Vec::new());
         let c = ("c", vec!["a", "b"]);
 
         let graph = create_dependency_graph(vec![a.clone(), b.clone(), c.clone()]).unwrap();
@@ -148,7 +148,7 @@ mod tests {
 
     #[test]
     fn test_get_dependencies_two_levels_deep() {
-        let a = ("a", vec![]);
+        let a = ("a", Vec::new());
         let b = ("b", vec!["a"]);
         let c = ("c", vec!["b"]);
 
@@ -169,9 +169,9 @@ mod tests {
     #[test]
     #[allow(clippy::many_single_char_names)]
     fn test_get_dependencies_with_overlap() {
-        let a = ("a", vec![]);
-        let b = ("b", vec![]);
-        let c = ("c", vec![]);
+        let a = ("a", Vec::new());
+        let b = ("b", Vec::new());
+        let c = ("c", Vec::new());
         let d = ("d", vec!["a", "b"]);
         let e = ("e", vec!["b", "c"]);
 

--- a/libcnb-test/README.md
+++ b/libcnb-test/README.md
@@ -197,7 +197,7 @@ use libcnb_test::{BuildConfig, BuildpackReference, TestRunner};
 // #[test]
 fn additional_buildpacks() {
     TestRunner::default().build(
-        BuildConfig::new("heroku/builder:22", "test-fixtures/app").buildpacks(vec![
+        BuildConfig::new("heroku/builder:22", "test-fixtures/app").buildpacks([
             BuildpackReference::CurrentCrate,
             BuildpackReference::WorkspaceBuildpack(buildpack_id!("my-project/buildpack")),
             BuildpackReference::Other(String::from("heroku/another-buildpack")),

--- a/libcnb-test/src/build_config.rs
+++ b/libcnb-test/src/build_config.rs
@@ -59,7 +59,7 @@ impl BuildConfig {
     /// use libcnb_test::{BuildConfig, BuildpackReference, TestRunner};
     ///
     /// TestRunner::default().build(
-    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app").buildpacks(vec![
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app").buildpacks([
     ///         BuildpackReference::CurrentCrate,
     ///         BuildpackReference::WorkspaceBuildpack(buildpack_id!("my-project/buildpack")),
     ///         BuildpackReference::Other(String::from("heroku/another-buildpack")),
@@ -149,7 +149,7 @@ impl BuildConfig {
     /// use libcnb_test::{BuildConfig, TestRunner};
     ///
     /// TestRunner::default().build(
-    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app").envs(vec![
+    ///     BuildConfig::new("heroku/builder:22", "test-fixtures/app").envs([
     ///         ("ENV_VAR_ONE", "VALUE ONE"),
     ///         ("ENV_VAR_TWO", "SOME OTHER VALUE"),
     ///     ]),

--- a/libcnb-test/src/container_config.rs
+++ b/libcnb-test/src/container_config.rs
@@ -180,7 +180,7 @@ impl ContainerConfig {
     ///     |context| {
     ///         // ...
     ///         context.start_container(
-    ///             ContainerConfig::new().envs(vec![("PORT", "5678"), ("DEBUG", "true")]),
+    ///             ContainerConfig::new().envs([("PORT", "5678"), ("DEBUG", "true")]),
     ///             |container| {
     ///                 // ...
     ///             },

--- a/libcnb-test/src/docker.rs
+++ b/libcnb-test/src/docker.rs
@@ -268,7 +268,7 @@ mod tests {
         assert_eq!(command.get_program(), "docker");
         assert_eq!(
             command.get_args().collect::<Vec<&OsStr>>(),
-            vec!["run", "--name", "my-container", "my-image"]
+            ["run", "--name", "my-container", "my-image"]
         );
 
         // With optional flag/arguments set
@@ -285,7 +285,7 @@ mod tests {
         let command: Command = docker_run_command.clone().into();
         assert_eq!(
             command.get_args().collect::<Vec<&OsStr>>(),
-            vec![
+            [
                 "run",
                 "--name",
                 "my-container",
@@ -317,7 +317,7 @@ mod tests {
         assert_eq!(command.get_program(), "docker");
         assert_eq!(
             command.get_args().collect::<Vec<&OsStr>>(),
-            vec!["exec", "my-container", "ps"]
+            ["exec", "my-container", "ps"]
         );
     }
 
@@ -330,7 +330,7 @@ mod tests {
         assert_eq!(command.get_program(), "docker");
         assert_eq!(
             command.get_args().collect::<Vec<&OsStr>>(),
-            vec!["logs", "my-container"]
+            ["logs", "my-container"]
         );
 
         // With optional flag/arguments set
@@ -339,7 +339,7 @@ mod tests {
         let command: Command = docker_logs_command.clone().into();
         assert_eq!(
             command.get_args().collect::<Vec<&OsStr>>(),
-            vec!["logs", "my-container", "--follow"]
+            ["logs", "my-container", "--follow"]
         );
     }
 
@@ -350,7 +350,7 @@ mod tests {
         assert_eq!(command.get_program(), "docker");
         assert_eq!(
             command.get_args().collect::<Vec<&OsStr>>(),
-            vec!["port", "my-container", "12345"]
+            ["port", "my-container", "12345"]
         );
     }
 
@@ -361,7 +361,7 @@ mod tests {
         assert_eq!(command.get_program(), "docker");
         assert_eq!(
             command.get_args().collect::<Vec<&OsStr>>(),
-            vec!["rm", "my-container", "--force"]
+            ["rm", "my-container", "--force"]
         );
     }
 
@@ -372,7 +372,7 @@ mod tests {
         assert_eq!(command.get_program(), "docker");
         assert_eq!(
             command.get_args().collect::<Vec<&OsStr>>(),
-            vec!["rmi", "my-image", "--force"]
+            ["rmi", "my-image", "--force"]
         );
     }
 }

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -192,7 +192,7 @@ mod tests {
 
         assert_eq!(
             command.get_args().collect::<Vec<&OsStr>>(),
-            vec![
+            [
                 "build",
                 "my-image",
                 "--builder",
@@ -214,7 +214,7 @@ mod tests {
             ]
         );
 
-        assert_eq!(command.get_envs().collect::<Vec<_>>(), vec![]);
+        assert_eq!(command.get_envs().collect::<Vec<_>>(), Vec::new());
 
         // Assert conditional '--trust-builder' flag works as expected:
         input.trust_builder = false;
@@ -242,10 +242,10 @@ mod tests {
 
         assert_eq!(
             command.get_args().collect::<Vec<&OsStr>>(),
-            vec!["sbom", "download", "my-image"]
+            ["sbom", "download", "my-image"]
         );
 
-        assert_eq!(command.get_envs().collect::<Vec<_>>(), vec![]);
+        assert_eq!(command.get_envs().collect::<Vec<_>>(), Vec::new());
 
         // Assert conditional '--output-dir' flag works as expected:
         input.output_dir = Some(PathBuf::from("/tmp/sboms"));
@@ -255,9 +255,9 @@ mod tests {
 
         assert_eq!(
             command.get_args().collect::<Vec<&OsStr>>(),
-            vec!["sbom", "download", "my-image", "--output-dir", "/tmp/sboms"]
+            ["sbom", "download", "my-image", "--output-dir", "/tmp/sboms"]
         );
 
-        assert_eq!(command.get_envs().collect::<Vec<_>>(), vec![]);
+        assert_eq!(command.get_envs().collect::<Vec<_>>(), Vec::new());
     }
 }

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -546,7 +546,7 @@ fn address_for_port_when_container_crashed() {
 #[ignore = "integration test"]
 fn basic_build_with_libcnb_reference_to_single_buildpack() {
     TestRunner::default().build(
-        BuildConfig::new("heroku/builder:22", "test-fixtures/empty").buildpacks(vec![
+        BuildConfig::new("heroku/builder:22", "test-fixtures/empty").buildpacks([
             BuildpackReference::WorkspaceBuildpack(buildpack_id!("libcnb-test/a")),
         ]),
         |context| {
@@ -565,7 +565,7 @@ fn basic_build_with_libcnb_reference_to_single_buildpack() {
 #[ignore = "integration test"]
 fn basic_build_with_libcnb_reference_to_meta_buildpack() {
     TestRunner::default().build(
-        BuildConfig::new("heroku/builder:22", "test-fixtures/empty").buildpacks(vec![
+        BuildConfig::new("heroku/builder:22", "test-fixtures/empty").buildpacks([
             BuildpackReference::WorkspaceBuildpack(buildpack_id!("libcnb-test/meta")),
         ]),
         |context| {

--- a/libcnb/src/layer/public_interface.rs
+++ b/libcnb/src/layer/public_interface.rs
@@ -187,7 +187,7 @@ impl<M> LayerResultBuilder<M> {
             metadata,
             env: None,
             exec_d_programs: HashMap::new(),
-            sboms: vec![],
+            sboms: Vec::new(),
         }
     }
 

--- a/libcnb/src/layer/tests.rs
+++ b/libcnb/src/layer/tests.rs
@@ -903,7 +903,9 @@ fn build_context(temp_dir: &TempDir) -> BuildContext<TestBuildpack> {
         buildpack_dir,
         stack_id: stack_id!("heroku-20"),
         platform: GenericPlatform::new(Env::new()),
-        buildpack_plan: BuildpackPlan { entries: vec![] },
+        buildpack_plan: BuildpackPlan {
+            entries: Vec::new(),
+        },
         buildpack_descriptor: SingleBuildpackDescriptor {
             api: LIBCNB_SUPPORTED_BUILDPACK_API,
             buildpack: crate::data::buildpack::Buildpack {
@@ -913,8 +915,8 @@ fn build_context(temp_dir: &TempDir) -> BuildContext<TestBuildpack> {
                 homepage: None,
                 clear_env: true,
                 description: None,
-                keywords: vec![],
-                licenses: vec![],
+                keywords: Vec::new(),
+                licenses: Vec::new(),
                 sbom_formats: HashSet::new(),
             },
             stacks: vec![Stack::Any],

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -284,7 +284,7 @@ impl LayerEnv {
         let include_path = layer_dir.as_ref().join("include");
         let pkgconfig_path = layer_dir.as_ref().join("pkgconfig");
 
-        let layer_path_specs = vec![
+        let layer_path_specs = [
             ("PATH", Scope::Build, &bin_path),
             ("LIBRARY_PATH", Scope::Build, &lib_path),
             ("LD_LIBRARY_PATH", Scope::Build, &lib_path),
@@ -822,7 +822,7 @@ mod tests {
 
     #[test]
     fn modification_behavior_order() {
-        let tests = vec![
+        let tests = [
             (
                 ModificationBehavior::Append,
                 ModificationBehavior::Default,

--- a/libcnb/src/sbom.rs
+++ b/libcnb/src/sbom.rs
@@ -45,7 +45,7 @@ impl TryFrom<cyclonedx_bom::models::bom::Bom> for Sbom {
     type Error = cyclonedx_bom::errors::JsonWriteError;
 
     fn try_from(cyclonedx_bom: cyclonedx_bom::models::bom::Bom) -> Result<Self, Self::Error> {
-        let mut data = vec![];
+        let mut data = Vec::new();
 
         cyclonedx_bom.output_as_json_v1_3(&mut data)?;
 

--- a/libherokubuildpack/src/command.rs
+++ b/libherokubuildpack/src/command.rs
@@ -86,8 +86,8 @@ impl CommandExt for process::Command {
         stdout_write: OW,
         stderr_write: EW,
     ) -> io::Result<process::Output> {
-        let mut stdout_buffer = vec![];
-        let mut stderr_buffer = vec![];
+        let mut stdout_buffer = Vec::new();
+        let mut stderr_buffer = Vec::new();
 
         self.spawn_and_write_streams(
             tee(&mut stdout_buffer, stdout_write),
@@ -151,8 +151,8 @@ mod test {
     #[test]
     #[cfg(unix)]
     fn test_spawn_and_write_streams() {
-        let mut stdout_buf = vec![];
-        let mut stderr_buf = vec![];
+        let mut stdout_buf = Vec::new();
+        let mut stderr_buf = Vec::new();
 
         Command::new("echo")
             .args(["-n", "Hello World!"])
@@ -167,8 +167,8 @@ mod test {
     #[test]
     #[cfg(unix)]
     fn test_output_and_write_streams() {
-        let mut stdout_buf = vec![];
-        let mut stderr_buf = vec![];
+        let mut stdout_buf = Vec::new();
+        let mut stderr_buf = Vec::new();
 
         let output = Command::new("echo")
             .args(["-n", "Hello World!"])

--- a/libherokubuildpack/src/toml.rs
+++ b/libherokubuildpack/src/toml.rs
@@ -131,7 +131,7 @@ mod test {
         hash_map.insert(String::from("foo"), String::from("bar"));
 
         assert_eq!(
-            toml_select_value::<&str, Vec<&str>>(vec![], &toml.into()),
+            toml_select_value::<&str, Vec<&str>>(Vec::new(), &toml.into()),
             Some(&toml::Value::from(hash_map))
         );
     }

--- a/libherokubuildpack/src/write.rs
+++ b/libherokubuildpack/src/write.rs
@@ -16,7 +16,7 @@ pub fn mapped<W: io::Write, F: (Fn(Vec<u8>) -> Vec<u8>) + Sync + Send + 'static>
     MappedWrite {
         inner: w,
         marker_byte,
-        buffer: vec![],
+        buffer: Vec::new(),
         mapping_fn: Arc::new(f),
     }
 }
@@ -122,8 +122,8 @@ mod test {
 
     #[test]
     fn test_tee_write() {
-        let mut a = vec![];
-        let mut b = vec![];
+        let mut a = Vec::new();
+        let mut b = Vec::new();
 
         let mut input = "foo bar baz".as_bytes();
         std::io::copy(&mut input, &mut tee(&mut a, &mut b)).unwrap();
@@ -134,7 +134,7 @@ mod test {
 
     #[test]
     fn test_mapped_write() {
-        let mut output = vec![];
+        let mut output = Vec::new();
 
         let mut input = "foo\nbar\nbaz".as_bytes();
         std::io::copy(


### PR DESCRIPTION
For cases where a known-at-compile-time length array is being passed to a function that accepts an `Into<Iterator>`, there is no need to wrap the array in a `vec![]` invocation.

I spotted a couple of these in one of the newly added libcnb-test tests, and a search and replace later it turns out there were quite a few more instances of this than I was expecting!

GUS-W-14160950.