### PR TITLE
Clean up rustdocs about how to run the integration tests

### DIFF
--- a/examples/execd/tests/integration_test.rs
+++ b/examples/execd/tests/integration_test.rs
@@ -1,7 +1,5 @@
-//! Integration tests using libcnb-test.
-//!
-//! All integration tests are skipped by default (using the `ignore` attribute),
-//! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
+//! All integration tests are skipped by default (using the `ignore` attribute)
+//! since performing builds is slow. To run them use: `cargo test -- --ignored`.
 
 // Enable Clippy lints that are disabled by default.
 // https://rust-lang.github.io/rust-clippy/stable/index.html

--- a/examples/ruby-sample/tests/integration_test.rs
+++ b/examples/ruby-sample/tests/integration_test.rs
@@ -1,7 +1,5 @@
-//! Integration tests using libcnb-test.
-//!
-//! All integration tests are skipped by default (using the `ignore` attribute),
-//! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
+//! All integration tests are skipped by default (using the `ignore` attribute)
+//! since performing builds is slow. To run them use: `cargo test -- --ignored`.
 
 // Enable Clippy lints that are disabled by default.
 // https://rust-lang.github.io/rust-clippy/stable/index.html

--- a/libcnb-cargo/tests/integration_test.rs
+++ b/libcnb-cargo/tests/integration_test.rs
@@ -1,3 +1,6 @@
+//! All integration tests are skipped by default (using the `ignore` attribute)
+//! since performing builds is slow. To run them use: `cargo test -- --ignored`.
+
 // Enable Clippy lints that are disabled by default.
 // https://rust-lang.github.io/rust-clippy/stable/index.html
 #![warn(clippy::pedantic)]

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -1,7 +1,5 @@
-//! Integration tests using libcnb-test.
-//!
-//! All integration tests are skipped by default (using the `ignore` attribute),
-//! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
+//! All integration tests are skipped by default (using the `ignore` attribute)
+//! since performing builds is slow. To run them use: `cargo test -- --ignored`.
 //!
 //! When testing panics, prefer using `#[should_panic(expected = "...")]`, unless you need
 //! to test dynamic values, in which case the only option is to use `panic::catch_unwind`

--- a/test-buildpacks/readonly-layer-files/tests/integration_test.rs
+++ b/test-buildpacks/readonly-layer-files/tests/integration_test.rs
@@ -1,7 +1,5 @@
-//! Integration tests using libcnb-test.
-//!
-//! All integration tests are skipped by default (using the `ignore` attribute),
-//! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
+//! All integration tests are skipped by default (using the `ignore` attribute)
+//! since performing builds is slow. To run them use: `cargo test -- --ignored`.
 
 // Enable Clippy lints that are disabled by default.
 // https://rust-lang.github.io/rust-clippy/stable/index.html

--- a/test-buildpacks/sbom/tests/integration_test.rs
+++ b/test-buildpacks/sbom/tests/integration_test.rs
@@ -1,7 +1,5 @@
-//! Integration tests using libcnb-test.
-//!
-//! All integration tests are skipped by default (using the `ignore` attribute),
-//! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
+//! All integration tests are skipped by default (using the `ignore` attribute)
+//! since performing builds is slow. To run them use: `cargo test -- --ignored`.
 
 // Enable Clippy lints that are disabled by default.
 // https://rust-lang.github.io/rust-clippy/stable/index.html

--- a/test-buildpacks/store/tests/integration_test.rs
+++ b/test-buildpacks/store/tests/integration_test.rs
@@ -1,7 +1,5 @@
-//! Integration tests using libcnb-test.
-//!
-//! All integration tests are skipped by default (using the `ignore` attribute),
-//! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
+//! All integration tests are skipped by default (using the `ignore` attribute)
+//! since performing builds is slow. To run them use: `cargo test -- --ignored`.
 
 // Enable Clippy lints that are disabled by default.
 // https://rust-lang.github.io/rust-clippy/stable/index.html


### PR DESCRIPTION
The rustdocs is now based on the wording used for the Python CNB, which has slightly less boilerplate. The docs have also been added to one place where they were missing.