### PR TITLE
Group OpenTelemetry Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       - "dependencies"
       - "rust"
       - "skip changelog"
+    groups:
+      opentelemetry:
+        patterns:
+          - "opentelemetry*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Since the `opentelemetry`, `opentelemetry_sdk` and `opentelemetry-stdout` crates all need to be updated at the same time, otherwise compilation errors occur due to trait version mismatches - such as those seen in #794.