### PR TITLE
Add optional opentelemetry file export tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `libcnb`:
+  - An optional `trace` feature has been added that emits OpenTelemetry tracing
+    data to a [File Export](https://opentelemetry.io/docs/specs/otel/protocol/file-exporter/). ([#723](https://github.com/heroku/libcnb.rs/pull/723))
 
 ## [0.16.0] - 2023-11-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "test-buildpacks/readonly-layer-files",
     "test-buildpacks/sbom",
     "test-buildpacks/store",
+    "test-buildpacks/tracing",
 ]
 
 [workspace.package]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 allow-unwrap-in-tests = true
+doc-valid-idents = ["OpenTelemetry", ".."]

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -33,3 +33,4 @@ toml.workspace = true
 [dev-dependencies]
 fastrand = "2.0.1"
 tempfile = "3.8.1"
+serde_json = "1.0.108"

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -15,7 +15,7 @@ include = ["src/**/*", "LICENSE", "README.md"]
 workspace = true
 
 [features]
-trace = ["dep:opentelemetry", "dep:opentelemetry-stdout"]
+trace = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-stdout"]
 
 [dependencies]
 anyhow = { version = "1.0.75", optional = true }
@@ -23,8 +23,9 @@ cyclonedx-bom = { version = "0.4.3", optional = true }
 libcnb-common.workspace = true
 libcnb-data.workspace = true
 libcnb-proc-macros.workspace = true
-opentelemetry = { version = "0.20.0", optional = true }
-opentelemetry-stdout = { version = "0.1.0", optional = true, features = ["trace"] }
+opentelemetry = { version = "0.21.0", optional = true }
+opentelemetry_sdk = { version = "0.21.0", optional = true }
+opentelemetry-stdout = { version = "0.2.0", optional = true, features = ["trace"] }
 serde = { version = "1.0.192", features = ["derive"] }
 thiserror = "1.0.50"
 toml.workspace = true

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -14,12 +14,17 @@ include = ["src/**/*", "LICENSE", "README.md"]
 [lints]
 workspace = true
 
+[features]
+trace = ["dep:opentelemetry", "dep:opentelemetry-stdout"]
+
 [dependencies]
 anyhow = { version = "1.0.75", optional = true }
 cyclonedx-bom = { version = "0.4.3", optional = true }
 libcnb-common.workspace = true
 libcnb-data.workspace = true
 libcnb-proc-macros.workspace = true
+opentelemetry = { version = "0.20.0", optional = true }
+opentelemetry-stdout = { version = "0.1.0", optional = true, features = ["trace"] }
 serde = { version = "1.0.192", features = ["derive"] }
 thiserror = "1.0.50"
 toml.workspace = true

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -18,6 +18,8 @@ mod error;
 mod exit_code;
 mod platform;
 mod runtime;
+#[cfg(feature = "trace")]
+mod tracing;
 mod util;
 
 pub use buildpack::Buildpack;

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -29,6 +29,9 @@ pub use libcnb_common::toml_file::*;
 pub use platform::*;
 pub use runtime::*;
 
+#[cfg(all(test, not(feature = "trace")))]
+use serde_json as _;
+
 /// Provides types for CNB data formats. Is a re-export of the `libcnb-data` crate.
 #[doc(inline)]
 pub use libcnb_data as data;

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -158,10 +158,11 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
         }
         InnerDetectResult::Pass { build_plan } => {
             if let Some(build_plan) = build_plan {
-                write_toml_file(&build_plan, build_plan_path).map_err(|err| {
+                write_toml_file(&build_plan, build_plan_path).map_err(|inner_err| {
+                    let err = Error::CannotWriteBuildPlan(inner_err);
                     #[cfg(feature = "trace")]
                     trace.set_error(&err);
-                    Error::CannotWriteBuildPlan(err)
+                    err
                 })?;
             }
             #[cfg(feature = "trace")]

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -132,7 +132,7 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
     #[cfg(feature = "trace")]
     let mut trace = start_trace(&buildpack_descriptor.buildpack, "detect");
 
-    let mut record_trace_err = |err: &dyn std::error::Error| {
+    let mut trace_error = |err: &dyn std::error::Error| {
         #[cfg(feature = "trace")]
         trace.set_error(err);
     };
@@ -140,13 +140,13 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
         .map_err(Error::CannotDetermineStackId)
         .and_then(|stack_id_string| stack_id_string.parse().map_err(Error::StackIdError))
         .map_err(|err| {
-            record_trace_err(&err);
+            trace_error(&err);
             err
         })?;
 
     let platform = B::Platform::from_path(&args.platform_dir_path).map_err(|inner_err| {
         let err = Error::CannotCreatePlatformFromPath(inner_err);
-        record_trace_err(&err);
+        trace_error(&err);
         err
     })?;
 
@@ -161,7 +161,7 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
     };
 
     let detect_result = buildpack.detect(detect_context).map_err(|err| {
-        record_trace_err(&err);
+        trace_error(&err);
         err
     });
 
@@ -175,7 +175,7 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
             if let Some(build_plan) = build_plan {
                 write_toml_file(&build_plan, build_plan_path).map_err(|inner_err| {
                     let err = Error::CannotWriteBuildPlan(inner_err);
-                    record_trace_err(&err);
+                    trace_error(&err);
                     err
                 })?;
             }
@@ -206,7 +206,7 @@ pub fn libcnb_runtime_build<B: Buildpack>(
     #[cfg(feature = "trace")]
     let mut trace = start_trace(&buildpack_descriptor.buildpack, "build");
 
-    let mut record_trace_err = |err: &dyn std::error::Error| {
+    let mut trace_error = |err: &dyn std::error::Error| {
         #[cfg(feature = "trace")]
         trace.set_error(err);
     };
@@ -215,19 +215,19 @@ pub fn libcnb_runtime_build<B: Buildpack>(
         .map_err(Error::CannotDetermineStackId)
         .and_then(|stack_id_string| stack_id_string.parse().map_err(Error::StackIdError))
         .map_err(|err| {
-            record_trace_err(&err);
+            trace_error(&err);
             err
         })?;
 
     let platform = Platform::from_path(&args.platform_dir_path).map_err(|inner_err| {
         let err = Error::CannotCreatePlatformFromPath(inner_err);
-        record_trace_err(&err);
+        trace_error(&err);
         err
     })?;
 
     let buildpack_plan = read_toml_file(&args.buildpack_plan_path).map_err(|inner_err| {
         let err = Error::CannotReadBuildpackPlan(inner_err);
-        record_trace_err(&err);
+        trace_error(&err);
         err
     })?;
 
@@ -237,7 +237,7 @@ pub fn libcnb_runtime_build<B: Buildpack>(
     }
     .map_err(Error::CannotReadStore)
     .map_err(|err| {
-        record_trace_err(&err);
+        trace_error(&err);
         err
     })?;
 
@@ -253,7 +253,7 @@ pub fn libcnb_runtime_build<B: Buildpack>(
     };
 
     let build_result = buildpack.build(build_context).map_err(|err| {
-        record_trace_err(&err);
+        trace_error(&err);
         err
     });
 
@@ -267,7 +267,7 @@ pub fn libcnb_runtime_build<B: Buildpack>(
             if let Some(launch) = launch {
                 write_toml_file(&launch, layers_dir.join("launch.toml")).map_err(|inner_err| {
                     let err = Error::CannotWriteLaunch(inner_err);
-                    record_trace_err(&err);
+                    trace_error(&err);
                     err
                 })?;
             };
@@ -275,7 +275,7 @@ pub fn libcnb_runtime_build<B: Buildpack>(
             if let Some(store) = store {
                 write_toml_file(&store, layers_dir.join("store.toml")).map_err(|inner_err| {
                     let err = Error::CannotWriteStore(inner_err);
-                    record_trace_err(&err);
+                    trace_error(&err);
                     err
                 })?;
             };
@@ -287,7 +287,7 @@ pub fn libcnb_runtime_build<B: Buildpack>(
                 )
                 .map_err(Error::CannotWriteBuildSbom)
                 .map_err(|err| {
-                    record_trace_err(&err);
+                    trace_error(&err);
                     err
                 })?;
             }
@@ -299,7 +299,7 @@ pub fn libcnb_runtime_build<B: Buildpack>(
                 )
                 .map_err(Error::CannotWriteLaunchSbom)
                 .map_err(|err| {
-                    record_trace_err(&err);
+                    trace_error(&err);
                     err
                 })?;
             }

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -137,14 +137,14 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
         .and_then(|stack_id_string| stack_id_string.parse().map_err(Error::StackIdError))
         .map_err(|err| {
             #[cfg(feature = "trace")]
-            trace.set_error(err);
+            trace.set_error(&err);
             err
         })?;
 
     let platform = B::Platform::from_path(&args.platform_dir_path).map_err(|inner_err| {
         let err = Error::CannotCreatePlatformFromPath(inner_err);
         #[cfg(feature = "trace")]
-        trace.set_error(err);
+        trace.set_error(&err);
         err
     })?;
 

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -163,9 +163,9 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
     let detect_result = buildpack.detect(detect_context).map_err(|err| {
         trace_error(&err);
         err
-    });
+    })?;
 
-    match detect_result?.0 {
+    match detect_result.0 {
         InnerDetectResult::Fail => {
             #[cfg(feature = "trace")]
             trace.add_event("detect-failed");
@@ -255,9 +255,9 @@ pub fn libcnb_runtime_build<B: Buildpack>(
     let build_result = buildpack.build(build_context).map_err(|err| {
         trace_error(&err);
         err
-    });
+    })?;
 
-    match build_result?.0 {
+    match build_result.0 {
         InnerBuildResult::Pass {
             launch,
             store,

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -263,7 +263,12 @@ pub fn libcnb_runtime_build<B: Buildpack>(
                     cnb_sbom_path(&launch_sbom.format, &layers_dir, "launch"),
                     &launch_sbom.data,
                 )
-                .map_err(Error::CannotWriteLaunchSbom)?;
+                .map_err(|inner_err| {
+                    let err = Error::CannotWriteLaunchSbom(inner_err);
+                    #[cfg(feature = "trace")]
+                    trace.set_error(&err);
+                    err
+                })?;
             }
 
             #[cfg(feature = "trace")]

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -152,9 +152,9 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
 
     let detect_context = DetectContext {
         app_dir,
+        buildpack_dir,
         stack_id,
         platform,
-        buildpack_dir,
         buildpack_descriptor,
     };
 

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -118,6 +118,7 @@ impl Drop for BuildpackTrace {
 mod tests {
     use super::start_trace;
     use libcnb_data::buildpack::{Buildpack, BuildpackVersion};
+    use serde_json::Value;
     use std::{
         collections::HashSet,
         fs,
@@ -154,6 +155,8 @@ mod tests {
             .expect("Expected telemetry file to exist, but couldn't read it");
 
         println!("tracing_contents: {tracing_contents}");
+        let _tracing_data: Value = serde_json::from_str(&tracing_contents)
+            .expect("Expected tracing export file contents to be valid json");
         assert!(tracing_contents.contains(phase));
         assert!(tracing_contents.contains(event));
         assert!(tracing_contents.contains(error_message));

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -31,7 +31,10 @@ pub(crate) struct BuildpackTrace {
 /// Open Telemetry file export. The resulting trace provider and span are
 /// enriched with data from the buildpack and the rust environment.
 pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> BuildpackTrace {
-    let trace_name = format!("{}-{phase_name}", buildpack.id.replace(['/', '.'], "_"));
+    let trace_name = format!(
+        "{}-{phase_name}",
+        buildpack.id.replace(['/', '.', '-'], "_")
+    );
     let tracing_file_path = Path::new(TELEMETRY_EXPORT_ROOT).join(format!("{trace_name}.jsonl"));
 
     // Ensure tracing file path parent exists by creating it.

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -8,15 +8,28 @@ use opentelemetry_sdk::{
     trace::{Config, Span, TracerProvider},
     Resource,
 };
-use std::path::Path;
+use std::{io::BufWriter, path::Path};
 
+// This is the diretory in which `BuildpackTrace` stores Open Telemetry File
+// Exports. Services which intend to export the tracing data from libcnb.rs
+// (such as [cnb-otel-collector](https://github.com/heroku/cnb-otel-collector))
+// should look for `.jsonl` file exports in this directory. This path was chosen
+// to prevent conflicts with the CNB spec and /tmp is commonly available and
+// writable on base images.
+#[cfg(target_family = "unix")]
 const TELEMETRY_EXPORT_ROOT: &str = "/tmp/cnb-telemetry";
 
+/// `BuildpackTrace` represents an Open Telemetry tracer provider and single span.
+/// It's designed to support tracing a CNB build or detect phase as a singular
+/// span.
 pub(crate) struct BuildpackTrace {
     provider: TracerProvider,
     span: Span,
 }
 
+/// `start_trace` starts an Open Telemetry trace and span that exports to an
+/// Open Telemetry file export. The resulting trace provider and span are
+/// enriched with data from the buildpack and the rust environment.
 pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> BuildpackTrace {
     let trace_name = format!("{}-{phase_name}", buildpack.id.replace(['/', '.'], "_"));
     let tracing_file_path = Path::new(TELEMETRY_EXPORT_ROOT).join(format!("{trace_name}.jsonl"));
@@ -30,28 +43,42 @@ pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> Bu
         .append(true)
         .open(&tracing_file_path)
     {
+        // Write tracing data to a file, which may be read by other
+        // services. Wrap with a BufWriter to prevent serde from sending each
+        // JSON token to IO, and instead send entire JSON objects to IO.
         Ok(file) => opentelemetry_stdout::SpanExporter::builder()
-            .with_writer(file)
+            .with_writer(BufWriter::new(file))
             .build(),
+        // Failed tracing shouldn't fail a build, and any logging here would
+        // likely confuse the user, so send telemetry to /dev/null on errors.
         Err(_) => opentelemetry_stdout::SpanExporter::builder()
             .with_writer(std::io::sink())
             .build(),
     };
 
-    let lib_name = option_env!("CARGO_PKG_NAME").unwrap_or("libcnb");
-    let lib_version = option_env!("CARGO_PKG_VERSION");
-
     let provider = TracerProvider::builder()
         .with_simple_exporter(exporter)
         .with_config(Config::default().with_resource(Resource::new(vec![
-            KeyValue::new("service.name", lib_name),
-            KeyValue::new("service.version", lib_version.unwrap_or_default()),
+            // Associate the tracer provider with service attributes. The buildpack
+            // name/version seems to map well to the suggestion
+            // [here](https://opentelemetry.io/docs/specs/semconv/resource/#service).
+            KeyValue::new("service.name", buildpack.id.to_string()),
+            KeyValue::new("service.version", buildpack.version.to_string()),
         ])))
         .build();
 
+    // Set the global tracer provider so that buildpacks may use it.
     global::set_tracer_provider(provider.clone());
 
-    let tracer = provider.versioned_tracer(lib_name, lib_version, None as Option<&str>, None);
+    // Get a tracer identified by the instrumentation scope/library. The crate
+    // name/version seems to map well to the suggestion
+    // [here](https://opentelemetry.io/docs/specs/otel/trace/api/#get-a-tracer).
+    let tracer = provider.versioned_tracer(
+        option_env!("CARGO_PKG_NAME").unwrap_or("libcnb.rs"),
+        option_env!("CARGO_PKG_VERSION"),
+        None as Option<&str>,
+        None,
+    );
 
     let mut span = tracer.start(trace_name);
     span.set_attributes(vec![
@@ -67,10 +94,13 @@ pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> Bu
 }
 
 impl BuildpackTrace {
+    /// `set_error` sets the status for the underlying span to error, and
+    /// also records an exception on the span.
     pub(crate) fn set_error(&mut self, err: &dyn std::error::Error) {
-        self.span.set_status(Status::error(err.to_string()));
+        self.span.set_status(Status::error(format!("{err:?}")));
         self.span.record_error(err);
     }
+    /// `add_event` adds a named event to the underlying span.
     pub(crate) fn add_event(&mut self, name: &'static str) {
         self.span.add_event(name, vec![]);
     }

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -73,7 +73,7 @@ pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> Bu
     // Set the global tracer provider so that buildpacks may use it.
     global::set_tracer_provider(provider.clone());
 
-    // Get a tracer identified by the instrumentation scope/library. The crate
+    // Get a tracer identified by the instrumentation scope/library. The libcnb crate
     // name/version seems to map well to the suggestion
     // [here](https://opentelemetry.io/docs/specs/otel/trace/api/#get-a-tracer).
     let tracer = provider.versioned_tracer(

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::doc_markdown)]
 use libcnb_data::buildpack::Buildpack;
 use opentelemetry::{
     global,

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -85,7 +85,7 @@ pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> Bu
 
     let mut span = tracer.start(trace_name);
     span.set_attributes(vec![
-        KeyValue::new("buildpack_id", buildpack.id.to_string().clone()),
+        KeyValue::new("buildpack_id", buildpack.id.to_string()),
         KeyValue::new("buildpack_name", buildpack.name.clone().unwrap_or_default()),
         KeyValue::new("buildpack_version", buildpack.version.to_string()),
         KeyValue::new(

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::doc_markdown)]
 use libcnb_data::buildpack::Buildpack;
 use opentelemetry::{
     global,

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -72,12 +72,12 @@ pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> Bu
     // Set the global tracer provider so that buildpacks may use it.
     global::set_tracer_provider(provider.clone());
 
-    // Get a tracer identified by the instrumentation scope/library. The libcnb crate
-    // name/version seems to map well to the suggestion here:
+    // Get a tracer identified by the instrumentation scope/library. The libcnb
+    // crate name/version seems to map well to the suggestion here:
     // https://opentelemetry.io/docs/specs/otel/trace/api/#get-a-tracer.
     let tracer = provider.versioned_tracer(
-        option_env!("CARGO_PKG_NAME").unwrap_or("libcnb.rs"),
-        option_env!("CARGO_PKG_VERSION"),
+        env!("CARGO_PKG_NAME"),
+        Some(env!("CARGO_PKG_VERSION")),
         None as Option<&str>,
         None,
     );

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -116,7 +116,7 @@ mod tests {
         _ = fs::remove_file(telemetry_path);
 
         {
-            let mut trace = start_trace(&buildpack, &phase);
+            let mut trace = start_trace(&buildpack, phase);
             trace.add_event(event);
             trace.set_error(&Error::new(ErrorKind::Other, error_message));
         }
@@ -132,6 +132,5 @@ mod tests {
         assert!(
             tracing_contents.contains(&buildpack.name.expect("Expected buildpack.name to exist"))
         );
-        assert!(tracing_contents.contains("something"));
     }
 }

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -1,0 +1,88 @@
+use libcnb_data::buildpack::Buildpack;
+use opentelemetry::{
+    global,
+    sdk::{
+        trace::{Config, Span, TracerProvider},
+        Resource,
+    },
+    trace::{Span as SpanTrait, Status, Tracer, TracerProvider as TracerProviderTrait},
+    KeyValue,
+};
+use std::path::Path;
+
+pub(crate) struct BuildpackTrace {
+    provider: TracerProvider,
+    span: Span,
+}
+
+pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> BuildpackTrace {
+    let bp_slug = buildpack.id.replace(['/', '.'], "_");
+    let tracing_file_path = Path::new("/tmp")
+        .join("cnb-telemetry")
+        .join(format!("{bp_slug}-{phase_name}.jsonl"));
+
+    // Ensure tracing file path parent exists by creating it.
+    if let Some(parent_dir) = tracing_file_path.parent() {
+        let _ = std::fs::create_dir_all(parent_dir);
+    }
+    let exporter = match std::fs::File::options()
+        .create(true)
+        .append(true)
+        .open(&tracing_file_path)
+    {
+        Ok(file) => opentelemetry_stdout::SpanExporter::builder()
+            .with_writer(file)
+            .build(),
+        Err(_) => opentelemetry_stdout::SpanExporter::builder()
+            .with_writer(std::io::sink())
+            .build(),
+    };
+
+    let lib_name = option_env!("CARGO_PKG_NAME").unwrap_or("libcnb");
+
+    let provider = opentelemetry::sdk::trace::TracerProvider::builder()
+        .with_simple_exporter(exporter)
+        .with_config(
+            Config::default()
+                .with_resource(Resource::new(vec![KeyValue::new("service.name", lib_name)])),
+        )
+        .build();
+
+    global::set_tracer_provider(provider.clone());
+
+    let tracer = provider.versioned_tracer(
+        lib_name,
+        option_env!("CARGO_PKG_VERSION"),
+        None as Option<&str>,
+        None,
+    );
+
+    let mut span = tracer.start(phase_name);
+    span.set_attributes(vec![
+        KeyValue::new("buildpack_id", buildpack.id.to_string().clone()),
+        KeyValue::new("buildpack_name", buildpack.name.clone().unwrap_or_default()),
+        KeyValue::new("buildpack_version", buildpack.version.to_string()),
+        KeyValue::new(
+            "buildpack_homepage",
+            buildpack.homepage.clone().unwrap_or_default(),
+        ),
+    ]);
+    BuildpackTrace { provider, span }
+}
+
+impl BuildpackTrace {
+    pub(crate) fn set_error(&mut self, err: &dyn std::error::Error) {
+        self.span.set_status(Status::error(err.to_string()));
+        self.span.record_error(err);
+    }
+    pub(crate) fn add_event(&mut self, name: &'static str) {
+        self.span.add_event(name, vec![]);
+    }
+}
+
+impl Drop for BuildpackTrace {
+    fn drop(&mut self) {
+        self.provider.force_flush();
+        global::shutdown_tracer_provider();
+    }
+}

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -10,7 +10,7 @@ use opentelemetry_sdk::{
 };
 use std::{io::BufWriter, path::Path};
 
-// This is the diretory in which `BuildpackTrace` stores Open Telemetry File
+// This is the directory in which `BuildpackTrace` stores Open Telemetry File
 // Exports. Services which intend to export the tracing data from libcnb.rs
 // (such as [cnb-otel-collector](https://github.com/heroku/cnb-otel-collector))
 // should look for `.jsonl` file exports in this directory. This path was chosen

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -16,10 +16,10 @@ pub(crate) struct BuildpackTrace {
 }
 
 pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> BuildpackTrace {
-    let bp_slug = buildpack.id.replace(['/', '.'], "_");
+    let trace_name = format!("{}-{phase_name}", buildpack.id.replace(['/', '.'], "_"));
     let tracing_file_path = Path::new("/tmp")
         .join("cnb-telemetry")
-        .join(format!("{bp_slug}-{phase_name}.jsonl"));
+        .join(format!("{trace_name}.jsonl"));
 
     // Ensure tracing file path parent exists by creating it.
     if let Some(parent_dir) = tracing_file_path.parent() {
@@ -57,7 +57,7 @@ pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> Bu
         None,
     );
 
-    let mut span = tracer.start(phase_name);
+    let mut span = tracer.start(trace_name);
     span.set_attributes(vec![
         KeyValue::new("buildpack_id", buildpack.id.to_string().clone()),
         KeyValue::new("buildpack_name", buildpack.name.clone().unwrap_or_default()),
@@ -82,7 +82,60 @@ impl BuildpackTrace {
 
 impl Drop for BuildpackTrace {
     fn drop(&mut self) {
+        self.span.end();
         self.provider.force_flush();
         global::shutdown_tracer_provider();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::start_trace;
+    use libcnb_data::buildpack::{Buildpack, BuildpackVersion};
+    use std::{
+        collections::HashSet,
+        fs,
+        io::{Error, ErrorKind},
+    };
+
+    #[test]
+    fn test_tracing() {
+        let buildpack = Buildpack {
+            id: "company.com/foo"
+                .parse()
+                .expect("Valid BuildpackId should parse"),
+            version: BuildpackVersion::new(0, 0, 0),
+            name: Some("Foo buildpack for company.com".to_string()),
+            homepage: None,
+            clear_env: false,
+            description: None,
+            keywords: vec![],
+            licenses: vec![],
+            sbom_formats: HashSet::new(),
+        };
+        let phase = "bar";
+        let event = "baz-event";
+        let error_message = "its broken";
+        let telemetry_path = "/tmp/cnb-telemetry/company_com_foo-bar.jsonl";
+        _ = fs::remove_file(telemetry_path);
+
+        {
+            let mut trace = start_trace(&buildpack, &phase);
+            trace.add_event(event);
+            trace.set_error(&Error::new(ErrorKind::Other, error_message));
+        }
+        let tracing_contents = fs::read_to_string(telemetry_path)
+            .expect("Expected telemetry file to exist, but couldn't read it");
+
+        println!("tracing_contents: {tracing_contents}");
+        assert!(tracing_contents.contains(phase));
+        assert!(tracing_contents.contains(event));
+        assert!(tracing_contents.contains(error_message));
+        assert!(tracing_contents.contains(buildpack.id.as_str()));
+        assert!(tracing_contents.contains(&buildpack.version.to_string()));
+        assert!(
+            tracing_contents.contains(&buildpack.name.expect("Expected buildpack.name to exist"))
+        );
+        assert!(tracing_contents.contains("something"));
     }
 }

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -1,12 +1,12 @@
 use libcnb_data::buildpack::Buildpack;
 use opentelemetry::{
     global,
-    sdk::{
-        trace::{Config, Span, TracerProvider},
-        Resource,
-    },
     trace::{Span as SpanTrait, Status, Tracer, TracerProvider as TracerProviderTrait},
     KeyValue,
+};
+use opentelemetry_sdk::{
+    trace::{Config, Span, TracerProvider},
+    Resource,
 };
 use std::path::Path;
 
@@ -41,7 +41,7 @@ pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> Bu
     let lib_name = option_env!("CARGO_PKG_NAME").unwrap_or("libcnb");
     let lib_version = option_env!("CARGO_PKG_VERSION");
 
-    let provider = opentelemetry::sdk::trace::TracerProvider::builder()
+    let provider = TracerProvider::builder()
         .with_simple_exporter(exporter)
         .with_config(Config::default().with_resource(Resource::new(vec![
             KeyValue::new("service.name", lib_name),

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -17,7 +17,7 @@ use std::{io::BufWriter, path::Path};
 // to prevent conflicts with the CNB spec and /tmp is commonly available and
 // writable on base images.
 #[cfg(target_family = "unix")]
-const TELEMETRY_EXPORT_ROOT: &str = "/tmp/cnb-telemetry";
+const TELEMETRY_EXPORT_ROOT: &str = "/tmp/libcnb-telemetry";
 
 /// `BuildpackTrace` represents an Open Telemetry tracer provider and single span.
 /// It's designed to support tracing a CNB build or detect phase as a singular
@@ -142,7 +142,7 @@ mod tests {
         let phase = "bar";
         let event = "baz-event";
         let error_message = "its broken";
-        let telemetry_path = "/tmp/cnb-telemetry/company_com_foo-bar.jsonl";
+        let telemetry_path = "/tmp/libcnb-telemetry/company_com_foo-bar.jsonl";
         _ = fs::remove_file(telemetry_path);
 
         {

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -60,7 +60,7 @@ pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> Bu
 
     let provider = TracerProvider::builder()
         .with_simple_exporter(exporter)
-        .with_config(Config::default().with_resource(Resource::new(vec![
+        .with_config(Config::default().with_resource(Resource::new([
             // Associate the tracer provider with service attributes. The buildpack
             // name/version seems to map well to the suggestion here
             // https://opentelemetry.io/docs/specs/semconv/resource/#service.
@@ -83,7 +83,7 @@ pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> Bu
     );
 
     let mut span = tracer.start(trace_name);
-    span.set_attributes(vec![
+    span.set_attributes([
         KeyValue::new("buildpack_id", buildpack.id.to_string()),
         KeyValue::new("buildpack_name", buildpack.name.clone().unwrap_or_default()),
         KeyValue::new("buildpack_version", buildpack.version.to_string()),

--- a/test-buildpacks/tracing/Cargo.toml
+++ b/test-buildpacks/tracing/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tracing"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+libcnb = { path = "../../libcnb", features = ["trace"] }
+
+[dev-dependencies]
+libcnb-test.workspace = true

--- a/test-buildpacks/tracing/Cargo.toml
+++ b/test-buildpacks/tracing/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 workspace = true
 
 [dependencies]
-libcnb = { path = "../../libcnb", features = ["trace"] }
+libcnb = { workspace = true, features = ["trace"] }
 
 [dev-dependencies]
 libcnb-test.workspace = true

--- a/test-buildpacks/tracing/Cargo.toml
+++ b/test-buildpacks/tracing/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 rust-version.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 libcnb = { path = "../../libcnb", features = ["trace"] }
 

--- a/test-buildpacks/tracing/buildpack.toml
+++ b/test-buildpacks/tracing/buildpack.toml
@@ -1,0 +1,9 @@
+api = "0.9"
+
+[buildpack]
+id = "libcnb-test-buildpacks/tracing"
+version = "0.1.0"
+name = "libcnb test buildpack: tracing"
+
+[[stacks]]
+id = "*"

--- a/test-buildpacks/tracing/src/main.rs
+++ b/test-buildpacks/tracing/src/main.rs
@@ -1,0 +1,28 @@
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+
+use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
+use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
+use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
+use libcnb::{buildpack_main, Buildpack};
+
+/// TestTracingBuildpack is a basic buildpack compiled with the libcnb.rs
+/// `tracing` flag, which should emit opentelemetry file exports to the build
+/// file system (but not the final image).
+pub struct TestTracingBuildpack;
+
+impl Buildpack for TestTracingBuildpack {
+    type Platform = GenericPlatform;
+    type Metadata = GenericMetadata;
+    type Error = GenericError;
+
+    fn detect(&self, _context: DetectContext<Self>) -> libcnb::Result<DetectResult, Self::Error> {
+        DetectResultBuilder::pass().build()
+    }
+
+    fn build(&self, _context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
+        BuildResultBuilder::new().build()
+    }
+}
+
+buildpack_main!(TestTracingBuildpack);

--- a/test-buildpacks/tracing/src/main.rs
+++ b/test-buildpacks/tracing/src/main.rs
@@ -1,6 +1,3 @@
-#![warn(clippy::pedantic)]
-#![allow(clippy::module_name_repetitions)]
-
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};

--- a/test-buildpacks/tracing/src/main.rs
+++ b/test-buildpacks/tracing/src/main.rs
@@ -3,6 +3,10 @@ use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
 use libcnb::{buildpack_main, Buildpack};
 
+// Suppress warnings due to the `unused_crate_dependencies` lint not handling integration tests well.
+#[cfg(test)]
+use libcnb_test as _;
+
 /// `TestTracingBuildpack` is a basic buildpack compiled with the libcnb.rs
 /// `trace` flag, which should emit opentelemetry file exports to the build
 /// file system (but not the final image).

--- a/test-buildpacks/tracing/src/main.rs
+++ b/test-buildpacks/tracing/src/main.rs
@@ -6,8 +6,8 @@ use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
 use libcnb::{buildpack_main, Buildpack};
 
-/// TestTracingBuildpack is a basic buildpack compiled with the libcnb.rs
-/// `tracing` flag, which should emit opentelemetry file exports to the build
+/// `TestTracingBuildpack` is a basic buildpack compiled with the libcnb.rs
+/// `trace` flag, which should emit opentelemetry file exports to the build
 /// file system (but not the final image).
 pub struct TestTracingBuildpack;
 

--- a/test-buildpacks/tracing/tests/fixtures/buildpacks/tracing-reader/bin/build
+++ b/test-buildpacks/tracing/tests/fixtures/buildpacks/tracing-reader/bin/build
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -euo pipefail
 
 echo "---> Tracing Reader Buildpack"
 

--- a/test-buildpacks/tracing/tests/fixtures/buildpacks/tracing-reader/bin/build
+++ b/test-buildpacks/tracing/tests/fixtures/buildpacks/tracing-reader/bin/build
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+echo "---> Tracing Reader Buildpack"
+
+# Report the contents of previous buildpack tracing file exports.
+# Useful for testing the contents of tracing file contents, which aren't
+# available in the resulting image of a CNB build.
+for tracing_file in /tmp/libcnb-telemetry/*.jsonl; do
+  cat $tracing_file
+done
+
+exit 0

--- a/test-buildpacks/tracing/tests/fixtures/buildpacks/tracing-reader/bin/detect
+++ b/test-buildpacks/tracing/tests/fixtures/buildpacks/tracing-reader/bin/detect
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+set -eo pipefail

--- a/test-buildpacks/tracing/tests/fixtures/buildpacks/tracing-reader/bin/detect
+++ b/test-buildpacks/tracing/tests/fixtures/buildpacks/tracing-reader/bin/detect
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -euo pipefail

--- a/test-buildpacks/tracing/tests/fixtures/buildpacks/tracing-reader/buildpack.toml
+++ b/test-buildpacks/tracing/tests/fixtures/buildpacks/tracing-reader/buildpack.toml
@@ -1,0 +1,9 @@
+api = "0.9"
+
+[buildpack]
+id = "libcnb-test-buildpacks/tracing-reader"
+version = "0.1.0"
+name = "libcnb test buildpack fixture: tracing-reader"
+
+[[stacks]]
+id = "*"

--- a/test-buildpacks/tracing/tests/integration_test.rs
+++ b/test-buildpacks/tracing/tests/integration_test.rs
@@ -1,0 +1,32 @@
+#![warn(clippy::pedantic)]
+
+use libcnb_test::{assert_contains, BuildConfig, BuildpackReference, TestRunner};
+use std::env::temp_dir;
+use std::fs;
+
+#[test]
+#[ignore = "integration test"]
+fn test_tracing_export_file() {
+    let empty_app_dir = temp_dir().join("empty-app-dir");
+    fs::create_dir_all(&empty_app_dir).unwrap();
+
+    let mut build_config = BuildConfig::new("heroku/builder:22", &empty_app_dir);
+
+    // Telemetry file exports are not persisted to the build's resulting image,
+    // so to test that contents are emitted, a second buildpack is used to read
+    // the contents during the build.
+    build_config.buildpacks(vec![
+        BuildpackReference::CurrentCrate,
+        BuildpackReference::Other(format!(
+            "file://{}/tests/fixtures/buildpacks/tracing-reader",
+            env!("CARGO_MANIFEST_DIR")
+        )),
+    ]);
+
+    TestRunner::default().build(&build_config, |context| {
+        // Ensure expected span names for detect and build phases are present
+        // in the file export contents.
+        assert_contains!(context.pack_stdout, "libcnb-test-buildpacks_tracing-detect");
+        assert_contains!(context.pack_stdout, "libcnb-test-buildpacks_tracing-build");
+    });
+}

--- a/test-buildpacks/tracing/tests/integration_test.rs
+++ b/test-buildpacks/tracing/tests/integration_test.rs
@@ -1,3 +1,6 @@
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
+
 use libcnb_test::{assert_contains, BuildConfig, BuildpackReference, TestRunner};
 use std::env::temp_dir;
 use std::fs;

--- a/test-buildpacks/tracing/tests/integration_test.rs
+++ b/test-buildpacks/tracing/tests/integration_test.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 use libcnb_test::{assert_contains, BuildConfig, BuildpackReference, TestRunner};
 use std::env::temp_dir;
 use std::fs;

--- a/test-buildpacks/tracing/tests/integration_test.rs
+++ b/test-buildpacks/tracing/tests/integration_test.rs
@@ -13,7 +13,7 @@ fn test_tracing_export_file() {
     // Telemetry file exports are not persisted to the build's resulting image,
     // so to test that contents are emitted, a second buildpack is used to read
     // the contents during the build.
-    build_config.buildpacks(vec![
+    build_config.buildpacks([
         BuildpackReference::CurrentCrate,
         BuildpackReference::Other(format!(
             "file://{}/tests/fixtures/buildpacks/tracing-reader",

--- a/test-buildpacks/tracing/tests/integration_test.rs
+++ b/test-buildpacks/tracing/tests/integration_test.rs
@@ -26,7 +26,7 @@ fn test_tracing_export_file() {
     TestRunner::default().build(&build_config, |context| {
         // Ensure expected span names for detect and build phases are present
         // in the file export contents.
-        assert_contains!(context.pack_stdout, "libcnb-test-buildpacks_tracing-detect");
-        assert_contains!(context.pack_stdout, "libcnb-test-buildpacks_tracing-build");
+        assert_contains!(context.pack_stdout, "libcnb_test_buildpacks_tracing-detect");
+        assert_contains!(context.pack_stdout, "libcnb_test_buildpacks_tracing-build");
     });
 }


### PR DESCRIPTION
This is an alternative implementation of #705. 

This PR adds opt-in functionality (with the `trace` feature) that writes [OpenTelemetry File Export](https://opentelemetry.io/docs/specs/otel/protocol/file-exporter/) tracing information during build and compile. The tracing data includes buildpack attributes (like buildpack id, name), spans for build and detect, events for `build-success`, `detect-pass`, `detect-fail`, and also sets errors and span status in the case of errors.

GUS-W-14348835.