### PR TITLE
Enable lints to prevent unwanted usages of `unwrap()`, `assert!` and `panic!`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/libcnb-cargo/src/main.rs
+++ b/libcnb-cargo/src/main.rs
@@ -1,6 +1,8 @@
 #![doc = include_str!("../README.md")]
-#![warn(clippy::pedantic)]
 #![warn(unused_crate_dependencies)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::panic_in_result_fn)]
+#![warn(clippy::unwrap_used)]
 // This lint is too noisy and enforces a style that reduces readability in many cases.
 #![allow(clippy::module_name_repetitions)]
 

--- a/libcnb-common/src/lib.rs
+++ b/libcnb-common/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc = include_str!("../README.md")]
-#![warn(clippy::pedantic)]
 #![warn(unused_crate_dependencies)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::panic_in_result_fn)]
+#![warn(clippy::unwrap_used)]
 // This lint is too noisy and enforces a style that reduces readability in many cases.
 #![allow(clippy::module_name_repetitions)]
 

--- a/libcnb-data/src/lib.rs
+++ b/libcnb-data/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc = include_str!("../README.md")]
-#![warn(clippy::pedantic)]
 #![warn(unused_crate_dependencies)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::panic_in_result_fn)]
+#![warn(clippy::unwrap_used)]
 // This lint is too noisy and enforces a style that reduces readability in many cases.
 #![allow(clippy::module_name_repetitions)]
 

--- a/libcnb-package/src/lib.rs
+++ b/libcnb-package/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc = include_str!("../README.md")]
-#![warn(clippy::pedantic)]
 #![warn(unused_crate_dependencies)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::panic_in_result_fn)]
+#![warn(clippy::unwrap_used)]
 // This lint is too noisy and enforces a style that reduces readability in many cases.
 #![allow(clippy::module_name_repetitions)]
 

--- a/libcnb-proc-macros/src/lib.rs
+++ b/libcnb-proc-macros/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc = include_str!("../README.md")]
-#![warn(clippy::pedantic)]
 #![warn(unused_crate_dependencies)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::panic_in_result_fn)]
+#![warn(clippy::unwrap_used)]
 
 use proc_macro::TokenStream;
 use quote::quote;

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -11,7 +11,10 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-/// Packages the current crate as a buildpack into a temporary directory.
+/// Packages the current crate as a buildpack into the provided directory.
+// TODO: Convert the `assert!` usages to an additional `PackageBuildpackError` variant instead:
+// https://github.com/heroku/libcnb.rs/issues/709
+#[allow(clippy::panic_in_result_fn)]
 pub(crate) fn package_crate_buildpack(
     cargo_profile: CargoProfile,
     target_triple: impl AsRef<str>,
@@ -38,6 +41,9 @@ pub(crate) fn package_crate_buildpack(
     )
 }
 
+// TODO: Convert the `assert!` usages to an additional `PackageBuildpackError` variant instead:
+// https://github.com/heroku/libcnb.rs/issues/709
+#[allow(clippy::panic_in_result_fn)]
 pub(crate) fn package_buildpack(
     buildpack_id: &BuildpackId,
     cargo_profile: CargoProfile,
@@ -87,6 +93,9 @@ pub(crate) fn package_buildpack(
     for node in &build_order {
         let buildpack_destination_dir = buildpack_dir_resolver(&node.buildpack_id);
 
+        // TODO: Convert the `unwrap()` to an additional `PackageBuildpackError` variant instead:
+        // https://github.com/heroku/libcnb.rs/issues/710
+        #[allow(clippy::unwrap_used)]
         fs::create_dir_all(&buildpack_destination_dir).unwrap();
 
         libcnb_package::package::package_buildpack(

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -2,6 +2,8 @@
 // Enable lints that are disabled by default.
 #![warn(unused_crate_dependencies)]
 #![warn(clippy::pedantic)]
+#![warn(clippy::panic_in_result_fn)]
+#![warn(clippy::unwrap_used)]
 // This lint is too noisy and enforces a style that reduces readability in many cases.
 #![allow(clippy::module_name_repetitions)]
 

--- a/libcnb/src/layer/tests.rs
+++ b/libcnb/src/layer/tests.rs
@@ -824,6 +824,7 @@ fn layer_env_read_write() {
         expected_layer_env: LayerEnv,
     }
 
+    #[allow(clippy::panic_in_result_fn)]
     impl Layer for LayerDataTestLayer {
         type Buildpack = TestBuildpack;
         type Metadata = GenericMetadata;

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc = include_str!("../README.md")]
-#![warn(clippy::pedantic)]
 #![warn(unused_crate_dependencies)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::panic_in_result_fn)]
+#![warn(clippy::unwrap_used)]
 // Most of libcnb's public API returns user-provided errors, making error docs redundant.
 #![allow(clippy::missing_errors_doc)]
 // This lint is too noisy and enforces a style that reduces readability in many cases.

--- a/libherokubuildpack/src/lib.rs
+++ b/libherokubuildpack/src/lib.rs
@@ -1,7 +1,9 @@
 #![doc = include_str!("../README.md")]
 // Enable lints that are disabled by default.
-#![warn(clippy::pedantic)]
 #![warn(unused_crate_dependencies)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::panic_in_result_fn)]
+#![warn(clippy::unwrap_used)]
 // In most cases adding error docs provides little value.
 #![allow(clippy::missing_errors_doc)]
 // This lint is too noisy and enforces a style that reduces readability in many cases.

--- a/libherokubuildpack/src/log.rs
+++ b/libherokubuildpack/src/log.rs
@@ -5,6 +5,9 @@ use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 ///
 /// Will panic if there was a problem setting the color settings, or all bytes could
 /// not be written due to either I/O errors or EOF being reached.
+// TODO: Replace `.unwrap()` usages with `.expect()` to give a clearer error message:
+// https://github.com/heroku/libcnb.rs/issues/712
+#[allow(clippy::unwrap_used)]
 pub fn log_error(header: impl AsRef<str>, body: impl AsRef<str>) {
     let mut stream = StandardStream::stderr(ColorChoice::Always);
     stream
@@ -24,6 +27,9 @@ pub fn log_error(header: impl AsRef<str>, body: impl AsRef<str>) {
 ///
 /// Will panic if there was a problem setting the color settings, or all bytes could
 /// not be written due to either I/O errors or EOF being reached.
+// TODO: Replace `.unwrap()` usages with `.expect()` to give a clearer error message:
+// https://github.com/heroku/libcnb.rs/issues/712
+#[allow(clippy::unwrap_used)]
 pub fn log_warning(header: impl AsRef<str>, body: impl AsRef<str>) {
     let mut stream = StandardStream::stderr(ColorChoice::Always);
     stream
@@ -43,6 +49,9 @@ pub fn log_warning(header: impl AsRef<str>, body: impl AsRef<str>) {
 ///
 /// Will panic if there was a problem setting the color settings, or all bytes could
 /// not be written due to either I/O errors or EOF being reached.
+// TODO: Replace `.unwrap()` usages with `.expect()` to give a clearer error message:
+// https://github.com/heroku/libcnb.rs/issues/712
+#[allow(clippy::unwrap_used)]
 pub fn log_header(title: impl AsRef<str>) {
     let mut stream = StandardStream::stdout(ColorChoice::Always);
     stream
@@ -56,6 +65,9 @@ pub fn log_header(title: impl AsRef<str>) {
 /// # Panics
 ///
 /// Will panic if all bytes could not be written due to I/O errors or EOF being reached.
+// TODO: Replace `.unwrap()` usages with `.expect()` to give a clearer error message:
+// https://github.com/heroku/libcnb.rs/issues/712
+#[allow(clippy::unwrap_used)]
 pub fn log_info(message: impl AsRef<str>) {
     println!("{}", message.as_ref());
     std::io::stdout().flush().unwrap();


### PR DESCRIPTION
The `clippy::unwrap_used` lint prevents usage of `.unwrap()` outside of tests:
https://rust-lang.github.io/rust-clippy/master/index.html#/unwrap_used

The `clippy::panic_in_result_fn` lint prevents usages of `assert!` or `panic!` in functions that already return a `Result`:
https://rust-lang.github.io/rust-clippy/master/index.html#/panic_in_result_fn

These lints catch cases like #709, #710 and #712.

The lints have not been enabled for the integration test modules (since using `unwrap()` is fine there), or to the example buildpacks, since it's a lot of boilerplate to add to an example.

Very soon we will be able to switch to the upcoming `[lints]` table feature, which will mean the duplication of lint definitions can be avoided entirely:
https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#lints

GUS-W-14413286.