### PR TITLE
Use multi-line `$GITHUB_OUTPUT` syntax for the changelog entry output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,13 @@ jobs:
 
       - name: Extract changelog entry
         id: changelog-entry
-        run: echo "content=$(awk '/^## \[${{ steps.new-version.outputs.version }}\]/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md)" >> "${GITHUB_OUTPUT}"
+        # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+        run: |
+          {
+            echo 'content<<CHANGELOG_END'
+            awk '/^## \[${{ steps.new-version.outputs.version }}\]/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md
+            echo CHANGELOG_END
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Publish to crates.io
         # cargo-release calculates the dependency graph for us, and also skips any already


### PR DESCRIPTION
The changelog entry is multi-line, so we need to use the multi-line syntax when using the `$GITHUB_OUTPUT` file.

This resolves:

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format '### Added'
```

See:
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings

GUS-W-14177169.