### PR TITLE
Switch tests from `heroku/buildpacks:20` to `heroku/builder:20`

### DIFF
--- a/examples/ruby-sample/tests/integration_test.rs
+++ b/examples/ruby-sample/tests/integration_test.rs
@@ -19,7 +19,7 @@ use std::{fs, io};
 #[test]
 #[ignore = "integration test"]
 fn basic() {
-    let config = BuildConfig::new("heroku/buildpacks:20", "tests/fixtures/simple-ruby-app");
+    let config = BuildConfig::new("heroku/builder:20", "tests/fixtures/simple-ruby-app");
 
     TestRunner::default().build(&config, |context| {
         assert_contains!(context.pack_stdout, "---> Ruby Buildpack");
@@ -60,7 +60,7 @@ fn basic() {
 #[ignore = "integration test"]
 fn missing_gemfile_lock() {
     TestRunner::default().build(
-        BuildConfig::new("heroku/buildpacks:20", "tests/fixtures/simple-ruby-app")
+        BuildConfig::new("heroku/builder:20", "tests/fixtures/simple-ruby-app")
             .app_dir_preprocessor(|path| fs::remove_file(path.join("Gemfile.lock")).unwrap())
             .expected_pack_result(PackResult::Failure),
         |context| {


### PR DESCRIPTION
Since the `heroku/buildpacks:20` image is about to be deprecated, and has been replaced by the newly added `heroku/builder:20` for those that need to use a Heroku-20 based builder.

The build and run images used by `heroku/builder:20` are the same as those used by `heroku/buildpacks:20` - the only differences between the builders are the included buildpacks (which is somewhat irrelevant for these integration tests, since the buildpack under test will be injected instead).

See:
https://github.com/heroku/builder/pull/394
https://salesforce.quip.com/0JtbAYiWZYk6

GUS-W-14186015.