### PR TITLE
Add `GH_TOKEN` env to `gh` CLI invocation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
             echo "If you are sure you want to recreate the release, delete the existing one first." >&2
             exit 1
           fi
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
 
       - name: Extract changelog entry
         id: changelog-entry


### PR DESCRIPTION
`gh` does not work properly without the `GH_TOKEN` environment variable. For the double release check, we fail the check if the invocation succeeds. Since the token is missing it will never succeed, making the check a no-op. This PR adds the missing token.

Ref: https://github.com/heroku/libcnb.rs/actions/runs/6299767340/job/17101136605#step:8:13