### PR TITLE
Refactor cross compile assistance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `libcnb`:
   - Changed `Layer` interface from `&self` to `&mut self`. ([#669](https://github.com/heroku/libcnb.rs/pull/669))
+- `libcnb-package`:
+  - Improved the consistency of cross-compilation assistance provided across all supported `target_triple` and host OS/architecture combinations. [#769](https://github.com/heroku/libcnb.rs/pull/769)
 
 ### Added
 
 - `libherokubuildpack`:
   - `MappedWrite::unwrap` for getting the wrapped `Write` back out. ([#765](https://github.com/heroku/libcnb.rs/pull/765))
+- `libcnb-package`:
+  - Added cross-compilation assistance for `aarch64-unknown-linux-musl` (on macOS and ARM64 Linux) and `x86_64-unknown-linux-musl` (on ARM64 Linux). [#769](https://github.com/heroku/libcnb.rs/pull/769)
 
 ## [0.17.0] - 2023-12-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved the consistency of cross-compilation assistance provided across all supported `target_triple` and host OS/architecture combinations. [#769](https://github.com/heroku/libcnb.rs/pull/769)
+- Added cross-compilation assistance for `aarch64-unknown-linux-musl` (on macOS and ARM64 Linux) and `x86_64-unknown-linux-musl` (on ARM64 Linux). [#769](https://github.com/heroku/libcnb.rs/pull/769)
 - `libcnb`:
   - Changed `Layer` interface from `&self` to `&mut self`. ([#669](https://github.com/heroku/libcnb.rs/pull/669))
-- `libcnb-package`:
-  - Improved the consistency of cross-compilation assistance provided across all supported `target_triple` and host OS/architecture combinations. [#769](https://github.com/heroku/libcnb.rs/pull/769)
 
 ### Added
 
 - `libherokubuildpack`:
   - `MappedWrite::unwrap` for getting the wrapped `Write` back out. ([#765](https://github.com/heroku/libcnb.rs/pull/765))
-- `libcnb-package`:
-  - Added cross-compilation assistance for `aarch64-unknown-linux-musl` (on macOS and ARM64 Linux) and `x86_64-unknown-linux-musl` (on ARM64 Linux). [#769](https://github.com/heroku/libcnb.rs/pull/769)
 
 ## [0.17.0] - 2023-12-06
 

--- a/libcnb-package/Cargo.toml
+++ b/libcnb-package/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 [dependencies]
 cargo_metadata = "0.18.1"
 ignore = "0.4"
+indoc = "2.0.4"
 libcnb-common.workspace = true
 libcnb-data.workspace = true
 petgraph = { version = "0.6.4", default-features = false }

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -64,7 +64,7 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
         }
         Err(_) => CrossCompileAssistance::HelpText(format!(
             r"For cross-compilation from {0} {1} to {target}, a C compiler and
-linker for the target platform must be installed on your computer:
+linker for the target platform must be installed:
 
 {help_text}
             

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -12,23 +12,23 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
     let (gcc_path, help_text) = match (target, consts::OS, consts::ARCH) {
         (AARCH64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_X86_64) => (
             "aarch64-linux-gnu-gcc",
-            "Install aarch64 cross-compiler:\nsudo apt-get install g++-aarch64-linux-gnu",
+            "To install an aarch64 cross-compiler on Ubuntu:\nsudo apt-get install g++-aarch64-linux-gnu",
         ),
         (AARCH64_UNKNOWN_LINUX_MUSL, OS_MACOS, _) => (
             "aarch64-unknown-linux-musl-gcc",
-            "Install aarch64 cross-compiler on macOS:\nbrew install messense/macos-cross-toolchains/aarch64-unknown-linux-musl",
+            "To install an aarch64 cross-compiler on macOS:\nbrew install messense/macos-cross-toolchains/aarch64-unknown-linux-musl",
         ),
         (AARCH64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_AARCH64) | (X86_64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_X86_64) => (
             "musl-gcc",
-            "Install musl-tools:\nsudo apt-get install musl-tools",
+            "To install musl-tools on Ubuntu:\nsudo apt-get install musl-tools",
         ),
         (X86_64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_AARCH64) => (
             "x86_64-linux-gnu-gcc",
-            "Install x86_64 cross-compiler:\nsudo apt-get install g++-x86_64-linux-gnu",
+            "To install an x86_64 cross-compiler on Ubuntu:\nsudo apt-get install g++-x86_64-linux-gnu",
         ),
         (X86_64_UNKNOWN_LINUX_MUSL, OS_MACOS, _) => (
             "x86_64-unknown-linux-musl-gcc",
-            "Install x86_64 cross-compiler on macOS:\nbrew install messense/macos-cross-toolchains/x86_64-unknown-linux-musl",
+            "To install an x86_64 cross-compiler on macOS:\nbrew install messense/macos-cross-toolchains/x86_64-unknown-linux-musl",
         ),
         _ => return CrossCompileAssistance::NoAssistance,
     };

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -52,6 +52,8 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
 
     match which(gcc_path) {
         Ok(_) => {
+            // When the gcc binary is `musl-gcc`, Cargo will automatically select the appropriate default linker,
+            // and set the required environment variables.
             if gcc_path == "musl-gcc" {
                 CrossCompileAssistance::Configuration {
                     cargo_env: Vec::new(),

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -15,7 +15,7 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
             "aarch64-linux-gnu-gcc",
             indoc! {"
                 To install an aarch64 cross-compiler on Ubuntu:
-                sudo apt-get install g++-aarch64-linux-gnu
+                sudo apt-get install g++-aarch64-linux-gnu libc6-dev-arm64-cross musl-tools
             "},
         ),
         (AARCH64_UNKNOWN_LINUX_MUSL, OS_MACOS, ARCH_X86_64 | ARCH_AARCH64) => (

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -48,25 +48,26 @@ fn generate_assistance(
                     cargo_env: Vec::new(),
                 }
             } else {
-                let cargo_env = vec![
-                    (
-                        // Required until Cargo can auto-detect the musl-cross gcc/linker itself,
-                        // since otherwise it checks for a binary named 'musl-gcc' (which is handled above):
-                        // https://github.com/rust-lang/cargo/issues/4133
-                        OsString::from(format!(
-                            "CARGO_TARGET_{}_LINKER",
-                            target_triple.to_uppercase().replace('-', "_")
-                        )),
-                        OsString::from(gcc_path),
-                    ),
-                    (
-                        // Required so that any crates that call out to gcc are also cross-compiled:
-                        // https://github.com/alexcrichton/cc-rs/issues/82
-                        OsString::from(format!("CC_{target_triple}")),
-                        OsString::from(gcc_path),
-                    ),
-                ];
-                CrossCompileAssistance::Configuration { cargo_env }
+                CrossCompileAssistance::Configuration {
+                    cargo_env: vec![
+                        (
+                            // Required until Cargo can auto-detect the musl-cross gcc/linker itself,
+                            // since otherwise it checks for a binary named 'musl-gcc' (which is handled above):
+                            // https://github.com/rust-lang/cargo/issues/4133
+                            OsString::from(format!(
+                                "CARGO_TARGET_{}_LINKER",
+                                target_triple.to_uppercase().replace('-', "_")
+                            )),
+                            OsString::from(gcc_path),
+                        ),
+                        (
+                            // Required so that any crates that call out to gcc are also cross-compiled:
+                            // https://github.com/alexcrichton/cc-rs/issues/82
+                            OsString::from(format!("CC_{target_triple}")),
+                            OsString::from(gcc_path),
+                        ),
+                    ],
+                }
             }
         }
     }

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -10,7 +10,7 @@ use which::which;
 /// any other issue has been detected.
 pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileAssistance {
     let target_triple = target_triple.as_ref();
-    let (gcc_path, help_text) = match (target_triple, consts::OS, consts::ARCH) {
+    let (gcc_binary_name, help_text) = match (target_triple, consts::OS, consts::ARCH) {
         (AARCH64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_X86_64) => (
             "aarch64-linux-gnu-gcc",
             indoc! {"
@@ -50,11 +50,11 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
         _ => return CrossCompileAssistance::NoAssistance,
     };
 
-    match which(gcc_path) {
+    match which(gcc_binary_name) {
         Ok(_) => {
-            // When the gcc binary is `musl-gcc`, Cargo will automatically select the appropriate default linker,
+            // When the gcc binary name is `musl-gcc`, Cargo will automatically select the appropriate default linker,
             // and set the required environment variables.
-            if gcc_path == "musl-gcc" {
+            if gcc_binary_name == "musl-gcc" {
                 CrossCompileAssistance::Configuration {
                     cargo_env: Vec::new(),
                 }
@@ -69,13 +69,13 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
                                 "CARGO_TARGET_{}_LINKER",
                                 target_triple.to_uppercase().replace('-', "_")
                             )),
-                            OsString::from(gcc_path),
+                            OsString::from(gcc_binary_name),
                         ),
                         (
                             // Required so that any crates that call out to gcc are also cross-compiled:
                             // https://github.com/alexcrichton/cc-rs/issues/82
                             OsString::from(format!("CC_{}", target_triple.replace('-', "_"))),
-                            OsString::from(gcc_path),
+                            OsString::from(gcc_binary_name),
                         ),
                     ],
                 }

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -1,4 +1,4 @@
-use indoc::indoc;
+use indoc::{formatdoc, indoc};
 use std::env::consts;
 use std::ffi::OsString;
 use which::which;
@@ -79,7 +79,7 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
                 }
             }
         }
-        Err(_) => CrossCompileAssistance::HelpText(format!(
+        Err(_) => CrossCompileAssistance::HelpText(formatdoc! {
             r"For cross-compilation from {0} {1} to {target_triple}, a C compiler and
 linker for the target platform must be installed:
 
@@ -89,7 +89,7 @@ You will also need to install the Rust target:
 rustup target add {target_triple}",
             consts::ARCH,
             consts::OS
-        )),
+        }),
     }
 }
 

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -40,11 +40,6 @@ fn generate_assistance(
     help_text: &str,
     target_triple: &str,
 ) -> CrossCompileAssistance {
-    let cargo_target_linker_var = format!(
-        "CARGO_TARGET_{}_LINKER",
-        target_triple.to_uppercase().replace('-', "_")
-    );
-
     if which(gcc_path).is_err() {
         CrossCompileAssistance::HelpText(help_text.to_string())
     } else if gcc_path == "musl-gcc" {
@@ -57,7 +52,10 @@ fn generate_assistance(
                 // Required until Cargo can auto-detect the musl-cross gcc/linker itself,
                 // since otherwise it checks for a binary named 'musl-gcc' (which is handled above):
                 // https://github.com/rust-lang/cargo/issues/4133
-                OsString::from(cargo_target_linker_var),
+                OsString::from(format!(
+                    "CARGO_TARGET_{}_LINKER",
+                    target_triple.to_uppercase().replace('-', "_")
+                )),
                 OsString::from(gcc_path),
             ),
             (

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -1,3 +1,4 @@
+use std::env::consts;
 use std::ffi::OsString;
 use which::which;
 
@@ -7,95 +8,66 @@ use which::which;
 /// look for the required tools and returns a human-readable help text if they can't be found or
 /// any other issue has been detected.
 pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileAssistance {
-    // Background: https://omarkhawaja.com/cross-compiling-rust-from-macos-to-linux/
-    if target_triple.as_ref() == X86_64_UNKNOWN_LINUX_MUSL && cfg!(target_os = "macos") {
-        // There is more than just one binary name here since we also support the binary name for
-        // an older version cross_compile_assistance which suggested installing a different
-        // toolchain.
-        let possible_gcc_binary_names = ["x86_64-unknown-linux-musl-gcc", "x86_64-linux-musl-gcc"];
+    let target = target_triple.as_ref();
+    let (gcc_path, help_text) = match (target, consts::OS, consts::ARCH) {
+        (AARCH64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_X86_64) => (
+            "aarch64-linux-gnu-gcc",
+            "Install aarch64 cross-compiler:\nsudo apt-get install g++-aarch64-linux-gnu",
+        ),
+        (AARCH64_UNKNOWN_LINUX_MUSL, OS_MACOS, _) => (
+            "aarch64-unknown-linux-musl-gcc",
+            "Install aarch64 cross-compiler on macOS:\nbrew install messense/macos-cross-toolchains/aarch64-unknown-linux-musl",
+        ),
+        (AARCH64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_AARCH64) | (X86_64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_X86_64) => (
+            "musl-gcc",
+            "Install musl-tools:\nsudo apt-get install musl-tools",
+        ),
+        (X86_64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_AARCH64) => (
+            "x86_64-linux-gnu-gcc",
+            "Install x86_64 cross-compiler:\nsudo apt-get install g++-x86_64-linux-gnu",
+        ),
+        (X86_64_UNKNOWN_LINUX_MUSL, OS_MACOS, _) => (
+            "x86_64-unknown-linux-musl-gcc",
+            "Install x86_64 cross-compiler on macOS:\nbrew install messense/macos-cross-toolchains/x86_64-unknown-linux-musl",
+        ),
+        _ => return CrossCompileAssistance::NoAssistance,
+        };
+    generate_assistance(gcc_path, help_text, target)
+}
 
-        possible_gcc_binary_names
-            .iter()
-            .find_map(|binary_name| which(binary_name).ok())
-            .map_or_else(|| CrossCompileAssistance::HelpText(String::from(
-                r"For cross-compilation from macOS to x86_64-unknown-linux-musl, a C compiler and
-linker for the target platform must be installed on your computer.
+fn generate_assistance(
+    gcc_path: &str,
+    help_text: &str,
+    target_triple: &str,
+) -> CrossCompileAssistance {
+    let cargo_target_linker_var = format!(
+        "CARGO_TARGET_{}_LINKER",
+        target_triple.to_uppercase().replace('-', "_")
+    );
 
-The easiest way to install the required cross-compilation toolchain is to run:
-brew install messense/macos-cross-toolchains/x86_64-unknown-linux-musl
-
-For more information, see:
-https://github.com/messense/homebrew-macos-cross-toolchains
-
-You will also need to install the Rust target, using:
-rustup target add x86_64-unknown-linux-musl",
-            )), |gcc_binary_path| {
-                CrossCompileAssistance::Configuration {
-                    cargo_env: vec![
-                        (
-                            // Required until Cargo can auto-detect the musl-cross gcc/linker itself,
-                            // since otherwise it checks for a binary named 'musl-gcc':
-                            // https://github.com/FiloSottile/homebrew-musl-cross/issues/16
-                            // https://github.com/rust-lang/cargo/issues/4133
-                            OsString::from("CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER"),
-                            OsString::from(&gcc_binary_path),
-                        ),
-                        (
-                            // Required so that any crates that call out to gcc are also cross-compiled:
-                            // https://github.com/alexcrichton/cc-rs/issues/82
-                            OsString::from("CC_x86_64_unknown_linux_musl"),
-                            OsString::from(&gcc_binary_path),
-                        ),
-                    ],
-                }
-            })
-    } else if target_triple.as_ref() == X86_64_UNKNOWN_LINUX_MUSL && cfg!(target_os = "linux") {
-        match which("musl-gcc") {
-            Ok(_) => CrossCompileAssistance::Configuration {
-                cargo_env: Vec::new(),
-            },
-            Err(_) => CrossCompileAssistance::HelpText(String::from(
-                r"For cross-compilation from Linux to x86_64-unknown-linux-musl, a C compiler and
-linker for the target platform must be installed on your computer.
-
-The easiest way to install 'musl-gcc' is to install the 'musl-tools' package:
-- https://packages.ubuntu.com/focal/musl-tools
-- https://packages.debian.org/bullseye/musl-tools
-
-You will also need to install the Rust target, using:
-rustup target add x86_64-unknown-linux-musl",
-            )),
-        }
-    } else if target_triple.as_ref() == AARCH64_UNKNOWN_LINUX_MUSL && cfg!(target_os = "linux") {
-        let gcc_binary_path = "aarch64-linux-gnu-gcc";
-        match which(gcc_binary_path) {
-            Ok(_) => CrossCompileAssistance::Configuration {
-                cargo_env: vec![
-                    (
-                        OsString::from("CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER"),
-                        OsString::from(gcc_binary_path),
-                    ),
-                    (
-                        OsString::from("CC_aarch64_unknown_linux_musl"),
-                        OsString::from(gcc_binary_path),
-                    ),
-                ],
-            },
-            Err(_) => CrossCompileAssistance::HelpText(String::from(
-                r"For cross-compilation from Linux to aarch64-unknown-linux-musl, a C compiler and
-linker for the target platform must installed on your computer.
-
-The easiest way to install the 'g++-aarch64-linux-gnu', 'libc6-dev-arm64-cross', and 'musl-tools' packages:
-- https://packages.ubuntu.com/focal/g++-aarch64-linux-gnu
-- https://packages.ubuntu.com/focal/musl-tools
-- https://packages.ubuntu.com/focal/libc6-dev-arm64-cross
-
-You will also need to install the Rust target, using:
-rustup target add aarch64-unknown-linux-musl",
-            )),
+    if which(gcc_path).is_err() {
+        CrossCompileAssistance::HelpText(help_text.to_string())
+    } else if gcc_path == "musl-gcc" {
+        CrossCompileAssistance::Configuration {
+            cargo_env: Vec::new(),
         }
     } else {
-        CrossCompileAssistance::NoAssistance
+        let cargo_env = vec![
+            (
+                // Required until Cargo can auto-detect the musl-cross gcc/linker itself,
+                // since otherwise it checks for a binary named 'musl-gcc' (which is handled above):
+                // https://github.com/rust-lang/cargo/issues/4133
+                OsString::from(cargo_target_linker_var),
+                OsString::from(gcc_path),
+            ),
+            (
+                // Required so that any crates that call out to gcc are also cross-compiled:
+                // https://github.com/alexcrichton/cc-rs/issues/82
+                OsString::from(format!("CC_{target_triple}")),
+                OsString::from(gcc_path),
+            ),
+        ];
+        CrossCompileAssistance::Configuration { cargo_env }
     }
 }
 
@@ -111,5 +83,12 @@ pub enum CrossCompileAssistance {
     },
 }
 
+// Constants for supported target triples
 const AARCH64_UNKNOWN_LINUX_MUSL: &str = "aarch64-unknown-linux-musl";
 const X86_64_UNKNOWN_LINUX_MUSL: &str = "x86_64-unknown-linux-musl";
+
+// Constants for OS and ARCH
+const OS_LINUX: &str = "linux";
+const OS_MACOS: &str = "macos";
+const ARCH_X86_64: &str = "x86_64";
+const ARCH_AARCH64: &str = "aarch64";

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -82,8 +82,8 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
             }
         }
         Err(_) => CrossCompileAssistance::HelpText(formatdoc! {"
-            For cross-compilation from {0} {1} to {target_triple}, a C compiler and
-            linker for the target platform must be installed:
+            For cross-compilation from {0} {1} to {target_triple},
+            a C compiler and linker for the target platform must be installed:
 
             {help_text}
             You will also need to install the Rust target:

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -37,7 +37,7 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
             "x86_64-linux-gnu-gcc",
             indoc! {"
                 To install an x86_64 cross-compiler on Ubuntu:
-                sudo apt-get install g++-x86-64-linux-gnu
+                sudo apt-get install g++-x86-64-linux-gnu libc6-dev-amd64-cross musl-tools
             "},
         ),
         (X86_64_UNKNOWN_LINUX_MUSL, OS_MACOS, ARCH_X86_64 | ARCH_AARCH64) => (

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -81,7 +81,7 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
                 }
             }
         }
-        Err(_) => CrossCompileAssistance::HelpText(formatdoc! {r"
+        Err(_) => CrossCompileAssistance::HelpText(formatdoc! {"
             For cross-compilation from {0} {1} to {target_triple}, a C compiler and
             linker for the target platform must be installed:
 

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -92,7 +92,7 @@ pub enum CrossCompileAssistance {
 const AARCH64_UNKNOWN_LINUX_MUSL: &str = "aarch64-unknown-linux-musl";
 const X86_64_UNKNOWN_LINUX_MUSL: &str = "x86_64-unknown-linux-musl";
 
-// Constants for OS and ARCH
+// Constants for `std::env::consts::OS` and `std::env::consts::ARCH`
 const OS_LINUX: &str = "linux";
 const OS_MACOS: &str = "macos";
 const ARCH_X86_64: &str = "x86_64";

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -79,14 +79,15 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
                 }
             }
         }
-        Err(_) => CrossCompileAssistance::HelpText(formatdoc! {
-            r"For cross-compilation from {0} {1} to {target_triple}, a C compiler and
-linker for the target platform must be installed:
+        Err(_) => CrossCompileAssistance::HelpText(formatdoc! {r"
+            For cross-compilation from {0} {1} to {target_triple}, a C compiler and
+            linker for the target platform must be installed:
 
-{help_text}
-            
-You will also need to install the Rust target:
-rustup target add {target_triple}",
+            {help_text}
+
+            You will also need to install the Rust target:
+            rustup target add {target_triple}
+            ",
             consts::ARCH,
             consts::OS
         }),

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -55,7 +55,7 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
                         (
                             // Required so that any crates that call out to gcc are also cross-compiled:
                             // https://github.com/alexcrichton/cc-rs/issues/82
-                            OsString::from(format!("CC_{target}")),
+                            OsString::from(format!("CC_{}", target.replace('-', "_"))),
                             OsString::from(gcc_path),
                         ),
                     ],

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -86,7 +86,6 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
             linker for the target platform must be installed:
 
             {help_text}
-
             You will also need to install the Rust target:
             rustup target add {target_triple}
             ",

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -31,15 +31,8 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
             "Install x86_64 cross-compiler on macOS:\nbrew install messense/macos-cross-toolchains/x86_64-unknown-linux-musl",
         ),
         _ => return CrossCompileAssistance::NoAssistance,
-        };
-    generate_assistance(gcc_path, help_text, target)
-}
+    };
 
-fn generate_assistance(
-    gcc_path: &str,
-    help_text: &str,
-    target_triple: &str,
-) -> CrossCompileAssistance {
     match which(gcc_path) {
         Ok(_) => {
             if gcc_path == "musl-gcc" {
@@ -55,14 +48,14 @@ fn generate_assistance(
                             // https://github.com/rust-lang/cargo/issues/4133
                             OsString::from(format!(
                                 "CARGO_TARGET_{}_LINKER",
-                                target_triple.to_uppercase().replace('-', "_")
+                                target.to_uppercase().replace('-', "_")
                             )),
                             OsString::from(gcc_path),
                         ),
                         (
                             // Required so that any crates that call out to gcc are also cross-compiled:
                             // https://github.com/alexcrichton/cc-rs/issues/82
-                            OsString::from(format!("CC_{target_triple}")),
+                            OsString::from(format!("CC_{target}")),
                             OsString::from(gcc_path),
                         ),
                     ],
@@ -72,6 +65,7 @@ fn generate_assistance(
         Err(_) => CrossCompileAssistance::HelpText(help_text.to_string()),
     }
 }
+
 pub enum CrossCompileAssistance {
     /// No specific assistance available for the current host and target platform combination.
     NoAssistance,

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -1,3 +1,4 @@
+use indoc::indoc;
 use std::env::consts;
 use std::ffi::OsString;
 use which::which;
@@ -12,24 +13,39 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
     let (gcc_path, help_text) = match (target_triple, consts::OS, consts::ARCH) {
         (AARCH64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_X86_64) => (
             "aarch64-linux-gnu-gcc",
-            "To install an aarch64 cross-compiler on Ubuntu:\nsudo apt-get install g++-aarch64-linux-gnu",
+            indoc! {"
+                To install an aarch64 cross-compiler on Ubuntu:
+                sudo apt-get install g++-aarch64-linux-gnu
+            "},
         ),
         (AARCH64_UNKNOWN_LINUX_MUSL, OS_MACOS, ARCH_X86_64 | ARCH_AARCH64) => (
             "aarch64-unknown-linux-musl-gcc",
-            "To install an aarch64 cross-compiler on macOS:\nbrew install messense/macos-cross-toolchains/aarch64-unknown-linux-musl",
+            indoc! {"
+                To install an aarch64 cross-compiler on macOS:
+                brew install messense/macos-cross-toolchains/aarch64-unknown-linux-musl
+            "},
         ),
         (AARCH64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_AARCH64)
         | (X86_64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_X86_64) => (
             "musl-gcc",
-            "To install musl-tools on Ubuntu:\nsudo apt-get install musl-tools",
+            indoc! {"
+                To install musl-tools on Ubuntu:
+                sudo apt-get install musl-tools
+            "},
         ),
         (X86_64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_AARCH64) => (
             "x86_64-linux-gnu-gcc",
-            "To install an x86_64 cross-compiler on Ubuntu:\nsudo apt-get install g++-x86_64-linux-gnu",
+            indoc! {"
+                To install an x86_64 cross-compiler on Ubuntu:
+                sudo apt-get install g++-x86_64-linux-gnu
+            "},
         ),
         (X86_64_UNKNOWN_LINUX_MUSL, OS_MACOS, ARCH_X86_64 | ARCH_AARCH64) => (
             "x86_64-unknown-linux-musl-gcc",
-            "To install an x86_64 cross-compiler on macOS:\nbrew install messense/macos-cross-toolchains/x86_64-unknown-linux-musl",
+            indoc! {"
+                To install an x86_64 cross-compiler on macOS:
+                brew install messense/macos-cross-toolchains/x86_64-unknown-linux-musl
+            "},
         ),
         _ => return CrossCompileAssistance::NoAssistance,
     };

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -18,7 +18,8 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
             "aarch64-unknown-linux-musl-gcc",
             "To install an aarch64 cross-compiler on macOS:\nbrew install messense/macos-cross-toolchains/aarch64-unknown-linux-musl",
         ),
-        (AARCH64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_AARCH64) | (X86_64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_X86_64) => (
+        (AARCH64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_AARCH64)
+        | (X86_64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_X86_64) => (
             "musl-gcc",
             "To install musl-tools on Ubuntu:\nsudo apt-get install musl-tools",
         ),

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -14,7 +14,7 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
             "aarch64-linux-gnu-gcc",
             "To install an aarch64 cross-compiler on Ubuntu:\nsudo apt-get install g++-aarch64-linux-gnu",
         ),
-        (AARCH64_UNKNOWN_LINUX_MUSL, OS_MACOS, _) => (
+        (AARCH64_UNKNOWN_LINUX_MUSL, OS_MACOS, ARCH_X86_64 | ARCH_AARCH64) => (
             "aarch64-unknown-linux-musl-gcc",
             "To install an aarch64 cross-compiler on macOS:\nbrew install messense/macos-cross-toolchains/aarch64-unknown-linux-musl",
         ),
@@ -26,7 +26,7 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
             "x86_64-linux-gnu-gcc",
             "To install an x86_64 cross-compiler on Ubuntu:\nsudo apt-get install g++-x86_64-linux-gnu",
         ),
-        (X86_64_UNKNOWN_LINUX_MUSL, OS_MACOS, _) => (
+        (X86_64_UNKNOWN_LINUX_MUSL, OS_MACOS, ARCH_X86_64 | ARCH_AARCH64) => (
             "x86_64-unknown-linux-musl-gcc",
             "To install an x86_64 cross-compiler on macOS:\nbrew install messense/macos-cross-toolchains/x86_64-unknown-linux-musl",
         ),

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -62,7 +62,17 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
                 }
             }
         }
-        Err(_) => CrossCompileAssistance::HelpText(help_text.to_string()),
+        Err(_) => CrossCompileAssistance::HelpText(format!(
+            r"For cross-compilation from {0} {1} to {target}, a C compiler and
+linker for the target platform must be installed on your computer:
+
+{help_text}
+            
+You will also need to install the Rust target:
+rustup target add {target}",
+            consts::ARCH,
+            consts::OS
+        )),
     }
 }
 

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -37,7 +37,7 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
             "x86_64-linux-gnu-gcc",
             indoc! {"
                 To install an x86_64 cross-compiler on Ubuntu:
-                sudo apt-get install g++-x86_64-linux-gnu
+                sudo apt-get install g++-x86-64-linux-gnu
             "},
         ),
         (X86_64_UNKNOWN_LINUX_MUSL, OS_MACOS, ARCH_X86_64 | ARCH_AARCH64) => (

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -41,7 +41,6 @@ fn generate_assistance(
     target_triple: &str,
 ) -> CrossCompileAssistance {
     match which(gcc_path) {
-        Err(_) => CrossCompileAssistance::HelpText(help_text.to_string()),
         Ok(_) => {
             if gcc_path == "musl-gcc" {
                 CrossCompileAssistance::Configuration {
@@ -70,6 +69,7 @@ fn generate_assistance(
                 }
             }
         }
+        Err(_) => CrossCompileAssistance::HelpText(help_text.to_string()),
     }
 }
 pub enum CrossCompileAssistance {

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -8,8 +8,8 @@ use which::which;
 /// look for the required tools and returns a human-readable help text if they can't be found or
 /// any other issue has been detected.
 pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileAssistance {
-    let target = target_triple.as_ref();
-    let (gcc_path, help_text) = match (target, consts::OS, consts::ARCH) {
+    let target_triple = target_triple.as_ref();
+    let (gcc_path, help_text) = match (target_triple, consts::OS, consts::ARCH) {
         (AARCH64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_X86_64) => (
             "aarch64-linux-gnu-gcc",
             "To install an aarch64 cross-compiler on Ubuntu:\nsudo apt-get install g++-aarch64-linux-gnu",
@@ -48,14 +48,14 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
                             // https://github.com/rust-lang/cargo/issues/4133
                             OsString::from(format!(
                                 "CARGO_TARGET_{}_LINKER",
-                                target.to_uppercase().replace('-', "_")
+                                target_triple.to_uppercase().replace('-', "_")
                             )),
                             OsString::from(gcc_path),
                         ),
                         (
                             // Required so that any crates that call out to gcc are also cross-compiled:
                             // https://github.com/alexcrichton/cc-rs/issues/82
-                            OsString::from(format!("CC_{}", target.replace('-', "_"))),
+                            OsString::from(format!("CC_{}", target_triple.replace('-', "_"))),
                             OsString::from(gcc_path),
                         ),
                     ],
@@ -63,13 +63,13 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
             }
         }
         Err(_) => CrossCompileAssistance::HelpText(format!(
-            r"For cross-compilation from {0} {1} to {target}, a C compiler and
+            r"For cross-compilation from {0} {1} to {target_triple}, a C compiler and
 linker for the target platform must be installed:
 
 {help_text}
             
 You will also need to install the Rust target:
-rustup target add {target}",
+rustup target add {target_triple}",
             consts::ARCH,
             consts::OS
         )),


### PR DESCRIPTION
We currently support targeting `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` on macOS and Linux, but the cross compile assistance provided is inconsistent depending on the host's CPU architecture. This refactoring aims to improve that across all supported `target_triple` and host OS/architecture combinations by providing helpful assistance for supported scenarios.

* Fixed https://github.com/heroku/libcnb.rs/issues/728 by improving the help text to include accurate advice for the `target_triple` relative to the current host OS *and* architecture.
* Fixed https://github.com/heroku/libcnb.rs/issues/726 by adding support for targeting `x86_64-unknown-linux-musl` from AARCH64 Linux.
* Improves maintainability by sharing CrossCompileAssistance::Configuration initialization with relevant environment variables (when appropriate) in one place (which will be useful if we want to set additional environment variables in the future, i.e. https://github.com/heroku/libcnb.rs/issues/725).
* Fixes part of https://github.com/heroku/libcnb.rs/issues/724 by adding support for targeting `aarch64-unknown-linux-musl` from AARCH64 Linux. The gcc binary used when targeting the same architecture is now `musl-gcc` on both `aarch64` and `x86-64`.
    * However, the binary used when the architectures don't match is still the `*-gnu-gcc` variant (as for instance `aarch64-linux-musl-gcc` is only available on aarch64 Linux (this requires further investigation, and a separate issue should be created for that)).
* Adds support for targeting `aarch64-unknown-linux-musl` from aarch64 macOS.
* Adds strict host architecture checks to ensure that `CrossCompileAssistance::Configuration` or `CrossCompileAssistance::HelpText` is only returned when supported. Otherwise `CrossCompileAssistance::NoAssistance` is returned.

It also:
* Drops support for a gcc binary (`x86_64-linux-musl-gcc`) installed by a previously recommended macOS toolchain. Since the current toolchain has been recommended for nearly 2 years it's probably safe to assume (or fair to require) that users have update to the recommended toolchain. 
The brew formula/revision has also been bumped, so the missing dependencies mentioned here https://github.com/heroku/libcnb.rs/pull/312#issuecomment-1038044636 are now included