### PR TITLE
Switch back to using `heroku/procfile` from the builder in tests

### DIFF
--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -17,11 +17,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use std::{env, fs, thread};
 
-// We're referencing the procfile buildpack via Docker URL to pin the version for the tests. This also
-// prevents issues when the builder contains multiple heroku/procfile versions. We don't use CNB
-// registry URLs since, as of August 2022, pack fails when another pack instance is resolving such
-// an URL in parallel.
-const PROCFILE_URL: &str = "docker://docker.io/heroku/procfile-cnb:2.0.1";
+const PROCFILE_URL: &str = "heroku/procfile";
 const TEST_PORT: u16 = 12345;
 
 #[test]


### PR DESCRIPTION
The `heroku/builder:22` builder image will now only ever contain one version of the `heroku/procfile` CNB, after:
https://github.com/heroku/buildpacks-jvm/pull/608
https://github.com/heroku/buildpacks-nodejs/pull/696

As such, we no longer need to use a manual Docker Hub URL to avoid the "multiple versions of this buildpack exist in the builder image" error, and instead can use the Procfile CNB directly from the builder image.

This does mean the version is now unpinned, however, it's unlikely to cause test failures in practice, and at least we'll be testing the version of procfile actually used in the builder image (for things like the container starting tests).