### PR TITLE
libcnb-test: Test container, volume and image cleanup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,29 @@ jobs:
       - name: Run integration tests
         # Runs only tests annotated with the `ignore` attribute (which in this repo, are the integration tests).
         run: cargo test -- --ignored
+      - name: Check libcnb-test has cleaned up test containers, volumes and images
+        run: |
+          if [[ -n "$(docker ps --all --quiet)" ]]; then
+            docker ps --all
+            echo "Unexpected Docker containers left behind!"
+            # TODO: Fix container cleanup and make this fail
+            # https://github.com/heroku/libcnb.rs/issues/737
+            # exit 1
+          fi
+
+          if [[ -n "$(docker volume ls --quiet)" ]]; then
+            docker volume ls
+            echo "Unexpected Docker volumes left behind!"
+            # TODO: Fix volume cleanup and make this fail
+            # https://github.com/heroku/libcnb.rs/issues/570
+            # exit 1
+          fi
+
+          if [[ -n "$(docker images --all --quiet '*libcnb*')" ]]; then
+            docker images --all '*libcnb*'
+            echo "Unexpected Docker images left behind!"
+            exit 1
+          fi
       - name: Compile and package examples/basics
         run: cargo run --package libcnb-cargo -- libcnb package
         working-directory: ./examples/basics


### PR DESCRIPTION
At the end of each test libcnb-test is meant to clean up any Docker resources that were created during the test. However, this functionality currently isn't tested, and we've found several cases where cleanup wasn't occurring as expected:
- https://github.com/heroku/libcnb.rs/issues/586
- https://github.com/heroku/libcnb.rs/issues/570
- https://github.com/heroku/libcnb.rs/issues/737

We could try and add a Rust integration test or two to check that cleanup works in the common case, however, as seen by the issues above, it's often in the edge cases where resource cleanup wasn't working. In addition, testing cleanup during an individual test is hard, since other tests will be running at the same time, so we'd have to check for individual image or container names, which would miss cases like #570.

As such, it's much easier for us to instead just check that there are zero unexpected resources left behind at the end of the existing entire libcnb-test test suite.

For now, two of the checks don't cause CI to fail, since the fixes for the cleanup implementations have not yet landed.

GUS-W-14502524.