### PR TITLE
Fix `starting_containers` test after release of Procfile CNB v3.0.0

### DIFF
--- a/libcnb-test/tests/fixtures/procfile/Procfile
+++ b/libcnb-test/tests/fixtures/procfile/Procfile
@@ -1,3 +1,2 @@
 web: python3 -u -m http.server ${PORT:+"${PORT}"}
 worker: echo 'this is the worker process!'
-echo-args: echo


### PR DESCRIPTION
Procfile CNB v3.0.0 was just released with an intentional change to the way that `command` vs `args` are handled in the CNB process type definition. (Before the `Procfile` file entry would be set as the process `command`, but now it's set as `args`.)

That change improves the overall UX of running images that use the Procfile CNB, but is breaking in some lesser used scenarios that happened to be tested via the `starting_containers` test in this repo.

See:
- https://github.com/heroku/procfile-cnb/pull/205#discussion_r1495090822
- https://github.com/heroku/procfile-cnb/compare/v2.0.2...v3.0.0#diff-782521a81713992d3a07e85975d367cfac60afc78583133551efcddc2026bd3eL19-R20

The tests have been updated to account for the new behaviour, and an additional test added for the "overriding command only" scenario (that wasn't possible to easily test before due to the way the Procfile CNB was previously implemented).

Fixes #800.
GUS-W-15139634.