### PR TITLE
Fix lint errors in Rust 1.73 and 1.74

### DIFF
--- a/libcnb-data/src/layer_content_metadata.rs
+++ b/libcnb-data/src/layer_content_metadata.rs
@@ -76,9 +76,9 @@ mod tests {
 
     #[test]
     fn types_table_with_no_entries_has_defaults() {
-        let toml_str = r#"
+        let toml_str = r"
         [types]
-        "#;
+        ";
         let layer = toml::from_str::<LayerContentMetadata>(toml_str).unwrap();
         assert_eq!(
             layer.types,

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -18,14 +18,14 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
             .iter()
             .find_map(|binary_name| which(binary_name).ok())
             .map_or_else(|| CrossCompileAssistance::HelpText(String::from(
-                r#"For cross-compilation from macOS to x86_64-unknown-linux-musl, a C compiler and
+                r"For cross-compilation from macOS to x86_64-unknown-linux-musl, a C compiler and
 linker for the target platform must be installed on your computer.
 
 The easiest way to install the required cross-compilation toolchain is to run:
 brew install messense/macos-cross-toolchains/x86_64-unknown-linux-musl
 
 For more information, see:
-https://github.com/messense/homebrew-macos-cross-toolchains"#,
+https://github.com/messense/homebrew-macos-cross-toolchains",
             )), |gcc_binary_path| {
                 CrossCompileAssistance::Configuration {
                     cargo_env: vec![
@@ -52,12 +52,12 @@ https://github.com/messense/homebrew-macos-cross-toolchains"#,
                 cargo_env: Vec::new(),
             },
             Err(_) => CrossCompileAssistance::HelpText(String::from(
-                r#"For cross-compilation from Linux to x86_64-unknown-linux-musl, a C compiler and
+                r"For cross-compilation from Linux to x86_64-unknown-linux-musl, a C compiler and
 linker for the target platform must be installed on your computer.
 
 The easiest way to install 'musl-gcc' is to install the 'musl-tools' package:
 - https://packages.ubuntu.com/focal/musl-tools
-- https://packages.debian.org/bullseye/musl-tools"#,
+- https://packages.debian.org/bullseye/musl-tools",
             )),
         }
     } else if target_triple.as_ref() == AARCH64_UNKNOWN_LINUX_MUSL && cfg!(target_os = "linux") {
@@ -76,13 +76,13 @@ The easiest way to install 'musl-gcc' is to install the 'musl-tools' package:
                 ],
             },
             Err(_) => CrossCompileAssistance::HelpText(String::from(
-                r#"For cross-compilation from Linux to aarch64-unknown-linux-musl, a C compiler and
+                r"For cross-compilation from Linux to aarch64-unknown-linux-musl, a C compiler and
 linker for the target platform must installed on your computer.
 
 The easiest way to install the 'g++-aarch64-linux-gnu', 'libc6-dev-arm64-cross', and 'musl-tools' packages:
 - https://packages.ubuntu.com/focal/g++-aarch64-linux-gnu
 - https://packages.ubuntu.com/focal/musl-tools
-- https://packages.ubuntu.com/focal/libc6-dev-arm64-cross"#,
+- https://packages.ubuntu.com/focal/libc6-dev-arm64-cross",
             )),
         }
     } else {

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -32,7 +32,7 @@ impl TestRunner {
     /// to build a new Docker image with the buildpacks specified by the passed [`BuildConfig`].
     ///
     /// Since this function is supposed to only be used in integration tests, failures are not
-    /// signalled via [`Result`](Result) values. Instead, this function panics whenever an unexpected error
+    /// signalled via [`Result`] values. Instead, this function panics whenever an unexpected error
     /// occurred to simplify testing code.
     ///
     /// # Example

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -42,7 +42,7 @@ pub trait Buildpack {
     /// collect and send metrics about occurring errors to a central system.
     ///
     /// The default implementation will simply print the error
-    /// (using its [`Debug`](std::fmt::Debug) implementation) to stderr.
+    /// (using its [`Debug`] implementation) to stderr.
     fn on_error(&self, error: crate::Error<Self::Error>) {
         eprintln!("Unhandled error:");
         eprintln!("> {error:?}");

--- a/libcnb/src/layer/handling.rs
+++ b/libcnb/src/layer/handling.rs
@@ -406,12 +406,12 @@ mod tests {
         fs::create_dir_all(&layer_dir).unwrap();
         fs::write(
             layers_dir.join(format!("{layer_name}.toml")),
-            r#"
+            r"
             [types]
             launch = true
             build = false
             cache = true
-            "#,
+            ",
         )
         .unwrap();
 
@@ -430,12 +430,12 @@ mod tests {
 
         fs::write(
             layers_dir.join(format!("{layer_name}.toml")),
-            r#"
+            r"
             [types]
             launch = true
             build = false
             cache = true
-            "#,
+            ",
         )
         .unwrap();
 
@@ -877,12 +877,12 @@ mod tests {
         fs::create_dir_all(layer_dir).unwrap();
         fs::write(
             layers_dir.join(format!("{layer_name}.toml")),
-            r#"
+            r"
             [types
             build = true
             launch = true
             cache = true
-            "#,
+            ",
         )
         .unwrap();
 

--- a/libcnb/src/layer/public_interface.rs
+++ b/libcnb/src/layer/public_interface.rs
@@ -21,7 +21,7 @@ pub trait Layer {
     type Buildpack: Buildpack;
 
     /// The metadata type for this layer. This is the data within `[metadata]` of the layer content
-    /// metadata. If you wish to use raw, untyped, TOML data instead, use [`GenericMetadata`](crate::generic::GenericMetadata).
+    /// metadata. If you wish to use raw, untyped, TOML data instead, use [`GenericMetadata`].
     ///
     /// If the layer metadata cannot be parsed into this type, libcnb will call [`migrate_incompatible_metadata`](Self::migrate_incompatible_metadata)
     /// with the layer's metadata as raw TOML. This allows migration of older metadata.
@@ -89,10 +89,10 @@ pub trait Layer {
     /// automatically.
     ///
     /// The return value of this method is the canonical value for metadata and environment variables.
-    /// If the returned [`LayerResult`](LayerResult) does not contain metadata or environment
+    /// If the returned [`LayerResult`] does not contain metadata or environment
     /// variables, the resulting layer will not have either. To keep the values from the cached
     /// version they must be explicitly added to the result. This can be done by reading the env
-    /// data from the given [`LayerData`](LayerData) value.
+    /// data from the given [`LayerData`] value.
     ///
     /// The default implementation will copy both the previous metadata and environment and not
     /// change the layer data itself, making the default implementation a no-op.


### PR DESCRIPTION
Fixes the following new error in Rust 1.73:

```
$ RUSTDOCFLAGS="-D warnings" cargo doc --all-features --document-private-items --no-deps
...
error: redundant explicit link target
  --> libcnb-test/src/test_runner.rs:35:34
   |
35 |     /// signalled via [`Result`](Result) values. Instead, this function panics whenever an unexpected error
   |                        --------  ^^^^^^ explicit target is redundant
   |                        |
   |                        because label contains path that resolves to same destination
   |
   = note: when a link's destination is not specified,
           the label is used to resolve intra-doc links
   = note: `-D rustdoc::redundant-explicit-links` implied by `-D warnings`
help: remove explicit link target
   |
35 |     /// signalled via [`Result`] values. Instead, this function panics whenever an unexpected error
   |                       ~~~~~~~~~~
...
```

And errors like these in Rust 1.74:

```
$ cargo clippy --all-targets
warning: unnecessary hashes around raw string literal
  --> libcnb-package/src/cross_compile.rs:21:17
   |
21 | /                 r#"For cross-compilation from macOS to x86_64-unknown-linux-musl, a C compiler and
22 | | linker for the target platform must be installed on your computer.
23 | |
24 | | The easiest way to install the required cross-compilation toolchain is to run:
...  |
27 | | For more information, see:
28 | | https://github.com/messense/homebrew-macos-cross-toolchains"#,
   | |_____________________________________________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_raw_string_hashes
```

GUS-W-14249508.