### PR TITLE
Remove leftover TODO comment in `buildpack_output`

### DIFF
--- a/libherokubuildpack/src/buildpack_output/mod.rs
+++ b/libherokubuildpack/src/buildpack_output/mod.rs
@@ -685,7 +685,6 @@ mod test {
         let io = second_stream.finish().finish().finish();
 
         let tab_char = '\t';
-        // TODO: See if there is a way to remove the additional newlines in the trailing newline case.
         let expected = formatdoc! {"
 
             # Heroku Ruby Buildpack


### PR DESCRIPTION
Since the issue to which it refers was fixed in:
https://github.com/heroku/libcnb.rs/pull/721/commits/e177d786f81190826fc222cbdd40a7e0bcd157fe