### PR TITLE
Fix compile warnings when `trace` feature is disabled

### DIFF
--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -132,10 +132,14 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
     #[cfg(feature = "trace")]
     let mut trace = start_trace(&buildpack_descriptor.buildpack, "detect");
 
+    #[cfg(feature = "trace")]
     let mut trace_error = |err: &dyn std::error::Error| {
-        #[cfg(feature = "trace")]
         trace.set_error(err);
     };
+
+    #[cfg(not(feature = "trace"))]
+    let trace_error = |_: &dyn std::error::Error| {};
+
     let stack_id: StackId = env::var("CNB_STACK_ID")
         .map_err(Error::CannotDetermineStackId)
         .and_then(|stack_id_string| stack_id_string.parse().map_err(Error::StackIdError))
@@ -190,6 +194,7 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
 ///
 /// Exposed only to allow for advanced use-cases where build is programmatically invoked.
 #[doc(hidden)]
+#[allow(clippy::too_many_lines)]
 pub fn libcnb_runtime_build<B: Buildpack>(
     buildpack: &B,
     args: BuildArgs,
@@ -206,10 +211,13 @@ pub fn libcnb_runtime_build<B: Buildpack>(
     #[cfg(feature = "trace")]
     let mut trace = start_trace(&buildpack_descriptor.buildpack, "build");
 
+    #[cfg(feature = "trace")]
     let mut trace_error = |err: &dyn std::error::Error| {
-        #[cfg(feature = "trace")]
         trace.set_error(err);
     };
+
+    #[cfg(not(feature = "trace"))]
+    let trace_error = |_: &dyn std::error::Error| {};
 
     let stack_id: StackId = env::var("CNB_STACK_ID")
         .map_err(Error::CannotDetermineStackId)


### PR DESCRIPTION
When the `trace` feature is disabled, several warnings will be emitted during compilation. These warnings started to appear after #723 was merged.

```
warning: unused variable: `err`
   --> libcnb/src/runtime.rs:135:28
    |
135 |     let mut trace_error = |err: &dyn std::error::Error| {
    |                            ^^^ help: if this is intentional, prefix it with an underscore: `_err`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: variable does not need to be mutable
   --> libcnb/src/runtime.rs:135:9
    |
135 |     let mut trace_error = |err: &dyn std::error::Error| {
    |         ----^^^^^^^^^^^
    |         |
    |         help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default

warning: unused variable: `err`
   --> libcnb/src/runtime.rs:209:28
    |
209 |     let mut trace_error = |err: &dyn std::error::Error| {
    |                            ^^^ help: if this is intentional, prefix it with an underscore: `_err`

warning: variable does not need to be mutable
   --> libcnb/src/runtime.rs:209:9
    |
209 |     let mut trace_error = |err: &dyn std::error::Error| {
    |         ----^^^^^^^^^^^
    |         |
    |         help: remove this `mut`

warning: `libcnb` (lib) generated 4 warnings (run `cargo fix --lib -p libcnb` to apply 4 suggestions)
```

This PR fixes those.