### PR TITLE
Simplify Cargo.toml for crates that are not published

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 
 [workspace.package]
 version = "0.17.0"
-rust-version = "1.74"
+rust-version = "1.75"
 edition = "2021"
 license = "BSD-3-Clause"
 

--- a/examples/basics/Cargo.toml
+++ b/examples/basics/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "examples-basics"
-version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
-publish = false
 
 [lints]
 workspace = true

--- a/examples/execd/Cargo.toml
+++ b/examples/execd/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "examples-execd"
-version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
-publish = false
 
 [lints]
 workspace = true

--- a/libcnb-cargo/tests/fixtures/multiple_buildpacks/Cargo.toml
+++ b/libcnb-cargo/tests/fixtures/multiple_buildpacks/Cargo.toml
@@ -3,6 +3,3 @@ members = [
     "buildpacks/one",
     "buildpacks/two"
 ]
-
-[workspace.package]
-version = "0.0.0"

--- a/libcnb-cargo/tests/fixtures/multiple_buildpacks/buildpacks/one/Cargo.toml
+++ b/libcnb-cargo/tests/fixtures/multiple_buildpacks/buildpacks/one/Cargo.toml
@@ -1,3 +1,2 @@
 [package]
 name = "one"
-version = "0.0.0"

--- a/libcnb-cargo/tests/fixtures/multiple_buildpacks/buildpacks/two/Cargo.toml
+++ b/libcnb-cargo/tests/fixtures/multiple_buildpacks/buildpacks/two/Cargo.toml
@@ -1,3 +1,2 @@
 [package]
 name = "two"
-version = "0.0.0"

--- a/libcnb-cargo/tests/fixtures/no_buildpacks/Cargo.toml
+++ b/libcnb-cargo/tests/fixtures/no_buildpacks/Cargo.toml
@@ -2,6 +2,3 @@
 members = [
     "not_a_buildpack"
 ]
-
-[workspace.package]
-version = "0.0.0"

--- a/libcnb-cargo/tests/fixtures/no_buildpacks/not_a_buildpack/Cargo.toml
+++ b/libcnb-cargo/tests/fixtures/no_buildpacks/not_a_buildpack/Cargo.toml
@@ -1,3 +1,2 @@
 [package]
 name = "not_a_buildpack"
-version = "0.0.0"

--- a/libcnb-cargo/tests/fixtures/single_buildpack/Cargo.toml
+++ b/libcnb-cargo/tests/fixtures/single_buildpack/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
 name = "single_buildpack"
-version = "0.0.0"
 
 [workspace]

--- a/libcnb-test/tests/fixtures/buildpacks/compile-error/Cargo.toml
+++ b/libcnb-test/tests/fixtures/buildpacks/compile-error/Cargo.toml
@@ -1,6 +1,4 @@
 [package]
 name = "compile-error"
-version = "0.0.0"
-publish = false
 
 [workspace]

--- a/libcnb-test/tests/fixtures/buildpacks/component-a/Cargo.toml
+++ b/libcnb-test/tests/fixtures/buildpacks/component-a/Cargo.toml
@@ -1,6 +1,4 @@
 [package]
 name = "component-a"
-version = "0.0.0"
-publish = false
 
 [workspace]

--- a/libcnb-test/tests/fixtures/buildpacks/component-b/Cargo.toml
+++ b/libcnb-test/tests/fixtures/buildpacks/component-b/Cargo.toml
@@ -1,6 +1,4 @@
 [package]
 name = "component-b"
-version = "0.0.0"
-publish = false
 
 [workspace]

--- a/test-buildpacks/readonly-layer-files/Cargo.toml
+++ b/test-buildpacks/readonly-layer-files/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "readonly-layer-files"
-version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
-publish = false
 
 [lints]
 workspace = true

--- a/test-buildpacks/sbom/Cargo.toml
+++ b/test-buildpacks/sbom/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "sbom"
-version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
-publish = false
 
 [lints]
 workspace = true

--- a/test-buildpacks/store/Cargo.toml
+++ b/test-buildpacks/store/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "store"
-version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
-publish = false
 
 [lints]
 workspace = true

--- a/test-buildpacks/tracing/Cargo.toml
+++ b/test-buildpacks/tracing/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "tracing"
-version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
-publish = false
 
 [lints]
 workspace = true


### PR DESCRIPTION
As of Cargo 1.75 the `version` property in `Cargo.toml` is now optional, and if omitted is the same as having specified `version = "0.0.0"` and `publish = false`:
https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-175-2023-12-28

Therefore for crates that we do not publish, we can now remove both the `version` and `publish` properties, avoiding the need for the fake `0.0.0` version that differs from the actual buildpack version in `buildpack.toml`.

GUS-W-14821120.