### PR TITLE
libcnb-test: Clean up Docker volumes after each test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,7 @@ jobs:
           if [[ -n "$(docker volume ls --quiet)" ]]; then
             docker volume ls
             echo "Unexpected Docker volumes left behind!"
-            # TODO: Fix volume cleanup and make this fail
-            # https://github.com/heroku/libcnb.rs/issues/570
-            # exit 1
+            exit 1
           fi
 
           if [[ -n "$(docker images --all --quiet '*libcnb*')" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `libcnb-test`:
   - Fixed incorrect error messages being shown for buildpack compilation/packaging failures. ([#720](https://github.com/heroku/libcnb.rs/pull/720))
+  - The Docker volumes created by Pack for the build and launch layer caches are now cleaned up after each test. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
+  - The Docker image cleanup process no longer makes duplicate attempts to remove images when using `TestContext::rebuild`. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
+  - Test failures due to the Docker daemon not being installed or started no longer cause a non-unwinding panic abort with noisy traceback. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
   - Containers created by `TestContext::start_container` are now correctly cleaned up if the container failed to start. ([#742](https://github.com/heroku/libcnb.rs/pull/742))
 
 ## [0.15.0] - 2023-09-25

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -48,7 +48,13 @@ impl TestRunner {
     /// )
     /// ```
     pub fn build<C: Borrow<BuildConfig>, F: FnOnce(TestContext)>(&self, config: C, f: F) {
-        self.build_internal(TemporaryDockerResources::new(), config, f);
+        let image_name = util::random_docker_identifier();
+        let docker_resources = TemporaryDockerResources {
+            build_cache_volume_name: format!("{image_name}.build-cache"),
+            launch_cache_volume_name: format!("{image_name}.launch-cache"),
+            image_name,
+        };
+        self.build_internal(docker_resources, config, f);
     }
 
     pub(crate) fn build_internal<C: Borrow<BuildConfig>, F: FnOnce(TestContext)>(
@@ -172,17 +178,6 @@ pub(crate) struct TemporaryDockerResources {
     pub(crate) build_cache_volume_name: String,
     pub(crate) image_name: String,
     pub(crate) launch_cache_volume_name: String,
-}
-
-impl TemporaryDockerResources {
-    pub fn new() -> Self {
-        let image_name = util::random_docker_identifier();
-        Self {
-            build_cache_volume_name: format!("{image_name}.build-cache"),
-            launch_cache_volume_name: format!("{image_name}.launch-cache"),
-            image_name,
-        }
-    }
 }
 
 impl Drop for TemporaryDockerResources {


### PR DESCRIPTION
When using `pack build`, by default Pack will create two Docker volumes for caching - one for the build layer cache, and the other for the launch layer cache. Pack bases the names for these volumes on the app image name, so that the next time a build is performed with the same app image name, the associated cache is used for that rebuild.

When libcnb-test runs tests, it intentionally uses a random Docker image name for each new test, and then tears down the image and any associated containers after the tests.

However, until now the Docker volumes automatically created by Pack were not being removed, which can cause issues when running the tests locally, since the Docker VM can run out of disk space - as seen in #570. The leftover volumes can also be seen in the tests log output added in #740.

Pack doesn't currently offer a "clean up the volumes associated with this app name" feature, so we have to remove these volumes manually. To do so we need the volume name - which we achieve by generating a name ourselves, and passing it to `pack build` using the `--cache` options, so Pack uses our volume name instead of generating its own automatic volume name.

Since we're now cleaning up not only images but volumes too, I've refactored the way resources are cleaned up, to reduce the amount of duplication (since otherwise we'd need to handle the "still clean up for expected failures" case for volumes too). This new implementation also solves #735 and #736.

Fixes #570.
Fixes #735.
Fixes #736.
GUS-W-13195631.
GUS-W-14503186.
GUS-W-14503192.