### PR TITLE
libcnb-test: Fix container cleanup when using `TestContext::start_container`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,7 @@ jobs:
           if [[ -n "$(docker ps --all --quiet)" ]]; then
             docker ps --all
             echo "Unexpected Docker containers left behind!"
-            # TODO: Fix container cleanup and make this fail
-            # https://github.com/heroku/libcnb.rs/issues/737
-            # exit 1
+            exit 1
           fi
 
           if [[ -n "$(docker volume ls --quiet)" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `libcnb-test`:
   - Fixed incorrect error messages being shown for buildpack compilation/packaging failures. ([#720](https://github.com/heroku/libcnb.rs/pull/720))
+  - Containers created by `TestContext::start_container` are now correctly cleaned up if the container failed to start. ([#742](https://github.com/heroku/libcnb.rs/pull/742))
 
 ## [0.15.0] - 2023-09-25
 

--- a/libcnb-test/src/test_context.rs
+++ b/libcnb-test/src/test_context.rs
@@ -106,13 +106,17 @@ impl<'a> TestContext<'a> {
             docker_run_command.expose_port(*port);
         });
 
+        // We create the ContainerContext early to ensure the cleanup in ContainerContext::drop
+        // is still performed even if the Docker command panics.
+        let container_context = ContainerContext {
+            container_name,
+            config: config.clone(),
+        };
+
         util::run_command(docker_run_command)
             .unwrap_or_else(|command_err| panic!("Error starting container:\n\n{command_err}"));
 
-        f(ContainerContext {
-            container_name,
-            config: config.clone(),
-        });
+        f(container_context);
     }
 
     /// Run the provided shell command.


### PR DESCRIPTION
Previously if the container started by `TestContext::start_container` failed to spawn, the container was left behind, since `TestContext::drop` was never run.

Now, the `TestContext` is created prior to the Docker run call, to ensure cleanup still occurs.

Fixes #737.
GUS-W-14504389.