### PR TITLE
Enable the rustc `unreachable_pub` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ edition = "2021"
 license = "BSD-3-Clause"
 
 [workspace.lints.rust]
+unreachable_pub = "warn"
 unsafe_code = "warn"
 unused_crate_dependencies = "warn"
 

--- a/examples/ruby-sample/src/layers/bundler.rs
+++ b/examples/ruby-sample/src/layers/bundler.rs
@@ -15,7 +15,7 @@ pub(crate) struct BundlerLayerMetadata {
 }
 
 pub(crate) struct BundlerLayer {
-    pub ruby_env: Env,
+    pub(crate) ruby_env: Env,
 }
 
 impl Layer for BundlerLayer {

--- a/examples/ruby-sample/src/main.rs
+++ b/examples/ruby-sample/src/main.rs
@@ -67,7 +67,7 @@ impl Buildpack for RubyBuildpack {
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RubyBuildpackMetadata {
-    pub ruby_url: String,
+    pub(crate) ruby_url: String,
 }
 
 #[derive(Debug)]

--- a/libcnb-cargo/src/cli.rs
+++ b/libcnb-cargo/src/cli.rs
@@ -19,16 +19,16 @@ pub(crate) enum LibcnbSubcommand {
 pub(crate) struct PackageArgs {
     /// Disable cross-compile assistance
     #[arg(long)]
-    pub no_cross_compile_assistance: bool,
+    pub(crate) no_cross_compile_assistance: bool,
     /// Build in release mode, with optimizations
     #[arg(long)]
-    pub release: bool,
+    pub(crate) release: bool,
     /// Build for the target triple
     #[arg(long, default_value = "x86_64-unknown-linux-musl")]
-    pub target: String,
+    pub(crate) target: String,
     /// Directory for packaged buildpacks, defaults to 'packaged' in Cargo workspace root
     #[arg(long)]
-    pub package_dir: Option<PathBuf>,
+    pub(crate) package_dir: Option<PathBuf>,
 }
 
 #[cfg(test)]

--- a/libcnb-data/src/buildpack/stack.rs
+++ b/libcnb-data/src/buildpack/stack.rs
@@ -7,9 +7,9 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct StackUnchecked {
-    pub id: String,
+    id: String,
     #[serde(default)]
-    pub mixins: Vec<String>,
+    mixins: Vec<String>,
 }
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -62,10 +62,12 @@ macro_rules! libcnb_newtype {
     ) => {
         #[derive(Debug, Eq, PartialEq, ::serde::Serialize, Clone, Hash)]
         $(#[$type_attributes])*
+        #[allow(unreachable_pub)]
         pub struct $name(String);
 
         #[derive(::thiserror::Error, Debug, Eq, PartialEq)]
         $(#[$error_type_attributes])*
+        #[allow(unreachable_pub)]
         pub enum $error_name {
             InvalidValue(String),
         }
@@ -155,6 +157,7 @@ macro_rules! libcnb_newtype {
             /// can be used by the compile-time validation macro.
             #[must_use]
             #[doc(hidden)]
+            #[allow(unreachable_pub)]
             pub fn new_unchecked(value: &str) -> Self {
                 Self(String::from(value))
             }

--- a/libcnb-test/src/app.rs
+++ b/libcnb-test/src/app.rs
@@ -22,7 +22,7 @@ pub(crate) fn copy_app(app_dir: impl AsRef<Path>) -> Result<AppDir, PrepareAppEr
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum PrepareAppError {
+pub(crate) enum PrepareAppError {
     #[error("Couldn't create temporary directory: {0}")]
     CreateTempDirError(std::io::Error),
     #[error("Couldn't copy directory: {0}")]
@@ -35,7 +35,7 @@ pub(crate) enum AppDir {
 }
 
 impl AppDir {
-    pub fn as_path(&self) -> &Path {
+    pub(crate) fn as_path(&self) -> &Path {
         match self {
             Self::Temporary(temp_dir) => temp_dir.path(),
             Self::Unmanaged(path) => path,

--- a/libcnb-test/src/docker.rs
+++ b/libcnb-test/src/docker.rs
@@ -16,7 +16,7 @@ pub(crate) struct DockerRunCommand {
 }
 
 impl DockerRunCommand {
-    pub fn new(image_name: impl Into<String>, container_name: impl Into<String>) -> Self {
+    pub(crate) fn new(image_name: impl Into<String>, container_name: impl Into<String>) -> Self {
         Self {
             command: None,
             container_name: container_name.into(),
@@ -30,37 +30,40 @@ impl DockerRunCommand {
         }
     }
 
-    pub fn command<I: IntoIterator<Item = S>, S: Into<String>>(&mut self, command: I) -> &mut Self {
+    pub(crate) fn command<I: IntoIterator<Item = S>, S: Into<String>>(
+        &mut self,
+        command: I,
+    ) -> &mut Self {
         self.command = Some(command.into_iter().map(S::into).collect());
         self
     }
 
-    pub fn detach(&mut self, detach: bool) -> &mut Self {
+    pub(crate) fn detach(&mut self, detach: bool) -> &mut Self {
         self.detach = detach;
         self
     }
 
-    pub fn entrypoint(&mut self, entrypoint: impl Into<String>) -> &mut Self {
+    pub(crate) fn entrypoint(&mut self, entrypoint: impl Into<String>) -> &mut Self {
         self.entrypoint = Some(entrypoint.into());
         self
     }
 
-    pub fn env(&mut self, k: impl Into<String>, v: impl Into<String>) -> &mut Self {
+    pub(crate) fn env(&mut self, k: impl Into<String>, v: impl Into<String>) -> &mut Self {
         self.env.insert(k.into(), v.into());
         self
     }
 
-    pub fn expose_port(&mut self, port: u16) -> &mut Self {
+    pub(crate) fn expose_port(&mut self, port: u16) -> &mut Self {
         self.exposed_ports.insert(port);
         self
     }
 
-    pub fn platform(&mut self, platform: impl Into<String>) -> &mut Self {
+    pub(crate) fn platform(&mut self, platform: impl Into<String>) -> &mut Self {
         self.platform = Some(platform.into());
         self
     }
 
-    pub fn remove(&mut self, remove: bool) -> &mut Self {
+    pub(crate) fn remove(&mut self, remove: bool) -> &mut Self {
         self.remove = remove;
         self
     }
@@ -113,7 +116,7 @@ pub(crate) struct DockerExecCommand {
 }
 
 impl DockerExecCommand {
-    pub fn new<I: IntoIterator<Item = S>, S: Into<String>>(
+    pub(crate) fn new<I: IntoIterator<Item = S>, S: Into<String>>(
         container_name: impl Into<String>,
         command: I,
     ) -> Self {
@@ -142,14 +145,14 @@ pub(crate) struct DockerLogsCommand {
 }
 
 impl DockerLogsCommand {
-    pub fn new(container_name: impl Into<String>) -> Self {
+    pub(crate) fn new(container_name: impl Into<String>) -> Self {
         Self {
             container_name: container_name.into(),
             follow: false,
         }
     }
 
-    pub fn follow(&mut self, follow: bool) -> &mut Self {
+    pub(crate) fn follow(&mut self, follow: bool) -> &mut Self {
         self.follow = follow;
         self
     }
@@ -176,7 +179,7 @@ pub(crate) struct DockerPortCommand {
 }
 
 impl DockerPortCommand {
-    pub fn new(container_name: impl Into<String>, port: u16) -> Self {
+    pub(crate) fn new(container_name: impl Into<String>, port: u16) -> Self {
         Self {
             container_name: container_name.into(),
             port,
@@ -204,7 +207,7 @@ pub(crate) struct DockerRemoveContainerCommand {
 }
 
 impl DockerRemoveContainerCommand {
-    pub fn new(container_name: impl Into<String>) -> Self {
+    pub(crate) fn new(container_name: impl Into<String>) -> Self {
         Self {
             container_name: container_name.into(),
             force: true,
@@ -233,7 +236,7 @@ pub(crate) struct DockerRemoveImageCommand {
 }
 
 impl DockerRemoveImageCommand {
-    pub fn new(container_name: impl Into<String>) -> Self {
+    pub(crate) fn new(container_name: impl Into<String>) -> Self {
         Self {
             force: true,
             image_name: container_name.into(),
@@ -262,7 +265,7 @@ pub(crate) struct DockerRemoveVolumeCommand {
 }
 
 impl DockerRemoveVolumeCommand {
-    pub fn new<I: IntoIterator<Item = S>, S: Into<String>>(volume_names: I) -> Self {
+    pub(crate) fn new<I: IntoIterator<Item = S>, S: Into<String>>(volume_names: I) -> Self {
         Self {
             force: true,
             volume_names: volume_names.into_iter().map(S::into).collect(),

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -47,7 +47,7 @@ pub(crate) enum PullPolicy {
 }
 
 impl PackBuildCommand {
-    pub fn new(
+    pub(crate) fn new(
         builder: impl Into<String>,
         path: impl Into<PathBuf>,
         image_name: impl Into<String>,
@@ -68,12 +68,12 @@ impl PackBuildCommand {
         }
     }
 
-    pub fn buildpack(&mut self, b: impl Into<BuildpackReference>) -> &mut Self {
+    pub(crate) fn buildpack(&mut self, b: impl Into<BuildpackReference>) -> &mut Self {
         self.buildpacks.push(b.into());
         self
     }
 
-    pub fn env(&mut self, k: impl Into<String>, v: impl Into<String>) -> &mut Self {
+    pub(crate) fn env(&mut self, k: impl Into<String>, v: impl Into<String>) -> &mut Self {
         self.env.insert(k.into(), v.into());
         self
     }
@@ -138,14 +138,14 @@ pub(crate) struct PackSbomDownloadCommand {
 
 /// Represents a `pack sbom download` command.
 impl PackSbomDownloadCommand {
-    pub fn new(image_name: impl Into<String>) -> Self {
+    pub(crate) fn new(image_name: impl Into<String>) -> Self {
         Self {
             image_name: image_name.into(),
             output_dir: None,
         }
     }
 
-    pub fn output_dir(&mut self, output_dir: impl Into<PathBuf>) -> &mut Self {
+    pub(crate) fn output_dir(&mut self, output_dir: impl Into<PathBuf>) -> &mut Self {
         self.output_dir = Some(output_dir.into());
         self
     }

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -233,7 +233,7 @@ pub fn libcnb_runtime_build<B: Buildpack>(
 // supported spec version.
 #[derive(Deserialize)]
 struct BuildpackDescriptorApiOnly {
-    pub api: BuildpackApi,
+    api: BuildpackApi,
 }
 
 #[doc(hidden)]

--- a/test-buildpacks/readonly-layer-files/src/layer.rs
+++ b/test-buildpacks/readonly-layer-files/src/layer.rs
@@ -9,7 +9,7 @@ use std::fs::Permissions;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
-pub struct TestLayer;
+pub(crate) struct TestLayer;
 
 impl Layer for TestLayer {
     type Buildpack = TestBuildpack;

--- a/test-buildpacks/readonly-layer-files/src/main.rs
+++ b/test-buildpacks/readonly-layer-files/src/main.rs
@@ -12,7 +12,7 @@ use std::io::Error;
 #[cfg(test)]
 use libcnb_test as _;
 
-pub struct TestBuildpack;
+pub(crate) struct TestBuildpack;
 
 impl Buildpack for TestBuildpack {
     type Platform = GenericPlatform;
@@ -30,7 +30,7 @@ impl Buildpack for TestBuildpack {
 }
 
 #[derive(Debug)]
-pub enum TestBuildpackError {
+pub(crate) enum TestBuildpackError {
     IOError(std::io::Error),
 }
 

--- a/test-buildpacks/sbom/src/main.rs
+++ b/test-buildpacks/sbom/src/main.rs
@@ -16,7 +16,7 @@ use std::io::Error;
 #[cfg(test)]
 use libcnb_test as _;
 
-pub struct TestBuildpack;
+pub(crate) struct TestBuildpack;
 
 impl Buildpack for TestBuildpack {
     type Platform = GenericPlatform;
@@ -61,7 +61,7 @@ impl Buildpack for TestBuildpack {
 }
 
 #[derive(Debug)]
-pub enum TestBuildpackError {
+pub(crate) enum TestBuildpackError {
     IOError(std::io::Error),
 }
 

--- a/test-buildpacks/sbom/src/test_layer.rs
+++ b/test-buildpacks/sbom/src/test_layer.rs
@@ -7,7 +7,7 @@ use libcnb::sbom::Sbom;
 use libcnb::Buildpack;
 use std::path::Path;
 
-pub struct TestLayer;
+pub(crate) struct TestLayer;
 
 impl Layer for TestLayer {
     type Buildpack = TestBuildpack;

--- a/test-buildpacks/sbom/src/test_layer_2.rs
+++ b/test-buildpacks/sbom/src/test_layer_2.rs
@@ -7,7 +7,7 @@ use libcnb::sbom::Sbom;
 use libcnb::Buildpack;
 use std::path::Path;
 
-pub struct TestLayer2;
+pub(crate) struct TestLayer2;
 
 impl Layer for TestLayer2 {
     type Buildpack = TestBuildpack;

--- a/test-buildpacks/store/src/main.rs
+++ b/test-buildpacks/store/src/main.rs
@@ -10,7 +10,7 @@ use toml::toml;
 #[cfg(test)]
 use libcnb_test as _;
 
-pub struct TestBuildpack;
+pub(crate) struct TestBuildpack;
 
 impl Buildpack for TestBuildpack {
     type Platform = GenericPlatform;
@@ -35,7 +35,7 @@ impl Buildpack for TestBuildpack {
 }
 
 #[derive(Debug)]
-pub enum TestBuildpackError {
+pub(crate) enum TestBuildpackError {
     IOError(std::io::Error),
 }
 


### PR DESCRIPTION
This lint enforces more explicit/correct use of `pub` vs `pub(crate)` for transitive types/fields/...

The majority of these changes were generated by `cargo clippy --fix`.

See:
https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unreachable-pub