### PR TITLE
Use `--force-color` with `pack build` invocations in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,4 +92,4 @@ jobs:
         # Uses a non-libc image to validate the static musl cross-compilation.
         # TODO: Switch this back to using the `alpine` tag once the stable Pack CLI release supports
         # image extensions (currently newer sample alpine images fail to build with stable Pack).
-        run: pack build example-basics --builder cnbs/sample-builder@sha256:da5ff69191919f1ff30d5e28859affff8e39f23038137c7751e24a42e919c1ab --trust-builder --buildpack packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_basics --path examples/
+        run: pack build example-basics --force-color --builder cnbs/sample-builder@sha256:da5ff69191919f1ff30d5e28859affff8e39f23038137c7751e24a42e919c1ab --trust-builder --buildpack packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_basics --path examples/


### PR DESCRIPTION
As of Pack 0.33.0 (which this repo is using thanks to #462), there is a new `--force-color` argument that makes `pack build` output logs in colour even if a TTY wasn't detected (as is the case on GHA):
https://github.com/buildpacks/pack/releases/tag/v0.33.0

This will allow us to see the colour output from the new build output implementation.

GUS-W-14968745.