### PR TITLE
Use `--locked` in docs for how to install libcnb-cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Start by installing [libcnb-cargo](https://crates.io/crates/libcnb-cargo), which
 that we will use later to package our buildpack:
 
 ```shell
-cargo install libcnb-cargo
+cargo install --locked libcnb-cargo
 ```
 
 #### Cross-compilation prerequisites

--- a/libcnb-cargo/README.md
+++ b/libcnb-cargo/README.md
@@ -5,7 +5,7 @@ A Cargo command for managing buildpacks written with [libcnb.rs](https://github.
 ## Installation
 
 ```shell
-cargo install libcnb-cargo
+cargo install --locked libcnb-cargo
 ```
 
 ## Usage


### PR DESCRIPTION
By default `cargo install` will not use any lockfile in the published crate, and instead will install the latest in-range version of any transitive dependencies.

By using `--locked` the lockfile will be used, ensuring a more deterministic installation.

Note: Whilst this repo intentionally doesn't commit a lockfile to Git (since this is a library crate), Cargo will include one in the crate uploaded to crates.io at time of publish, so `--locked` will still work.

See:
https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile