### PR TITLE
Reintroduce Stack, with weak validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `libcnb-data':
+  - Reintroduced support for deserializing `[[stacks]]` in `buildpack.toml`.
+    ([#789](https://github.com/heroku/libcnb.rs/pull/789))
 - `libherokubuildpack`:
   - Added `buildpack_output` module. This will help buildpack authors provide consistent and delightful output to their buildpack users ([#721](https://github.com/heroku/libcnb.rs/pull/721))
 

--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -261,6 +261,20 @@ uri = "https://example.tld/my-license"
 [[buildpack.licenses]]
 uri = "https://example.tld/my-license"
 
+[[stacks]]
+id = "heroku-20"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"
+mixins = []
+
+[[stacks]]
+id = "io.buildpacks.stacks.focal"
+mixins = ["build:jq", "wget"]
+
+[[stacks]]
+id = "*"
+
 [[targets]]
 os = "linux"
 arch = "amd64"
@@ -342,6 +356,27 @@ checksum = "abc123"
                 SbomFormat::CycloneDxJson,
                 SbomFormat::SpdxJson
             ])
+        );
+        assert_eq!(
+            buildpack_descriptor.stacks,
+            [
+                Stack {
+                    id: String::from("heroku-20"),
+                    mixins: Vec::new(),
+                },
+                Stack {
+                    id: String::from("io.buildpacks.stacks.bionic"),
+                    mixins: Vec::new(),
+                },
+                Stack {
+                    id: String::from("io.buildpacks.stacks.focal"),
+                    mixins: vec![String::from("build:jq"), String::from("wget")]
+                },
+                Stack {
+                    id: String::from("*"),
+                    mixins: Vec::new()
+                }
+            ]
         );
         assert_eq!(
             buildpack_descriptor.targets,
@@ -533,6 +568,7 @@ version = "0.0.1"
         );
         assert_eq!(buildpack_descriptor.buildpack.licenses, Vec::new());
         assert_eq!(buildpack_descriptor.buildpack.sbom_formats, HashSet::new());
+        assert_eq!(buildpack_descriptor.stacks, []);
         assert_eq!(buildpack_descriptor.targets, []);
         assert_eq!(buildpack_descriptor.metadata, None);
     }

--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -1,5 +1,6 @@
 mod api;
 mod id;
+mod stack;
 mod target;
 mod version;
 
@@ -8,6 +9,7 @@ use crate::sbom::SbomFormat;
 pub use api::*;
 pub use id::*;
 use serde::Deserialize;
+pub use stack::*;
 use std::collections::HashSet;
 pub use target::*;
 pub use version::*;
@@ -119,6 +121,8 @@ impl<BM> BuildpackDescriptor<BM> {
 pub struct ComponentBuildpackDescriptor<BM = GenericMetadata> {
     pub api: BuildpackApi,
     pub buildpack: Buildpack,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub stacks: Vec<Stack>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub targets: Vec<Target>,
     pub metadata: BM,

--- a/libcnb-data/src/buildpack/stack.rs
+++ b/libcnb-data/src/buildpack/stack.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 #[serde(deny_unknown_fields)]
 pub struct Stack {
     pub id: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub mixins: Vec<String>,
 }
 

--- a/libcnb-data/src/buildpack/stack.rs
+++ b/libcnb-data/src/buildpack/stack.rs
@@ -1,0 +1,60 @@
+use serde::Deserialize;
+
+// Stacks are deprecated in Buildpack API 0.10, and libcnb.rs effectively
+// ignores them. However, they are still supported by the Buildpack API, so
+// libcnb should continue to allow them to exist in buildpack.toml.
+#[derive(Deserialize, Debug, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct Stack {
+    id: String,
+    #[serde(default)]
+    mixins: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_specific_stack_without_mixins() {
+        let toml_str = r#"
+id = "heroku-20"
+"#;
+        assert_eq!(
+            toml::from_str::<Stack>(toml_str),
+            Ok(Stack {
+                id: String::from("heroku-20"),
+                mixins: Vec::new()
+            }),
+        );
+    }
+
+    #[test]
+    fn deserialize_specific_stack_with_mixins() {
+        let toml_str = r#"
+id = "io.buildpacks.stacks.focal"
+mixins = ["build:jq", "wget"]
+"#;
+        assert_eq!(
+            toml::from_str::<Stack>(toml_str),
+            Ok(Stack {
+                id: String::from("io.buildpacks.stacks.focal"),
+                mixins: vec![String::from("build:jq"), String::from("wget")]
+            }),
+        );
+    }
+
+    #[test]
+    fn deserialize_any_stack() {
+        let toml_str = r#"
+id = "*"
+"#;
+        assert_eq!(
+            toml::from_str::<Stack>(toml_str),
+            Ok(Stack {
+                id: String::from("*"),
+                mixins: vec![],
+            }),
+        );
+    }
+}

--- a/libcnb-data/src/buildpack/stack.rs
+++ b/libcnb-data/src/buildpack/stack.rs
@@ -6,9 +6,9 @@ use serde::Deserialize;
 #[derive(Deserialize, Debug, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Stack {
-    id: String,
+    pub id: String,
     #[serde(default)]
-    mixins: Vec<String>,
+    pub mixins: Vec<String>,
 }
 
 #[cfg(test)]

--- a/libcnb/src/layer/tests.rs
+++ b/libcnb/src/layer/tests.rs
@@ -925,6 +925,7 @@ fn build_context(temp_dir: &TempDir) -> BuildContext<TestBuildpack> {
                 licenses: Vec::new(),
                 sbom_formats: HashSet::new(),
             },
+            stacks: vec![],
             targets: vec![Target {
                 os: Some(String::from("linux")),
                 arch: Some(String::from("amd64")),


### PR DESCRIPTION
As noted in #788, working with buildpacks that still have `[[stacks]]` in `buildpack.toml` can cause some trouble. While `[[stacks]]` is deprecated in Buildpack API 0.10, it is still supported: https://github.com/buildpacks/spec/blob/buildpack/v0.10/buildpack.md#buildpacktoml-toml-stacks-array.

This PR re-introduces support for serializing a `buildpack.toml` with `[[stacks]]` in it. However, `Stack` remains unused within libcnb, and thus the validation and parsing is weaker. I would expect `Stack` to be removed again in Buildpack API 0.11. This change is mostly to facilitate upgrades.