### PR TITLE
Enable the rustc `unsafe_code` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ edition = "2021"
 license = "BSD-3-Clause"
 
 [workspace.lints.rust]
+unsafe_code = "warn"
 unused_crate_dependencies = "warn"
 
 [workspace.lints.clippy]

--- a/libcnb/src/exec_d.rs
+++ b/libcnb/src/exec_d.rs
@@ -24,6 +24,7 @@ pub fn write_exec_d_program_output<O: Into<ExecDProgramOutput>>(o: O) {
         // actually mapped to something. Since we're implementing the CNB spec and it explicitly
         // tells us to write to that file descriptor, this is safe to do without additional
         // validation in this context.
+        #[allow(unsafe_code)]
         let output_file = unsafe { File::from_raw_fd(3) };
 
         let serialized_output = toml::to_string(&o.into())


### PR DESCRIPTION
To help make any usages of unsafe more obvious, since they will now require the addition of an `allow` attribute (and ideally an explaining comment).

See:
https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unsafe-code