### PR TITLE
Use `inspect_err` for tracing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved the consistency of cross-compilation assistance provided across all supported `target_triple` and host OS/architecture combinations. [#769](https://github.com/heroku/libcnb.rs/pull/769)
 - Added cross-compilation assistance for `aarch64-unknown-linux-musl` (on macOS and ARM64 Linux) and `x86_64-unknown-linux-musl` (on ARM64 Linux). [#769](https://github.com/heroku/libcnb.rs/pull/769)
+- Raised Minimum Supported Rust Version (MSRV) to `1.76`. ([#774](https://github.com/heroku/libcnb.rs/pull/774))
 - `libcnb`:
   - Changed `Layer` interface from `&self` to `&mut self`. ([#669](https://github.com/heroku/libcnb.rs/pull/669))
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 
 [workspace.package]
 version = "0.17.0"
-rust-version = "1.75"
+rust-version = "1.76"
 edition = "2021"
 license = "BSD-3-Clause"
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [docs.rs]: https://docs.rs/libcnb/latest/libcnb/
 [Latest Version]: https://img.shields.io/crates/v/libcnb.svg
 [crates.io]: https://crates.io/crates/libcnb
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.74+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.76+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install
 
 `libcnb.rs` is a framework for writing [Cloud Native Buildpacks](https://buildpacks.io) in Rust.

--- a/libcnb-cargo/README.md
+++ b/libcnb-cargo/README.md
@@ -53,5 +53,5 @@ pack build my-image-name \
 
 [Latest Version]: https://img.shields.io/crates/v/libcnb-cargo.svg
 [crates.io]: https://crates.io/crates/libcnb-cargo
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.74+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.76+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb-common/README.md
+++ b/libcnb-common/README.md
@@ -8,5 +8,5 @@ This is an internal crate and should not be used by users directly. There are no
 [docs.rs]: https://docs.rs/libcnb-proc-macros/latest/libcnb_common/
 [Latest Version]: https://img.shields.io/crates/v/libcnb-common.svg
 [crates.io]: https://crates.io/crates/libcnb-common
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.74+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.76+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb-data/README.md
+++ b/libcnb-data/README.md
@@ -10,5 +10,5 @@ on this crate directly.
 [docs.rs]: https://docs.rs/libcnb-data/latest/libcnb_data/
 [Latest Version]: https://img.shields.io/crates/v/libcnb-data.svg
 [crates.io]: https://crates.io/crates/libcnb-data
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.74+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.76+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb-package/README.md
+++ b/libcnb-package/README.md
@@ -12,5 +12,5 @@ directly.
 [docs.rs]: https://docs.rs/libcnb-package/latest/libcnb_package/
 [Latest Version]: https://img.shields.io/crates/v/libcnb-package.svg
 [crates.io]: https://crates.io/crates/libcnb-package
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.74+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.76+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb-proc-macros/README.md
+++ b/libcnb-proc-macros/README.md
@@ -9,5 +9,5 @@ depending on this crate directly.
 [docs.rs]: https://docs.rs/libcnb-proc-macros/latest/libcnb_proc_macros/
 [Latest Version]: https://img.shields.io/crates/v/libcnb-proc-macros.svg
 [crates.io]: https://crates.io/crates/libcnb-proc-macros
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.74+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.76+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libcnb-test/README.md
+++ b/libcnb-test/README.md
@@ -226,5 +226,5 @@ fn additional_buildpacks() {
 [docs.rs]: https://docs.rs/libcnb-test/latest/libcnb_test/
 [Latest Version]: https://img.shields.io/crates/v/libcnb-test.svg
 [crates.io]: https://crates.io/crates/libcnb-test
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.74+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.76+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install

--- a/libherokubuildpack/README.md
+++ b/libherokubuildpack/README.md
@@ -37,5 +37,5 @@ The feature names line up with the modules in this crate. All features are enabl
 [docs.rs]: https://docs.rs/libherokubuildpack/latest/libherokubuildpack/
 [Latest Version]: https://img.shields.io/crates/v/libherokubuildpack.svg
 [crates.io]: https://crates.io/crates/libherokubuildpack
-[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.74+-lightgray.svg
+[MSRV]: https://img.shields.io/badge/MSRV-rustc_1.76+-lightgray.svg
 [install-rust]: https://www.rust-lang.org/tools/install


### PR DESCRIPTION
With Rust 1.76 now out, `Result::inspect_err` is stable! Using it over `Resut::map_err` un-clutters the tracing code a lot. This PR will bump the MSRV to `1.76`.