### PR TITLE
Remove unused internal `From<&TempDir>` implementation

### DIFF
--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Command;
-use tempfile::TempDir;
 
 /// Represents a `pack build` command.
 #[derive(Clone, Debug)]
@@ -25,12 +24,6 @@ pub(crate) enum BuildpackReference {
 impl From<PathBuf> for BuildpackReference {
     fn from(path: PathBuf) -> Self {
         Self::Path(path)
-    }
-}
-
-impl From<&TempDir> for BuildpackReference {
-    fn from(path: &TempDir) -> Self {
-        Self::Path(path.path().into())
     }
 }
 


### PR DESCRIPTION
Since `pack::BuildpackReference` is an internal-only type (not to be confused with the public `build_config::BuildpackReference`), and the `From<&TempDir>` implementation is unused since #666.

GUS-W-14502304.