### PR TITLE
Add a link to the Buildpack API specification in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 It is an opinionated implementation adding language constructs and convenience methods for working
 with the spec. It values strong adherence to the spec and data formats.
 
-It currently targets version `0.9` of the CNB spec.
+It currently targets version `0.9` of the CNB [Buildpack API specification](https://github.com/buildpacks/spec/blob/buildpack/0.9/buildpack.md).
 
 ## Quick Start Guide
 


### PR DESCRIPTION
Since:
- it's still necessary to know about/understand the spec when using `libcnb.rs`
- the previous wording implied there was just one CNB spec with version `0.9`, when it's only the Buildpack API spec that's version `0.9` (and the platform and distribution specs have their own versions)