### PR TITLE
Fix typos in comments and variable names

### DIFF
--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -143,7 +143,7 @@ impl WorkingDirectory {
 
 // Custom Serialize implementation since we want to always serialize as a string. Serde's untagged
 // enum representation does not work here since App would serialize as null, but we want a default
-// string value. #[serde(rename = ".")] doesnt work here. There are more generic solutions that can
+// string value. #[serde(rename = ".")] doesn't work here. There are more generic solutions that can
 // be found on the web, but they're much more heavyweight than this simple Serialize implementation.
 impl Serialize for WorkingDirectory {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/libcnb-package/src/util.rs
+++ b/libcnb-package/src/util.rs
@@ -4,7 +4,7 @@ use std::path::{Component, Path, PathBuf};
 ///
 /// # Errors
 ///
-/// Returns `Err` if an IO error occurred during the size calucaltion.
+/// Returns `Err` if an IO error occurred during the size calculation.
 pub fn calculate_dir_size(path: impl AsRef<Path>) -> std::io::Result<u64> {
     let mut size_in_bytes = 0;
 

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -111,14 +111,14 @@ impl TestRunner {
                     pack_command.buildpack(crate_buildpack_dir);
                 }
 
-                BuildpackReference::WorkspaceBuildpack(builpack_id) => {
+                BuildpackReference::WorkspaceBuildpack(buildpack_id) => {
                     let buildpack_dir = build::package_buildpack(
-                        builpack_id,
+                        buildpack_id,
                         config.cargo_profile,
                         &config.target_triple,
                         &cargo_manifest_dir,
                         buildpacks_target_dir.path()
-                    ).unwrap_or_else(|_| panic!("Test references buildpack `{builpack_id}`, but this directory wasn't packaged as a buildpack. This is an internal libcnb-test error, please report any occurrences"));
+                    ).unwrap_or_else(|_| panic!("Test references buildpack `{buildpack_id}`, but this directory wasn't packaged as a buildpack. This is an internal libcnb-test error, please report any occurrences"));
                     pack_command.buildpack(buildpack_dir);
                 }
 


### PR DESCRIPTION
As reported by my editor spell checker.