### PR TITLE
Replace `MappedWrite`'s magic u8 constant with byte string literal

### DIFF
--- a/libherokubuildpack/src/write.rs
+++ b/libherokubuildpack/src/write.rs
@@ -16,7 +16,7 @@ pub fn mapped<W: io::Write, F: (Fn(Vec<u8>) -> Vec<u8>) + Sync + Send + 'static>
     MappedWrite::new(w, marker_byte, f)
 }
 
-/// Constructs a writer that buffers written data until an ASCII/UTF-8 newline byte (`0x0A`) is
+/// Constructs a writer that buffers written data until an ASCII/UTF-8 newline byte (`b'\n'`) is
 /// encountered and then applies the given mapping function to the data before passing the result to
 /// the wrapped writer.
 ///
@@ -25,7 +25,7 @@ pub fn line_mapped<W: io::Write, F: (Fn(Vec<u8>) -> Vec<u8>) + Sync + Send + 'st
     w: W,
     f: F,
 ) -> MappedWrite<W> {
-    mapped(w, NEWLINE_ASCII_BYTE, f)
+    mapped(w, b'\n', f)
 }
 
 /// Constructs a writer that writes to two other writers. Similar to the UNIX `tee` command.
@@ -154,8 +154,6 @@ impl<A: io::Write, B: io::Write> io::Write for TeeWrite<A, B> {
         self.inner_b.flush()
     }
 }
-
-const NEWLINE_ASCII_BYTE: u8 = 0x0Au8;
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
The `NEWLINE_ASCII_BYTE` constant only really existed because it's otherwise not obvious that the `0x0Au8` u8 value represents an ASCII newline byte.

However, we can replace the `0x0Au8` u8 with a byte string literal of `b'\n'` which is identical in it's value, but much easier to reason about.

The byte string literal form is what the Rust stdlib uses in several places:
https://github.com/rust-lang/rust/blob/1.76.0/library/core/src/num/mod.rs#L1023
https://github.com/rust-lang/rust/blob/1.76.0/library/core/src/escape.rs#L20
https://github.com/rust-lang/rust/blob/1.76.0/library/std/src/io/buffered/linewritershim.rs#L46

(I spotted this whilst reviewing #721's usage of `MappedWrite` - since I think `BuildpackOutput::start_stream` might also need to start handling newline bytes in the closure passed to `line_mapped`, and was otherwise thinking we'd need to expose the `NEWLINE_ASCII_BYTE` constant to `build_output`, until I realised we didn't really need the magic `0x0Au8` value after all.)