### PR TITLE
Include the `rustup target add` step in the cross-compile assistance text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved the consistency of all user-facing libcnb.rs error message wordings. ([#722](https://github.com/heroku/libcnb.rs/pull/722))
+- The assistance error message shown when the necessary cross-compilation tools are not found now also includes the `rustup target add` step. ([#729](https://github.com/heroku/libcnb.rs/pull/729))
 
 ### Fixed
 

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -25,7 +25,10 @@ The easiest way to install the required cross-compilation toolchain is to run:
 brew install messense/macos-cross-toolchains/x86_64-unknown-linux-musl
 
 For more information, see:
-https://github.com/messense/homebrew-macos-cross-toolchains",
+https://github.com/messense/homebrew-macos-cross-toolchains
+
+You will also need to install the Rust target, using:
+rustup target add x86_64-unknown-linux-musl",
             )), |gcc_binary_path| {
                 CrossCompileAssistance::Configuration {
                     cargo_env: vec![
@@ -57,7 +60,10 @@ linker for the target platform must be installed on your computer.
 
 The easiest way to install 'musl-gcc' is to install the 'musl-tools' package:
 - https://packages.ubuntu.com/focal/musl-tools
-- https://packages.debian.org/bullseye/musl-tools",
+- https://packages.debian.org/bullseye/musl-tools
+
+You will also need to install the Rust target, using:
+rustup target add x86_64-unknown-linux-musl",
             )),
         }
     } else if target_triple.as_ref() == AARCH64_UNKNOWN_LINUX_MUSL && cfg!(target_os = "linux") {
@@ -82,7 +88,10 @@ linker for the target platform must installed on your computer.
 The easiest way to install the 'g++-aarch64-linux-gnu', 'libc6-dev-arm64-cross', and 'musl-tools' packages:
 - https://packages.ubuntu.com/focal/g++-aarch64-linux-gnu
 - https://packages.ubuntu.com/focal/musl-tools
-- https://packages.ubuntu.com/focal/libc6-dev-arm64-cross",
+- https://packages.ubuntu.com/focal/libc6-dev-arm64-cross
+
+You will also need to install the Rust target, using:
+rustup target add aarch64-unknown-linux-musl",
             )),
         }
     } else {


### PR DESCRIPTION
In order to compile buildpacks, users need to have both the musl toolchain and the Rust target installed.

If the musl toolchain is missing, we already show help text that says what packages need to be installed.

However, this help text does not mention the Rust target, meaning after installing the musl tools, users will then go on to receive another error - this time from the Rust compiler.

Whilst the Rust compiler error message does suggest running the `rustup target add` command itself:
- this suggestion is often lost in the noise: https://github.com/rust-lang/rust/issues/117640
- it means the users has had two failed attempts in a row, which could make the experience feel open-ended/frustrating

Now, the cross-compile assistance help text also suggests the `rustup target add` step, improving the UX slightly.

The help texts are starting to include a fair bit of duplication, however, refactoring is covered by the separate #727.

Fixes #716.
GUS-W-14438920.