### PR TITLE
Fix lint errors with Rust 1.77

### DIFF
--- a/libcnb/src/layer/tests.rs
+++ b/libcnb/src/layer/tests.rs
@@ -68,7 +68,7 @@ impl Layer for TestLayer {
             layer_path.join(TEST_LAYER_CREATE_FILE_NAME),
             TEST_LAYER_CREATE_FILE_CONTENTS,
         )
-        .map_err(TestBuildpackError::IoError)?;
+        .expect("Couldn't write file");
 
         LayerResultBuilder::new(TestLayerMetadata {
             version: self.write_version.clone(),
@@ -94,7 +94,7 @@ impl Layer for TestLayer {
             layer_data.path.join(TEST_LAYER_UPDATE_FILE_NAME),
             TEST_LAYER_UPDATE_FILE_CONTENTS,
         )
-        .map_err(TestBuildpackError::IoError)?;
+        .expect("Couldn't write file");
 
         LayerResultBuilder::new(layer_data.content_metadata.metadata.clone()).build()
     }
@@ -955,6 +955,4 @@ impl Buildpack for TestBuildpack {
 }
 
 #[derive(Debug)]
-enum TestBuildpackError {
-    IoError(std::io::Error),
-}
+enum TestBuildpackError {}

--- a/test-buildpacks/readonly-layer-files/src/layer.rs
+++ b/test-buildpacks/readonly-layer-files/src/layer.rs
@@ -29,14 +29,15 @@ impl Layer for TestLayer {
         layer_path: &Path,
     ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
         let directory = layer_path.join("sub_directory");
-        fs::create_dir_all(&directory)?;
+        fs::create_dir_all(&directory).expect("Couldn't create subdirectory");
 
-        fs::write(directory.join("foo.txt"), "hello world!")?;
+        fs::write(directory.join("foo.txt"), "hello world!").expect("Couldn't write file");
 
         // By making the sub-directory read-only, files inside it cannot be deleted. This would
         // cause issues when libcnb.rs tries to delete a cached layer directory unless libcnb.rs
         // handles this case explicitly.
-        fs::set_permissions(&directory, Permissions::from_mode(0o555))?;
+        fs::set_permissions(&directory, Permissions::from_mode(0o555))
+            .expect("Couldn't set permissions to read-only");
 
         LayerResultBuilder::new(GenericMetadata::default()).build()
     }

--- a/test-buildpacks/readonly-layer-files/src/main.rs
+++ b/test-buildpacks/readonly-layer-files/src/main.rs
@@ -6,7 +6,6 @@ use libcnb::data::layer_name;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericMetadata, GenericPlatform};
 use libcnb::{buildpack_main, Buildpack};
-use std::io::Error;
 
 // Suppress warnings due to the `unused_crate_dependencies` lint not handling integration tests well.
 #[cfg(test)]
@@ -30,14 +29,6 @@ impl Buildpack for TestBuildpack {
 }
 
 #[derive(Debug)]
-pub(crate) enum TestBuildpackError {
-    IOError(std::io::Error),
-}
-
-impl From<std::io::Error> for TestBuildpackError {
-    fn from(io_error: Error) -> Self {
-        Self::IOError(io_error)
-    }
-}
+enum TestBuildpackError {}
 
 buildpack_main!(TestBuildpack);

--- a/test-buildpacks/sbom/src/main.rs
+++ b/test-buildpacks/sbom/src/main.rs
@@ -10,7 +10,6 @@ use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericMetadata, GenericPlatform};
 use libcnb::sbom::Sbom;
 use libcnb::{buildpack_main, Buildpack};
-use std::io::Error;
 
 // Suppress warnings due to the `unused_crate_dependencies` lint not handling integration tests well.
 #[cfg(test)]
@@ -61,14 +60,6 @@ impl Buildpack for TestBuildpack {
 }
 
 #[derive(Debug)]
-pub(crate) enum TestBuildpackError {
-    IOError(std::io::Error),
-}
-
-impl From<std::io::Error> for TestBuildpackError {
-    fn from(io_error: Error) -> Self {
-        Self::IOError(io_error)
-    }
-}
+enum TestBuildpackError {}
 
 buildpack_main!(TestBuildpack);

--- a/test-buildpacks/store/src/main.rs
+++ b/test-buildpacks/store/src/main.rs
@@ -3,7 +3,6 @@ use libcnb::data::store::Store;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericMetadata, GenericPlatform};
 use libcnb::{buildpack_main, Buildpack};
-use std::io::Error;
 use toml::toml;
 
 // Suppress warnings due to the `unused_crate_dependencies` lint not handling integration tests well.
@@ -35,14 +34,6 @@ impl Buildpack for TestBuildpack {
 }
 
 #[derive(Debug)]
-pub(crate) enum TestBuildpackError {
-    IOError(std::io::Error),
-}
-
-impl From<std::io::Error> for TestBuildpackError {
-    fn from(io_error: Error) -> Self {
-        Self::IOError(io_error)
-    }
-}
+enum TestBuildpackError {}
 
 buildpack_main!(TestBuildpack);


### PR DESCRIPTION
Fixes:

```
warning: field `0` is never read
  --> test-buildpacks/readonly-layer-files/src/main.rs:34:13
   |
34 |     IOError(std::io::Error),
   |     ------- ^^^^^^^^^^^^^^
   |     |
   |     field in this variant
   |
   = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
34 |     IOError(()),
   |             ~~

warning: field `0` is never read
  --> test-buildpacks/sbom/src/main.rs:65:13
   |
65 |     IOError(std::io::Error),
   |     ------- ^^^^^^^^^^^^^^
   |     |
   |     field in this variant
   |
   = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
65 |     IOError(()),
   |             ~~

warning: field `0` is never read
  --> test-buildpacks/store/src/main.rs:39:13
   |
39 |     IOError(std::io::Error),
   |     ------- ^^^^^^^^^^^^^^
   |     |
   |     field in this variant
   |
   = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
39 |     IOError(()),
   |             ~~

warning: field `0` is never read
   --> libcnb/src/layer/tests.rs:959:13
    |
959 |     IoError(std::io::Error),
    |     ------- ^^^^^^^^^^^^^^
    |     |
    |     field in this variant
    |
    = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
    |
959 |     IoError(()),
    |             ~~
```

GUS-W-15350320.