### PR TITLE
Correct `ContextTarget` references to distro image label names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `libcnb`:
   - `WriteLayerError` changed to contain more specific error enums instead of generic ones. ([#786](https://github.com/heroku/libcnb.rs/pull/786))
 
+### Fixed
+
+- `libcnb`
+  - Fixed the Docker label names mentioned in the rustdocs for `ContextTarget`'s `distro_name` and `distro_version`. ([#811](https://github.com/heroku/libcnb.rs/pull/811))
+
 ## [0.19.0] - 2024-02-23
 
 ### Added

--- a/libcnb/src/target.rs
+++ b/libcnb/src/target.rs
@@ -25,12 +25,12 @@ pub struct ContextTarget {
     ///
     /// For example: `ubuntu` or `alpine`.
     ///
-    /// CNB `lifecycle` sources this value from the build OCI image's `io.buildpacks.distro.name` label.
+    /// CNB `lifecycle` sources this value from the build OCI image's `io.buildpacks.base.distro.name` label.
     pub distro_name: Option<String>,
     /// The version of the operating system distribution.
     ///
     /// For example: `18.02` or `3.19`.
     ///
-    /// CNB `lifecycle` sources this value from the build OCI image's `io.buildpacks.distro.version` label.
+    /// CNB `lifecycle` sources this value from the build OCI image's `io.buildpacks.base.distro.version` label.
     pub distro_version: Option<String>,
 }


### PR DESCRIPTION
Since the relevant distros run image Docker label names are `io.buildpacks.base.distro.name` and `io.buildpacks.base.distro.version`. 

See:
https://github.com/buildpacks/spec/blob/buildpack/v0.10/platform.md#target-data

I believe the rustdocs here were based on the `lifecycle` codebase, which uses the wrong label name, and is about to be fixed:
https://github.com/buildpacks/lifecycle/pull/1325