### PR TITLE
Test helpers to match against regular expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,181 +9,263 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `libcnb-test`
+    - Added the macro `assert_contains_match!` for testing if a value contains a regular expression match.
+    - Added the macro `assert_not_contains_match!` for testing if a value does not contain a regular expression match.
+
 ### Changed
 
 - `libcnb`:
-  - `WriteLayerError` changed to contain more specific error enums instead of generic ones. ([#786](https://github.com/heroku/libcnb.rs/pull/786))
+    - `WriteLayerError` changed to contain more specific error enums instead of generic
+      ones. ([#786](https://github.com/heroku/libcnb.rs/pull/786))
 
 ### Fixed
 
 - `libcnb`
-  - Fixed the Docker label names mentioned in the rustdocs for `ContextTarget`'s `distro_name` and `distro_version`. ([#811](https://github.com/heroku/libcnb.rs/pull/811))
+    - Fixed the Docker label names mentioned in the rustdocs for `ContextTarget`'s `distro_name`
+      and `distro_version`. ([#811](https://github.com/heroku/libcnb.rs/pull/811))
 
 ## [0.19.0] - 2024-02-23
 
 ### Added
 
 - `libcnb-data`:
-  - Reintroduced support for deserializing `[[stacks]]` in `buildpack.toml`.
-    ([#789](https://github.com/heroku/libcnb.rs/pull/789))
+    - Reintroduced support for deserializing `[[stacks]]` in `buildpack.toml`.
+      ([#789](https://github.com/heroku/libcnb.rs/pull/789))
 - `libherokubuildpack`:
-  - Added `buildpack_output` module. This will help buildpack authors provide consistent and delightful output to their buildpack users ([#721](https://github.com/heroku/libcnb.rs/pull/721))
+    - Added `buildpack_output` module. This will help buildpack authors provide consistent and delightful output to
+      their buildpack users ([#721](https://github.com/heroku/libcnb.rs/pull/721))
 
 ## [0.18.0] - 2024-02-12
 
 ### Changed
 
-- Now targets [Buildpack API 0.10](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.10). Buildpacks need to upgrade the `api` key to `0.10` in their `buildpack.toml`. ([#773](https://github.com/heroku/libcnb.rs/pull/773))
-- Improved the consistency of cross-compilation assistance provided across all supported `target_triple` and host OS/architecture combinations. [#769](https://github.com/heroku/libcnb.rs/pull/769)
-- Added cross-compilation assistance for `aarch64-unknown-linux-musl` (on macOS and ARM64 Linux) and `x86_64-unknown-linux-musl` (on ARM64 Linux). [#769](https://github.com/heroku/libcnb.rs/pull/769)
+- Now targets [Buildpack API 0.10](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.10). Buildpacks need
+  to upgrade the `api` key to `0.10` in their `buildpack.toml`. ([#773](https://github.com/heroku/libcnb.rs/pull/773))
+- Improved the consistency of cross-compilation assistance provided across all supported `target_triple` and host
+  OS/architecture combinations. [#769](https://github.com/heroku/libcnb.rs/pull/769)
+- Added cross-compilation assistance for `aarch64-unknown-linux-musl` (on macOS and ARM64 Linux)
+  and `x86_64-unknown-linux-musl` (on ARM64 Linux). [#769](https://github.com/heroku/libcnb.rs/pull/769)
 - Raised Minimum Supported Rust Version (MSRV) to `1.76`. ([#774](https://github.com/heroku/libcnb.rs/pull/774))
 - `libcnb`:
-  - Changed `Layer` interface from `&self` to `&mut self`. ([#669](https://github.com/heroku/libcnb.rs/pull/669))
+    - Changed `Layer` interface from `&self` to `&mut self`. ([#669](https://github.com/heroku/libcnb.rs/pull/669))
 
 ### Added
 
 - `libherokubuildpack`:
-  - `MappedWrite::unwrap` for getting the wrapped `Write` back out. ([#765](https://github.com/heroku/libcnb.rs/pull/765))
+    - `MappedWrite::unwrap` for getting the wrapped `Write` back
+      out. ([#765](https://github.com/heroku/libcnb.rs/pull/765))
 
 ### Removed
 
-- Types, errors, macros and functions related to stacks. The concept of stacks has been removed from the CNB spec. Use `Target` instead. ([#773](https://github.com/heroku/libcnb.rs/pull/773))
+- Types, errors, macros and functions related to stacks. The concept of stacks has been removed from the CNB spec.
+  Use `Target` instead. ([#773](https://github.com/heroku/libcnb.rs/pull/773))
 
 ## [0.17.0] - 2023-12-06
 
 ### Added
 
 - `libcnb`:
-  - An optional `trace` feature has been added that emits OpenTelemetry tracing
-    data to a [File Export](https://opentelemetry.io/docs/specs/otel/protocol/file-exporter/). ([#723](https://github.com/heroku/libcnb.rs/pull/723))
+    - An optional `trace` feature has been added that emits OpenTelemetry tracing
+      data to
+      a [File Export](https://opentelemetry.io/docs/specs/otel/protocol/file-exporter/). ([#723](https://github.com/heroku/libcnb.rs/pull/723))
 
 ## [0.16.0] - 2023-11-17
 
 ### Changed
 
 - Raised Minimum Supported Rust Version (MSRV) to `1.74`. ([#747](https://github.com/heroku/libcnb.rs/pull/747))
-- Improved the consistency of all user-facing libcnb.rs error message wordings. ([#722](https://github.com/heroku/libcnb.rs/pull/722))
-- The assistance error message shown when the necessary cross-compilation tools are not found now also includes the `rustup target add` step. ([#729](https://github.com/heroku/libcnb.rs/pull/729))
-- Updated the documentation for `TestRunner::build` and `TestContext::start_container` to mention when Docker resource teardown occurs. ([#743](https://github.com/heroku/libcnb.rs/pull/743))
+- Improved the consistency of all user-facing libcnb.rs error message
+  wordings. ([#722](https://github.com/heroku/libcnb.rs/pull/722))
+- The assistance error message shown when the necessary cross-compilation tools are not found now also includes
+  the `rustup target add` step. ([#729](https://github.com/heroku/libcnb.rs/pull/729))
+- Updated the documentation for `TestRunner::build` and `TestContext::start_container` to mention when Docker resource
+  teardown occurs. ([#743](https://github.com/heroku/libcnb.rs/pull/743))
 
 ### Fixed
 
 - `libcnb-test`:
-  - Fixed incorrect error messages being shown for buildpack compilation/packaging failures. ([#720](https://github.com/heroku/libcnb.rs/pull/720))
-  - The Docker volumes created by Pack for the build and launch layer caches are now cleaned up after each test. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
-  - The Docker image cleanup process no longer makes duplicate attempts to remove images when using `TestContext::rebuild`. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
-  - Test failures due to the Docker daemon not being installed or started no longer cause a non-unwinding panic abort with noisy traceback. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
-  - Containers created by `TestContext::start_container` are now correctly cleaned up if the container failed to start. ([#742](https://github.com/heroku/libcnb.rs/pull/742))
+    - Fixed incorrect error messages being shown for buildpack compilation/packaging
+      failures. ([#720](https://github.com/heroku/libcnb.rs/pull/720))
+    - The Docker volumes created by Pack for the build and launch layer caches are now cleaned up after each
+      test. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
+    - The Docker image cleanup process no longer makes duplicate attempts to remove images when
+      using `TestContext::rebuild`. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
+    - Test failures due to the Docker daemon not being installed or started no longer cause a non-unwinding panic abort
+      with noisy traceback. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
+    - Containers created by `TestContext::start_container` are now correctly cleaned up if the container failed to
+      start. ([#742](https://github.com/heroku/libcnb.rs/pull/742))
 
 ## [0.15.0] - 2023-09-25
 
 ### Added
 
 - `libcnb`:
-  - `LayerTypes` now implements `Copy` and `Clone`. ([#670](https://github.com/heroku/libcnb.rs/pull/670)).
+    - `LayerTypes` now implements `Copy` and `Clone`. ([#670](https://github.com/heroku/libcnb.rs/pull/670)).
 - `libcnb-data`:
-  - `ExecDProgramOutputKey`, `ProcessType`, `LayerName`, `BuildpackId` and `StackId` now implement `Ord` and `PartialOrd`. ([#658](https://github.com/heroku/libcnb.rs/pull/658))
-  - Added `generic::GenericMetadata` as a generic metadata type. Also makes it the default for `BuildpackDescriptor`, `SingleBuildpackDescriptor`, `CompositeBuildpackDescriptor` and `LayerContentMetadata`. ([#664](https://github.com/heroku/libcnb.rs/pull/664))
+    - `ExecDProgramOutputKey`, `ProcessType`, `LayerName`, `BuildpackId` and `StackId` now implement `Ord`
+      and `PartialOrd`. ([#658](https://github.com/heroku/libcnb.rs/pull/658))
+    - Added `generic::GenericMetadata` as a generic metadata type. Also makes it the default
+      for `BuildpackDescriptor`, `SingleBuildpackDescriptor`, `CompositeBuildpackDescriptor`
+      and `LayerContentMetadata`. ([#664](https://github.com/heroku/libcnb.rs/pull/664))
 - `libcnb-test`:
-  - Added the `BuildpackReference::WorkspaceBuildpack` enum variant. This allows for the testing of any libcnb.rs or composite buildpack in the Cargo workspace, instead of only the buildpack of the current crate. **Note: The testing of composite buildpacks requires `pack` CLI version `>=0.30`.** ([#666](https://github.com/heroku/libcnb.rs/pull/666))
+    - Added the `BuildpackReference::WorkspaceBuildpack` enum variant. This allows for the testing of any libcnb.rs or
+      composite buildpack in the Cargo workspace, instead of only the buildpack of the current crate. **Note: The
+      testing of composite buildpacks requires `pack` CLI version `>=0.30`.
+      ** ([#666](https://github.com/heroku/libcnb.rs/pull/666))
 
 ### Changed
 
 - `libcnb-data`:
-  - Renamed the `buildpackage` module to `package_descriptor`, and the `Buildpackage*` types within it to `PackageDescriptor*`. ([#656](https://github.com/heroku/libcnb.rs/pull/656))
-  - Renamed multiple types to match the new composite vs component buildpack [upstream terminology](https://github.com/buildpacks/spec/blob/main/buildpack.md#cnb-terminology). Renamed `SingleBuildpackDescriptor` to `ComponentBuildpackDescriptor`, `MetaBuildpackDescriptor` to `CompositeBuildpackDescriptor` and `BuildpackDescriptor::{Single,Meta}` to `BuildpackDescriptor::{Component,Composite}`. ([#682](https://github.com/heroku/libcnb.rs/pull/682))
+    - Renamed the `buildpackage` module to `package_descriptor`, and the `Buildpackage*` types within it
+      to `PackageDescriptor*`. ([#656](https://github.com/heroku/libcnb.rs/pull/656))
+    - Renamed multiple types to match the new composite vs component
+      buildpack [upstream terminology](https://github.com/buildpacks/spec/blob/main/buildpack.md#cnb-terminology).
+      Renamed `SingleBuildpackDescriptor` to `ComponentBuildpackDescriptor`, `MetaBuildpackDescriptor`
+      to `CompositeBuildpackDescriptor` and `BuildpackDescriptor::{Single,Meta}`
+      to `BuildpackDescriptor::{Component,Composite}`. ([#682](https://github.com/heroku/libcnb.rs/pull/682))
 - `libcnb-cargo`:
-  - No longer outputs paths for non-libcnb.rs and non-meta buildpacks. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
-  - Build output for humans changed slightly, output intended for machines/scripting didn't change. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
-  - When performing buildpack detection, standard ignore files (`.ignore` and `.gitignore`) will be respected. ([#673](https://github.com/heroku/libcnb.rs/pull/673))
+    - No longer outputs paths for non-libcnb.rs and non-meta
+      buildpacks. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
+    - Build output for humans changed slightly, output intended for machines/scripting didn't
+      change. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
+    - When performing buildpack detection, standard ignore files (`.ignore` and `.gitignore`) will be
+      respected. ([#673](https://github.com/heroku/libcnb.rs/pull/673))
 - `libcnb-test`:
-  - Renamed `BuildpackReference::Crate` to `BuildpackReference::CurrentCrate`. ([#666](https://github.com/heroku/libcnb.rs/pull/666))
+    - Renamed `BuildpackReference::Crate`
+      to `BuildpackReference::CurrentCrate`. ([#666](https://github.com/heroku/libcnb.rs/pull/666))
 
 ## [0.14.0] - 2023-08-18
 
 ### Added
 
-- `libcnb-package`: Added cross-compilation assistance for Linux `aarch64-unknown-linux-musl`. ([#577](https://github.com/heroku/libcnb.rs/pull/577))
-- `libcnb-cargo`: Added `--package-dir` command line option to control where packaged buildpacks are written. ([#583](https://github.com/heroku/libcnb.rs/pull/583))
+- `libcnb-package`: Added cross-compilation assistance for
+  Linux `aarch64-unknown-linux-musl`. ([#577](https://github.com/heroku/libcnb.rs/pull/577))
+- `libcnb-cargo`: Added `--package-dir` command line option to control where packaged buildpacks are
+  written. ([#583](https://github.com/heroku/libcnb.rs/pull/583))
 - `libcnb-test`:
-  - `LogOutput` now implements `std::fmt::Display`. ([#635](https://github.com/heroku/libcnb.rs/pull/635))
-  - `ContainerConfig` now implements `Clone`. ([#636](https://github.com/heroku/libcnb.rs/pull/636))
+    - `LogOutput` now implements `std::fmt::Display`. ([#635](https://github.com/heroku/libcnb.rs/pull/635))
+    - `ContainerConfig` now implements `Clone`. ([#636](https://github.com/heroku/libcnb.rs/pull/636))
 
 ### Changed
 
-- `libcnb-cargo`: Moved the default location for packaged buildpacks from Cargo's `target/` directory to `packaged/` in the Cargo workspace root. This simplifies the path and stops modification of the `target/` directory which previously might have caching implications when other tools didn't expect non-Cargo output in that directory. Users that implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new locations. ([#583](https://github.com/heroku/libcnb.rs/pull/583))
+- `libcnb-cargo`: Moved the default location for packaged buildpacks from Cargo's `target/` directory to `packaged/` in
+  the Cargo workspace root. This simplifies the path and stops modification of the `target/` directory which previously
+  might have caching implications when other tools didn't expect non-Cargo output in that directory. Users that
+  implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new
+  locations. ([#583](https://github.com/heroku/libcnb.rs/pull/583))
 - `libcnb-package`:
-  - buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
-  - `get_buildpack_target_dir` was renamed to `get_buildpack_package_dir` ([#583](https://github.com/heroku/libcnb.rs/pull/583))
+    - buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need
+      to adapt. The output of `cargo libcnb package` will refer to the new
+      locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
+    - `get_buildpack_target_dir` was renamed
+      to `get_buildpack_package_dir` ([#583](https://github.com/heroku/libcnb.rs/pull/583))
 - `libcnb-test`:
-  - `ContainerContext::address_for_port` will now panic for all failure modes rather than just some, and so now returns `SocketAddr` directly instead of `Option<SocketAddr>`. This reduces test boilerplate due to the caller no longer needing to `.unwrap()` and improves debugging UX when containers crash after startup. ([#605](https://github.com/heroku/libcnb.rs/pull/605) and [#636](https://github.com/heroku/libcnb.rs/pull/636))
-  - Docker commands are now run using the Docker CLI instead of Bollard and the Docker daemon API. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
-  - `ContainerConfig::entrypoint` now accepts a String rather than a vector of strings. Any arguments to the entrypoint should be moved to `ContainerConfig::command`. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
-  - Removed `TestRunner::new` since its only purpose was for advanced configuration that's no longer applicable. Use `TestRunner::default` instead. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
-  - Removed `stdout_raw` and `stderr_raw` from `LogOutput`. ([#607](https://github.com/heroku/libcnb.rs/pull/607))
-  - Improved wording of panic error messages. ([#619](https://github.com/heroku/libcnb.rs/pull/619) and [#620](https://github.com/heroku/libcnb.rs/pull/620))
-- `libherokubuildpack`: Changed the `flate2` decompression backend from `miniz_oxide` to `zlib`. ([#593](https://github.com/heroku/libcnb.rs/pull/593))
+    - `ContainerContext::address_for_port` will now panic for all failure modes rather than just some, and so now
+      returns `SocketAddr` directly instead of `Option<SocketAddr>`. This reduces test boilerplate due to the caller no
+      longer needing to `.unwrap()` and improves debugging UX when containers crash after
+      startup. ([#605](https://github.com/heroku/libcnb.rs/pull/605)
+      and [#636](https://github.com/heroku/libcnb.rs/pull/636))
+    - Docker commands are now run using the Docker CLI instead of Bollard and the Docker daemon
+      API. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
+    - `ContainerConfig::entrypoint` now accepts a String rather than a vector of strings. Any arguments to the
+      entrypoint should be moved to `ContainerConfig::command`. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
+    - Removed `TestRunner::new` since its only purpose was for advanced configuration that's no longer applicable.
+      Use `TestRunner::default` instead. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
+    - Removed `stdout_raw` and `stderr_raw` from `LogOutput`. ([#607](https://github.com/heroku/libcnb.rs/pull/607))
+    - Improved wording of panic error messages. ([#619](https://github.com/heroku/libcnb.rs/pull/619)
+      and [#620](https://github.com/heroku/libcnb.rs/pull/620))
+- `libherokubuildpack`: Changed the `flate2` decompression backend from `miniz_oxide`
+  to `zlib`. ([#593](https://github.com/heroku/libcnb.rs/pull/593))
 
 ### Fixed
 
 - `libcnb-test`:
-  - `TestContext::run_shell_command` and `ContainerContext::shell_exec` now validate the exit code of the spawned commands and panic if they are non-zero. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
-  - `ContainerContext::expose_port` now only exposes the port to localhost. ([#610](https://github.com/heroku/libcnb.rs/pull/610))
-  - If a test with an expected result of `PackResult::Failure` unexpectedly succeeds, the built app image is now correctly cleaned up. ([#625](https://github.com/heroku/libcnb.rs/pull/625))
+    - `TestContext::run_shell_command` and `ContainerContext::shell_exec` now validate the exit code of the spawned
+      commands and panic if they are non-zero. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
+    - `ContainerContext::expose_port` now only exposes the port to
+      localhost. ([#610](https://github.com/heroku/libcnb.rs/pull/610))
+    - If a test with an expected result of `PackResult::Failure` unexpectedly succeeds, the built app image is now
+      correctly cleaned up. ([#625](https://github.com/heroku/libcnb.rs/pull/625))
 
 ## [0.13.0] - 2023-06-21
 
-The highlight of this release is the `cargo libcnb package` changes to support compilation of both buildpacks and meta-buildpacks.
+The highlight of this release is the `cargo libcnb package` changes to support compilation of both buildpacks and
+meta-buildpacks.
 
 ### Changed
 
-- `libcnb-cargo`: The `cargo libcnb package` command now supports compiling buildpacks and meta-buildpacks ([#575](https://github.com/heroku/libcnb.rs/pull/575)):
-  - When used in a buildpack directory it will compile only that buildpack.
-  - When used in a workspace directory it will compile all buildpacks found in subdirectories.
-- `libcnb-package`: Changed `default_buildpack_directory_name` to accept a `BuildpackId` ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+- `libcnb-cargo`: The `cargo libcnb package` command now supports compiling buildpacks and
+  meta-buildpacks ([#575](https://github.com/heroku/libcnb.rs/pull/575)):
+    - When used in a buildpack directory it will compile only that buildpack.
+    - When used in a workspace directory it will compile all buildpacks found in subdirectories.
+- `libcnb-package`: Changed `default_buildpack_directory_name` to accept
+  a `BuildpackId` ([#575](https://github.com/heroku/libcnb.rs/pull/575))
 
 ### Added
 
 - `libcnb-cargo`
-  - Buildpacks can reference other buildpacks within a workspace by using `uri = "libcnb:{buildpack_id}"` as a dependency entry in the buildpack's [package.toml](https://buildpacks.io/docs/reference/config/package-config/) file. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+    - Buildpacks can reference other buildpacks within a workspace by using `uri = "libcnb:{buildpack_id}"` as a
+      dependency entry in the buildpack's [package.toml](https://buildpacks.io/docs/reference/config/package-config/)
+      file. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
 - `libcnb-data`
-  - Serialization / deserialization of [package.toml](https://buildpacks.io/docs/reference/config/package-config/) files supported with the `Buildpackage` struct. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+    - Serialization / deserialization of [package.toml](https://buildpacks.io/docs/reference/config/package-config/)
+      files supported with the `Buildpackage` struct. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
 - `libcnb-package`
-  - Added
-    `read_buildpackage_data`,
-    `find_buildpack_dirs`,
-    `get_buildpack_target_dir`
-    to support packaging operations. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
-  - Added
-    `buildpack_dependency::BuildpackDependency`,
-    `buildpack_dependency::get_local_buildpackage_dependencies`,
-    `buildpack_dependency::rewrite_buildpackage_local_dependencies`,
-    `buildpack_dependency::rewrite_buildpackage_relative_path_dependencies_to_absolute`
-    to support Buildpack dependency handling and packaging operations. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
-  - Added
-    `buildpack_package::BuildpackPackage`,
-    `buildpack_package::read_buildpack_package`
-    to support libcnb.rs-based Rust packages. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
-  - Added
-    `dependency_graph::DependencyNode`,
-    `dependency_graph::create_dependency_graph`,
-    `dependency_graph::get_dependencies`
-    to support dependency ordering and resolution in libcnb.rs-based Rust packages. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+    - Added
+      `read_buildpackage_data`,
+      `find_buildpack_dirs`,
+      `get_buildpack_target_dir`
+      to support packaging operations. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+    - Added
+      `buildpack_dependency::BuildpackDependency`,
+      `buildpack_dependency::get_local_buildpackage_dependencies`,
+      `buildpack_dependency::rewrite_buildpackage_local_dependencies`,
+      `buildpack_dependency::rewrite_buildpackage_relative_path_dependencies_to_absolute`
+      to support Buildpack dependency handling and packaging
+      operations. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+    - Added
+      `buildpack_package::BuildpackPackage`,
+      `buildpack_package::read_buildpack_package`
+      to support libcnb.rs-based Rust packages. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+    - Added
+      `dependency_graph::DependencyNode`,
+      `dependency_graph::create_dependency_graph`,
+      `dependency_graph::get_dependencies`
+      to support dependency ordering and resolution in libcnb.rs-based Rust
+      packages. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
 
 ## [0.12.0] - 2023-04-28
 
-Highlight of this release is the bump to [Buildpack API 0.9](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.9). This release contains breaking changes, please refer to the items below for migration advice.
+Highlight of this release is the bump
+to [Buildpack API 0.9](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.9). This release contains breaking
+changes, please refer to the items below for migration advice.
 
 ### Changed
 
-- libcnb.rs now targets [Buildpack API 0.9](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.9). Buildpacks need to upgrade the `api` key to `0.9` in their `buildpack.toml`. ([#567](https://github.com/heroku/libcnb.rs/pull/567))
-  - `Process` no longer supports the `direct` flag. All processes are now `direct`. Processes that need to use bash can use bash explicitly in the command. ([#567](https://github.com/heroku/libcnb.rs/pull/567))
-  - `Process::command` has been changed to a sequence of values where the first one is the executable and any additional values are arguments to the executable. The already existing `args` field behaves slightly different now as its contents can now be overridden by the user. See the [upstream CNB specification](https://github.com/buildpacks/spec/blob/buildpack/v0.9/buildpack.md#launchtoml-toml) for details. ([#567](https://github.com/heroku/libcnb.rs/pull/567))
-- `Env::get` now returns `Option<&OsString>` instead of `Option<OsString>`. This is more in line with expectations users have when dealing with a collection type. This is a breaking change, compile errors can be fixed by adding a [`Option::cloned`](https://doc.rust-lang.org/std/option/enum.Option.html#method.cloned-1) call after `Env::get` to get the old behaviour. In some cases, cloning might not be necessary, slightly improving the code that uses `Env::get`. ([#565](https://github.com/heroku/libcnb.rs/pull/565))
+- libcnb.rs now targets [Buildpack API 0.9](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.9).
+  Buildpacks need to upgrade the `api` key to `0.9` in
+  their `buildpack.toml`. ([#567](https://github.com/heroku/libcnb.rs/pull/567))
+    - `Process` no longer supports the `direct` flag. All processes are now `direct`. Processes that need to use bash
+      can use bash explicitly in the command. ([#567](https://github.com/heroku/libcnb.rs/pull/567))
+    - `Process::command` has been changed to a sequence of values where the first one is the executable and any
+      additional values are arguments to the executable. The already existing `args` field behaves slightly different
+      now as its contents can now be overridden by the user. See
+      the [upstream CNB specification](https://github.com/buildpacks/spec/blob/buildpack/v0.9/buildpack.md#launchtoml-toml)
+      for details. ([#567](https://github.com/heroku/libcnb.rs/pull/567))
+- `Env::get` now returns `Option<&OsString>` instead of `Option<OsString>`. This is more in line with expectations users
+  have when dealing with a collection type. This is a breaking change, compile errors can be fixed by adding
+  a [`Option::cloned`](https://doc.rust-lang.org/std/option/enum.Option.html#method.cloned-1) call after `Env::get` to
+  get the old behaviour. In some cases, cloning might not be necessary, slightly improving the code that
+  uses `Env::get`. ([#565](https://github.com/heroku/libcnb.rs/pull/565))
 
 ### Added
 
-- `Env::get_string_lossy` as a convenience method to work with environment variables directly. Getting a value out of an `Env` and treating its contents as unicode is a common case. Using this new method can simplify buildpack code. ([#565](https://github.com/heroku/libcnb.rs/pull/565))
+- `Env::get_string_lossy` as a convenience method to work with environment variables directly. Getting a value out of
+  an `Env` and treating its contents as unicode is a common case. Using this new method can simplify buildpack
+  code. ([#565](https://github.com/heroku/libcnb.rs/pull/565))
 - `Clone` implementation for `libcnb::layer_env::Scope`. ([#566](https://github.com/heroku/libcnb.rs/pull/566))
 
 ## [0.11.5] - 2023-02-07
@@ -191,41 +273,47 @@ Highlight of this release is the bump to [Buildpack API 0.9](https://github.com/
 ### Changed
 
 - Update `toml` to `0.7.1`. If your buildpack interacts with TOML data directly, you probably want to bump
-the `toml` version in your buildpack as well. ([#556](https://github.com/heroku/libcnb.rs/pull/556))
+  the `toml` version in your buildpack as well. ([#556](https://github.com/heroku/libcnb.rs/pull/556))
 
 ## [0.11.4] - 2023-01-11
 
 ### Added
 
-- libcnb-data: Store struct now supports `clone()` and `default()`. ([#547](https://github.com/heroku/libcnb.rs/pull/547))
+- libcnb-data: Store struct now supports `clone()`
+  and `default()`. ([#547](https://github.com/heroku/libcnb.rs/pull/547))
 
 ## [0.11.3] - 2023-01-09
 
 ### Added
 
-- libcnb: Add `store` field to `BuildContext`, exposing the contents of `store.toml` if present. ([#543](https://github.com/heroku/libcnb.rs/pull/543))
+- libcnb: Add `store` field to `BuildContext`, exposing the contents of `store.toml` if
+  present. ([#543](https://github.com/heroku/libcnb.rs/pull/543))
 
 ## [0.11.2] - 2022-12-15
 
 ### Fixed
 
-- libcnb-test: `TestContext::download_sbom_files` now checks the exit code of the `pack sbom download` command it runs. ([#520](https://github.com/heroku/libcnb.rs/pull/520))
+- libcnb-test: `TestContext::download_sbom_files` now checks the exit code of the `pack sbom download` command it
+  runs. ([#520](https://github.com/heroku/libcnb.rs/pull/520))
 
 ### Changed
 
-- libcnb: Drop the use of the `stacker` crate when recursively removing layer directories. ([#517](https://github.com/heroku/libcnb.rs/pull/517))
+- libcnb: Drop the use of the `stacker` crate when recursively removing layer
+  directories. ([#517](https://github.com/heroku/libcnb.rs/pull/517))
 - libcnb-cargo: Updated to Clap v4. ([#511](https://github.com/heroku/libcnb.rs/pull/511))
 
 ## Added
 
-- libherokubuildpack: Add `command` and `write` modules for working with `std::process::Command` output streams. ([#535](https://github.com/heroku/libcnb.rs/pull/535))
+- libherokubuildpack: Add `command` and `write` modules for working with `std::process::Command` output
+  streams. ([#535](https://github.com/heroku/libcnb.rs/pull/535))
 
 ## [0.11.1] - 2022-09-29
 
 ### Fixed
 
 - All crates now properly include the `LICENSE` file. ([#506](https://github.com/heroku/libcnb.rs/pull/506))
-- Fix `libcnb` readme file metadata which prevented vendoring `libcnb` via `cargo vendor`. ([#506](https://github.com/heroku/libcnb.rs/pull/506))
+- Fix `libcnb` readme file metadata which prevented vendoring `libcnb`
+  via `cargo vendor`. ([#506](https://github.com/heroku/libcnb.rs/pull/506))
 
 ### Changed
 
@@ -240,7 +328,9 @@ the `toml` version in your buildpack as well. ([#556](https://github.com/heroku/
 
 ### Added
 
-- Add new crate `libherokubuildpack` with common code that can be useful when implementing buildpacks with libcnb. Originally hosted in a separate, private, repository. Code from `libherokubuildpack` might eventually find its way into libcnb.rs proper. At this point, consider it an incubator. ([#495](https://github.com/heroku/libcnb.rs/pull/495))
+- Add new crate `libherokubuildpack` with common code that can be useful when implementing buildpacks with libcnb.
+  Originally hosted in a separate, private, repository. Code from `libherokubuildpack` might eventually find its way
+  into libcnb.rs proper. At this point, consider it an incubator. ([#495](https://github.com/heroku/libcnb.rs/pull/495))
 
 ## [0.10.0] - 2022-08-31
 
@@ -251,42 +341,70 @@ version number. See the changelog below for other changes.
 
 ### Changed
 
-- libcnb.rs now targets [Buildpack API 0.8](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.8). Buildpacks need to upgrade the `api` key to `0.8` in their `buildpack.toml`. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- In accordance to the CNB specification `>=0.7`, `BuildpackId` no longer permits `sbom` as a buildpack id. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- Replace builder style functions from `Launch` with a dedicated `LaunchBuilder` to be more consistent with other builders in the library. Additionally, all fields of `Launch` can now be modified via the builder pattern. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
-- Rename `paths` field in `launch::Slice` to `path_globs` and add docs to make it clearer that these strings are Go standard library globs. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
-- Add explicit `DeleteLayerError` to provide more context when debugging layer handling problems. ([#488](https://github.com/heroku/libcnb.rs/pull/488))
+- libcnb.rs now targets [Buildpack API 0.8](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.8).
+  Buildpacks need to upgrade the `api` key to `0.8` in
+  their `buildpack.toml`. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- In accordance to the CNB specification `>=0.7`, `BuildpackId` no longer permits `sbom` as a buildpack
+  id. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Replace builder style functions from `Launch` with a dedicated `LaunchBuilder` to be more consistent with other
+  builders in the library. Additionally, all fields of `Launch` can now be modified via the builder
+  pattern. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
+- Rename `paths` field in `launch::Slice` to `path_globs` and add docs to make it clearer that these strings are Go
+  standard library globs. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
+- Add explicit `DeleteLayerError` to provide more context when debugging layer handling
+  problems. ([#488](https://github.com/heroku/libcnb.rs/pull/488))
 
 ### Fixed
 
-- Fix `BuildpackApi` to use `u64` instead of `u32` for major and minor version parts. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- Fix permission issues during layer handling when the layer contains read-only directories. ([#488](https://github.com/heroku/libcnb.rs/pull/488))
+- Fix `BuildpackApi` to use `u64` instead of `u32` for major and minor version
+  parts. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Fix permission issues during layer handling when the layer contains read-only
+  directories. ([#488](https://github.com/heroku/libcnb.rs/pull/488))
 
 ### Added
 
-- Add `BuildResultBuilder::build_sbom`, `BuildResultBuilder::launch_sbom` and `LayerResultBuilder::sbom` to enable buildpack authors to attach SBOM data for layers and launch. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Add `BuildResultBuilder::build_sbom`, `BuildResultBuilder::launch_sbom` and `LayerResultBuilder::sbom` to enable
+  buildpack authors to attach SBOM data for layers and launch. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
 - Add `sbom::SbomFormat`, describing supported SBOM formats. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
 - Add `Buildpack::sbom_formats` field. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- Add support for setting a working directory for launch processes. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- Add `TestContext::download_sbom_files` to allow testing of SBOM logic. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Add support for setting a working directory for launch
+  processes. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Add `TestContext::download_sbom_files` to allow testing of SBOM
+  logic. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
 
 ### Removed
 
-- Remove support for legacy BOM. Remove `Launch::bom`, `Build::bom`, `bom::Bom`, `bom::Entry`. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Remove support for legacy BOM.
+  Remove `Launch::bom`, `Build::bom`, `bom::Bom`, `bom::Entry`. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
 
 [unreleased]: https://github.com/heroku/libcnb.rs/compare/v0.19.0...HEAD
+
 [0.19.0]: https://github.com/heroku/libcnb.rs/compare/v0.18.0...v0.19.0
+
 [0.18.0]: https://github.com/heroku/libcnb.rs/compare/v0.17.0...v0.18.0
+
 [0.17.0]: https://github.com/heroku/libcnb.rs/compare/v0.16.0...v0.17.0
+
 [0.16.0]: https://github.com/heroku/libcnb.rs/compare/v0.15.0...v0.16.0
+
 [0.15.0]: https://github.com/heroku/libcnb.rs/compare/v0.14.0...v0.15.0
+
 [0.14.0]: https://github.com/heroku/libcnb.rs/compare/v0.13.0...v0.14.0
+
 [0.13.0]: https://github.com/heroku/libcnb.rs/compare/v0.12.0...v0.13.0
+
 [0.12.0]: https://github.com/heroku/libcnb.rs/compare/v0.11.5...v0.12.0
+
 [0.11.5]: https://github.com/heroku/libcnb.rs/compare/v0.11.4...v0.11.5
+
 [0.11.4]: https://github.com/heroku/libcnb.rs/compare/v0.11.3...v0.11.4
+
 [0.11.3]: https://github.com/heroku/libcnb.rs/compare/v0.11.2...v0.11.3
+
 [0.11.2]: https://github.com/heroku/libcnb.rs/compare/v0.11.1...v0.11.2
+
 [0.11.1]: https://github.com/heroku/libcnb.rs/compare/v0.11.0...v0.11.1
+
 [0.11.0]: https://github.com/heroku/libcnb.rs/compare/v0.10.0...v0.11.0
+
 [0.10.0]: https://github.com/heroku/libcnb.rs/compare/libcnb/v0.9.0...v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,31 +29,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `libcnb-data`:
-    - Reintroduced support for deserializing `[[stacks]]` in `buildpack.toml`.
-      ([#789](https://github.com/heroku/libcnb.rs/pull/789))
+  - Reintroduced support for deserializing `[[stacks]]` in `buildpack.toml`.
+    ([#789](https://github.com/heroku/libcnb.rs/pull/789))
 - `libherokubuildpack`:
-    - Added `buildpack_output` module. This will help buildpack authors provide consistent and delightful output to
-      their buildpack users ([#721](https://github.com/heroku/libcnb.rs/pull/721))
+  - Added `buildpack_output` module. This will help buildpack authors provide consistent and delightful output to their buildpack users ([#721](https://github.com/heroku/libcnb.rs/pull/721))
 
 ## [0.18.0] - 2024-02-12
 
 ### Changed
 
-- Now targets [Buildpack API 0.10](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.10). Buildpacks need
-  to upgrade the `api` key to `0.10` in their `buildpack.toml`. ([#773](https://github.com/heroku/libcnb.rs/pull/773))
-- Improved the consistency of cross-compilation assistance provided across all supported `target_triple` and host
-  OS/architecture combinations. [#769](https://github.com/heroku/libcnb.rs/pull/769)
-- Added cross-compilation assistance for `aarch64-unknown-linux-musl` (on macOS and ARM64 Linux)
-  and `x86_64-unknown-linux-musl` (on ARM64 Linux). [#769](https://github.com/heroku/libcnb.rs/pull/769)
+- Now targets [Buildpack API 0.10](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.10). Buildpacks need to upgrade the `api` key to `0.10` in their `buildpack.toml`. ([#773](https://github.com/heroku/libcnb.rs/pull/773))
+- Improved the consistency of cross-compilation assistance provided across all supported `target_triple` and host OS/architecture combinations. [#769](https://github.com/heroku/libcnb.rs/pull/769)
+- Added cross-compilation assistance for `aarch64-unknown-linux-musl` (on macOS and ARM64 Linux) and `x86_64-unknown-linux-musl` (on ARM64 Linux). [#769](https://github.com/heroku/libcnb.rs/pull/769)
 - Raised Minimum Supported Rust Version (MSRV) to `1.76`. ([#774](https://github.com/heroku/libcnb.rs/pull/774))
 - `libcnb`:
-    - Changed `Layer` interface from `&self` to `&mut self`. ([#669](https://github.com/heroku/libcnb.rs/pull/669))
+  - Changed `Layer` interface from `&self` to `&mut self`. ([#669](https://github.com/heroku/libcnb.rs/pull/669))
 
 ### Added
 
 - `libherokubuildpack`:
-    - `MappedWrite::unwrap` for getting the wrapped `Write` back
-      out. ([#765](https://github.com/heroku/libcnb.rs/pull/765))
+  - `MappedWrite::unwrap` for getting the wrapped `Write` back out. ([#765](https://github.com/heroku/libcnb.rs/pull/765))
 
 ### Removed
 
@@ -64,204 +59,136 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `libcnb`:
-    - An optional `trace` feature has been added that emits OpenTelemetry tracing
-      data to
-      a [File Export](https://opentelemetry.io/docs/specs/otel/protocol/file-exporter/). ([#723](https://github.com/heroku/libcnb.rs/pull/723))
+  - An optional `trace` feature has been added that emits OpenTelemetry tracing
+    data to a [File Export](https://opentelemetry.io/docs/specs/otel/protocol/file-exporter/). ([#723](https://github.com/heroku/libcnb.rs/pull/723))
 
 ## [0.16.0] - 2023-11-17
 
 ### Changed
 
 - Raised Minimum Supported Rust Version (MSRV) to `1.74`. ([#747](https://github.com/heroku/libcnb.rs/pull/747))
-- Improved the consistency of all user-facing libcnb.rs error message
-  wordings. ([#722](https://github.com/heroku/libcnb.rs/pull/722))
-- The assistance error message shown when the necessary cross-compilation tools are not found now also includes
-  the `rustup target add` step. ([#729](https://github.com/heroku/libcnb.rs/pull/729))
-- Updated the documentation for `TestRunner::build` and `TestContext::start_container` to mention when Docker resource
-  teardown occurs. ([#743](https://github.com/heroku/libcnb.rs/pull/743))
+- Improved the consistency of all user-facing libcnb.rs error message wordings. ([#722](https://github.com/heroku/libcnb.rs/pull/722))
+- The assistance error message shown when the necessary cross-compilation tools are not found now also includes the `rustup target add` step. ([#729](https://github.com/heroku/libcnb.rs/pull/729))
+- Updated the documentation for `TestRunner::build` and `TestContext::start_container` to mention when Docker resource teardown occurs. ([#743](https://github.com/heroku/libcnb.rs/pull/743))
 
 ### Fixed
 
 - `libcnb-test`:
-    - Fixed incorrect error messages being shown for buildpack compilation/packaging
-      failures. ([#720](https://github.com/heroku/libcnb.rs/pull/720))
-    - The Docker volumes created by Pack for the build and launch layer caches are now cleaned up after each
-      test. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
-    - The Docker image cleanup process no longer makes duplicate attempts to remove images when
-      using `TestContext::rebuild`. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
-    - Test failures due to the Docker daemon not being installed or started no longer cause a non-unwinding panic abort
-      with noisy traceback. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
-    - Containers created by `TestContext::start_container` are now correctly cleaned up if the container failed to
-      start. ([#742](https://github.com/heroku/libcnb.rs/pull/742))
+  - Fixed incorrect error messages being shown for buildpack compilation/packaging failures. ([#720](https://github.com/heroku/libcnb.rs/pull/720))
+  - The Docker volumes created by Pack for the build and launch layer caches are now cleaned up after each test. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
+  - The Docker image cleanup process no longer makes duplicate attempts to remove images when using `TestContext::rebuild`. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
+  - Test failures due to the Docker daemon not being installed or started no longer cause a non-unwinding panic abort with noisy traceback. ([#741](https://github.com/heroku/libcnb.rs/pull/741))
+  - Containers created by `TestContext::start_container` are now correctly cleaned up if the container failed to start. ([#742](https://github.com/heroku/libcnb.rs/pull/742))
 
 ## [0.15.0] - 2023-09-25
 
 ### Added
 
 - `libcnb`:
-    - `LayerTypes` now implements `Copy` and `Clone`. ([#670](https://github.com/heroku/libcnb.rs/pull/670)).
+  - `LayerTypes` now implements `Copy` and `Clone`. ([#670](https://github.com/heroku/libcnb.rs/pull/670)).
 - `libcnb-data`:
-    - `ExecDProgramOutputKey`, `ProcessType`, `LayerName`, `BuildpackId` and `StackId` now implement `Ord`
-      and `PartialOrd`. ([#658](https://github.com/heroku/libcnb.rs/pull/658))
-    - Added `generic::GenericMetadata` as a generic metadata type. Also makes it the default
-      for `BuildpackDescriptor`, `SingleBuildpackDescriptor`, `CompositeBuildpackDescriptor`
-      and `LayerContentMetadata`. ([#664](https://github.com/heroku/libcnb.rs/pull/664))
+  - `ExecDProgramOutputKey`, `ProcessType`, `LayerName`, `BuildpackId` and `StackId` now implement `Ord` and `PartialOrd`. ([#658](https://github.com/heroku/libcnb.rs/pull/658))
+  - Added `generic::GenericMetadata` as a generic metadata type. Also makes it the default for `BuildpackDescriptor`, `SingleBuildpackDescriptor`, `CompositeBuildpackDescriptor` and `LayerContentMetadata`. ([#664](https://github.com/heroku/libcnb.rs/pull/664))
 - `libcnb-test`:
-    - Added the `BuildpackReference::WorkspaceBuildpack` enum variant. This allows for the testing of any libcnb.rs or
-      composite buildpack in the Cargo workspace, instead of only the buildpack of the current crate. **Note: The
-      testing of composite buildpacks requires `pack` CLI version `>=0.30`.
-      ** ([#666](https://github.com/heroku/libcnb.rs/pull/666))
+  - Added the `BuildpackReference::WorkspaceBuildpack` enum variant. This allows for the testing of any libcnb.rs or composite buildpack in the Cargo workspace, instead of only the buildpack of the current crate. **Note: The testing of composite buildpacks requires `pack` CLI version `>=0.30`.** ([#666](https://github.com/heroku/libcnb.rs/pull/666))
 
 ### Changed
 
 - `libcnb-data`:
-    - Renamed the `buildpackage` module to `package_descriptor`, and the `Buildpackage*` types within it
-      to `PackageDescriptor*`. ([#656](https://github.com/heroku/libcnb.rs/pull/656))
-    - Renamed multiple types to match the new composite vs component
-      buildpack [upstream terminology](https://github.com/buildpacks/spec/blob/main/buildpack.md#cnb-terminology).
-      Renamed `SingleBuildpackDescriptor` to `ComponentBuildpackDescriptor`, `MetaBuildpackDescriptor`
-      to `CompositeBuildpackDescriptor` and `BuildpackDescriptor::{Single,Meta}`
-      to `BuildpackDescriptor::{Component,Composite}`. ([#682](https://github.com/heroku/libcnb.rs/pull/682))
+  - Renamed the `buildpackage` module to `package_descriptor`, and the `Buildpackage*` types within it to `PackageDescriptor*`. ([#656](https://github.com/heroku/libcnb.rs/pull/656))
+  - Renamed multiple types to match the new composite vs component buildpack [upstream terminology](https://github.com/buildpacks/spec/blob/main/buildpack.md#cnb-terminology). Renamed `SingleBuildpackDescriptor` to `ComponentBuildpackDescriptor`, `MetaBuildpackDescriptor` to `CompositeBuildpackDescriptor` and `BuildpackDescriptor::{Single,Meta}` to `BuildpackDescriptor::{Component,Composite}`. ([#682](https://github.com/heroku/libcnb.rs/pull/682))
 - `libcnb-cargo`:
-    - No longer outputs paths for non-libcnb.rs and non-meta
-      buildpacks. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
-    - Build output for humans changed slightly, output intended for machines/scripting didn't
-      change. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
-    - When performing buildpack detection, standard ignore files (`.ignore` and `.gitignore`) will be
-      respected. ([#673](https://github.com/heroku/libcnb.rs/pull/673))
+  - No longer outputs paths for non-libcnb.rs and non-meta buildpacks. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
+  - Build output for humans changed slightly, output intended for machines/scripting didn't change. ([#657](https://github.com/heroku/libcnb.rs/pull/657))
+  - When performing buildpack detection, standard ignore files (`.ignore` and `.gitignore`) will be respected. ([#673](https://github.com/heroku/libcnb.rs/pull/673))
 - `libcnb-test`:
-    - Renamed `BuildpackReference::Crate`
-      to `BuildpackReference::CurrentCrate`. ([#666](https://github.com/heroku/libcnb.rs/pull/666))
+  - Renamed `BuildpackReference::Crate` to `BuildpackReference::CurrentCrate`. ([#666](https://github.com/heroku/libcnb.rs/pull/666))
 
 ## [0.14.0] - 2023-08-18
 
 ### Added
 
-- `libcnb-package`: Added cross-compilation assistance for
-  Linux `aarch64-unknown-linux-musl`. ([#577](https://github.com/heroku/libcnb.rs/pull/577))
-- `libcnb-cargo`: Added `--package-dir` command line option to control where packaged buildpacks are
-  written. ([#583](https://github.com/heroku/libcnb.rs/pull/583))
+- `libcnb-package`: Added cross-compilation assistance for Linux `aarch64-unknown-linux-musl`. ([#577](https://github.com/heroku/libcnb.rs/pull/577))
+- `libcnb-cargo`: Added `--package-dir` command line option to control where packaged buildpacks are written. ([#583](https://github.com/heroku/libcnb.rs/pull/583))
 - `libcnb-test`:
-    - `LogOutput` now implements `std::fmt::Display`. ([#635](https://github.com/heroku/libcnb.rs/pull/635))
-    - `ContainerConfig` now implements `Clone`. ([#636](https://github.com/heroku/libcnb.rs/pull/636))
+  - `LogOutput` now implements `std::fmt::Display`. ([#635](https://github.com/heroku/libcnb.rs/pull/635))
+  - `ContainerConfig` now implements `Clone`. ([#636](https://github.com/heroku/libcnb.rs/pull/636))
 
 ### Changed
 
-- `libcnb-cargo`: Moved the default location for packaged buildpacks from Cargo's `target/` directory to `packaged/` in
-  the Cargo workspace root. This simplifies the path and stops modification of the `target/` directory which previously
-  might have caching implications when other tools didn't expect non-Cargo output in that directory. Users that
-  implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new
-  locations. ([#583](https://github.com/heroku/libcnb.rs/pull/583))
+- `libcnb-cargo`: Moved the default location for packaged buildpacks from Cargo's `target/` directory to `packaged/` in the Cargo workspace root. This simplifies the path and stops modification of the `target/` directory which previously might have caching implications when other tools didn't expect non-Cargo output in that directory. Users that implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new locations. ([#583](https://github.com/heroku/libcnb.rs/pull/583))
 - `libcnb-package`:
-    - buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need
-      to adapt. The output of `cargo libcnb package` will refer to the new
-      locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
-    - `get_buildpack_target_dir` was renamed
-      to `get_buildpack_package_dir` ([#583](https://github.com/heroku/libcnb.rs/pull/583))
+  - buildpack target directory now contains the target triple. Users that implicitly rely on the output directory need to adapt. The output of `cargo libcnb package` will refer to the new locations. ([#580](https://github.com/heroku/libcnb.rs/pull/580))
+  - `get_buildpack_target_dir` was renamed to `get_buildpack_package_dir` ([#583](https://github.com/heroku/libcnb.rs/pull/583))
 - `libcnb-test`:
-    - `ContainerContext::address_for_port` will now panic for all failure modes rather than just some, and so now
-      returns `SocketAddr` directly instead of `Option<SocketAddr>`. This reduces test boilerplate due to the caller no
-      longer needing to `.unwrap()` and improves debugging UX when containers crash after
-      startup. ([#605](https://github.com/heroku/libcnb.rs/pull/605)
-      and [#636](https://github.com/heroku/libcnb.rs/pull/636))
-    - Docker commands are now run using the Docker CLI instead of Bollard and the Docker daemon
-      API. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
-    - `ContainerConfig::entrypoint` now accepts a String rather than a vector of strings. Any arguments to the
-      entrypoint should be moved to `ContainerConfig::command`. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
-    - Removed `TestRunner::new` since its only purpose was for advanced configuration that's no longer applicable.
-      Use `TestRunner::default` instead. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
-    - Removed `stdout_raw` and `stderr_raw` from `LogOutput`. ([#607](https://github.com/heroku/libcnb.rs/pull/607))
-    - Improved wording of panic error messages. ([#619](https://github.com/heroku/libcnb.rs/pull/619)
-      and [#620](https://github.com/heroku/libcnb.rs/pull/620))
-- `libherokubuildpack`: Changed the `flate2` decompression backend from `miniz_oxide`
-  to `zlib`. ([#593](https://github.com/heroku/libcnb.rs/pull/593))
+  - `ContainerContext::address_for_port` will now panic for all failure modes rather than just some, and so now returns `SocketAddr` directly instead of `Option<SocketAddr>`. This reduces test boilerplate due to the caller no longer needing to `.unwrap()` and improves debugging UX when containers crash after startup. ([#605](https://github.com/heroku/libcnb.rs/pull/605) and [#636](https://github.com/heroku/libcnb.rs/pull/636))
+  - Docker commands are now run using the Docker CLI instead of Bollard and the Docker daemon API. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
+  - `ContainerConfig::entrypoint` now accepts a String rather than a vector of strings. Any arguments to the entrypoint should be moved to `ContainerConfig::command`. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
+  - Removed `TestRunner::new` since its only purpose was for advanced configuration that's no longer applicable. Use `TestRunner::default` instead. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
+  - Removed `stdout_raw` and `stderr_raw` from `LogOutput`. ([#607](https://github.com/heroku/libcnb.rs/pull/607))
+  - Improved wording of panic error messages. ([#619](https://github.com/heroku/libcnb.rs/pull/619) and [#620](https://github.com/heroku/libcnb.rs/pull/620))
+- `libherokubuildpack`: Changed the `flate2` decompression backend from `miniz_oxide` to `zlib`. ([#593](https://github.com/heroku/libcnb.rs/pull/593))
 
 ### Fixed
 
 - `libcnb-test`:
-    - `TestContext::run_shell_command` and `ContainerContext::shell_exec` now validate the exit code of the spawned
-      commands and panic if they are non-zero. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
-    - `ContainerContext::expose_port` now only exposes the port to
-      localhost. ([#610](https://github.com/heroku/libcnb.rs/pull/610))
-    - If a test with an expected result of `PackResult::Failure` unexpectedly succeeds, the built app image is now
-      correctly cleaned up. ([#625](https://github.com/heroku/libcnb.rs/pull/625))
+  - `TestContext::run_shell_command` and `ContainerContext::shell_exec` now validate the exit code of the spawned commands and panic if they are non-zero. ([#620](https://github.com/heroku/libcnb.rs/pull/620))
+  - `ContainerContext::expose_port` now only exposes the port to localhost. ([#610](https://github.com/heroku/libcnb.rs/pull/610))
+  - If a test with an expected result of `PackResult::Failure` unexpectedly succeeds, the built app image is now correctly cleaned up. ([#625](https://github.com/heroku/libcnb.rs/pull/625))
 
 ## [0.13.0] - 2023-06-21
 
-The highlight of this release is the `cargo libcnb package` changes to support compilation of both buildpacks and
-meta-buildpacks.
+The highlight of this release is the `cargo libcnb package` changes to support compilation of both buildpacks and meta-buildpacks.
 
 ### Changed
 
-- `libcnb-cargo`: The `cargo libcnb package` command now supports compiling buildpacks and
-  meta-buildpacks ([#575](https://github.com/heroku/libcnb.rs/pull/575)):
-    - When used in a buildpack directory it will compile only that buildpack.
-    - When used in a workspace directory it will compile all buildpacks found in subdirectories.
-- `libcnb-package`: Changed `default_buildpack_directory_name` to accept
-  a `BuildpackId` ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+- `libcnb-cargo`: The `cargo libcnb package` command now supports compiling buildpacks and meta-buildpacks ([#575](https://github.com/heroku/libcnb.rs/pull/575)):
+  - When used in a buildpack directory it will compile only that buildpack.
+  - When used in a workspace directory it will compile all buildpacks found in subdirectories.
+- `libcnb-package`: Changed `default_buildpack_directory_name` to accept a `BuildpackId` ([#575](https://github.com/heroku/libcnb.rs/pull/575))
 
 ### Added
 
 - `libcnb-cargo`
-    - Buildpacks can reference other buildpacks within a workspace by using `uri = "libcnb:{buildpack_id}"` as a
-      dependency entry in the buildpack's [package.toml](https://buildpacks.io/docs/reference/config/package-config/)
-      file. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+  - Buildpacks can reference other buildpacks within a workspace by using `uri = "libcnb:{buildpack_id}"` as a dependency entry in the buildpack's [package.toml](https://buildpacks.io/docs/reference/config/package-config/) file. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
 - `libcnb-data`
-    - Serialization / deserialization of [package.toml](https://buildpacks.io/docs/reference/config/package-config/)
-      files supported with the `Buildpackage` struct. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+  - Serialization / deserialization of [package.toml](https://buildpacks.io/docs/reference/config/package-config/) files supported with the `Buildpackage` struct. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
 - `libcnb-package`
-    - Added
-      `read_buildpackage_data`,
-      `find_buildpack_dirs`,
-      `get_buildpack_target_dir`
-      to support packaging operations. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
-    - Added
-      `buildpack_dependency::BuildpackDependency`,
-      `buildpack_dependency::get_local_buildpackage_dependencies`,
-      `buildpack_dependency::rewrite_buildpackage_local_dependencies`,
-      `buildpack_dependency::rewrite_buildpackage_relative_path_dependencies_to_absolute`
-      to support Buildpack dependency handling and packaging
-      operations. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
-    - Added
-      `buildpack_package::BuildpackPackage`,
-      `buildpack_package::read_buildpack_package`
-      to support libcnb.rs-based Rust packages. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
-    - Added
-      `dependency_graph::DependencyNode`,
-      `dependency_graph::create_dependency_graph`,
-      `dependency_graph::get_dependencies`
-      to support dependency ordering and resolution in libcnb.rs-based Rust
-      packages. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+  - Added
+    `read_buildpackage_data`,
+    `find_buildpack_dirs`,
+    `get_buildpack_target_dir`
+    to support packaging operations. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+  - Added
+    `buildpack_dependency::BuildpackDependency`,
+    `buildpack_dependency::get_local_buildpackage_dependencies`,
+    `buildpack_dependency::rewrite_buildpackage_local_dependencies`,
+    `buildpack_dependency::rewrite_buildpackage_relative_path_dependencies_to_absolute`
+    to support Buildpack dependency handling and packaging operations. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+  - Added
+    `buildpack_package::BuildpackPackage`,
+    `buildpack_package::read_buildpack_package`
+    to support libcnb.rs-based Rust packages. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
+  - Added
+    `dependency_graph::DependencyNode`,
+    `dependency_graph::create_dependency_graph`,
+    `dependency_graph::get_dependencies`
+    to support dependency ordering and resolution in libcnb.rs-based Rust packages. ([#575](https://github.com/heroku/libcnb.rs/pull/575))
 
 ## [0.12.0] - 2023-04-28
 
-Highlight of this release is the bump
-to [Buildpack API 0.9](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.9). This release contains breaking
-changes, please refer to the items below for migration advice.
+Highlight of this release is the bump to [Buildpack API 0.9](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.9). This release contains breaking changes, please refer to the items below for migration advice.
 
 ### Changed
 
-- libcnb.rs now targets [Buildpack API 0.9](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.9).
-  Buildpacks need to upgrade the `api` key to `0.9` in
-  their `buildpack.toml`. ([#567](https://github.com/heroku/libcnb.rs/pull/567))
-    - `Process` no longer supports the `direct` flag. All processes are now `direct`. Processes that need to use bash
-      can use bash explicitly in the command. ([#567](https://github.com/heroku/libcnb.rs/pull/567))
-    - `Process::command` has been changed to a sequence of values where the first one is the executable and any
-      additional values are arguments to the executable. The already existing `args` field behaves slightly different
-      now as its contents can now be overridden by the user. See
-      the [upstream CNB specification](https://github.com/buildpacks/spec/blob/buildpack/v0.9/buildpack.md#launchtoml-toml)
-      for details. ([#567](https://github.com/heroku/libcnb.rs/pull/567))
-- `Env::get` now returns `Option<&OsString>` instead of `Option<OsString>`. This is more in line with expectations users
-  have when dealing with a collection type. This is a breaking change, compile errors can be fixed by adding
-  a [`Option::cloned`](https://doc.rust-lang.org/std/option/enum.Option.html#method.cloned-1) call after `Env::get` to
-  get the old behaviour. In some cases, cloning might not be necessary, slightly improving the code that
-  uses `Env::get`. ([#565](https://github.com/heroku/libcnb.rs/pull/565))
+- libcnb.rs now targets [Buildpack API 0.9](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.9). Buildpacks need to upgrade the `api` key to `0.9` in their `buildpack.toml`. ([#567](https://github.com/heroku/libcnb.rs/pull/567))
+  - `Process` no longer supports the `direct` flag. All processes are now `direct`. Processes that need to use bash can use bash explicitly in the command. ([#567](https://github.com/heroku/libcnb.rs/pull/567))
+  - `Process::command` has been changed to a sequence of values where the first one is the executable and any additional values are arguments to the executable. The already existing `args` field behaves slightly different now as its contents can now be overridden by the user. See the [upstream CNB specification](https://github.com/buildpacks/spec/blob/buildpack/v0.9/buildpack.md#launchtoml-toml) for details. ([#567](https://github.com/heroku/libcnb.rs/pull/567))
+- `Env::get` now returns `Option<&OsString>` instead of `Option<OsString>`. This is more in line with expectations users have when dealing with a collection type. This is a breaking change, compile errors can be fixed by adding a [`Option::cloned`](https://doc.rust-lang.org/std/option/enum.Option.html#method.cloned-1) call after `Env::get` to get the old behaviour. In some cases, cloning might not be necessary, slightly improving the code that uses `Env::get`. ([#565](https://github.com/heroku/libcnb.rs/pull/565))
 
 ### Added
 
-- `Env::get_string_lossy` as a convenience method to work with environment variables directly. Getting a value out of
-  an `Env` and treating its contents as unicode is a common case. Using this new method can simplify buildpack
-  code. ([#565](https://github.com/heroku/libcnb.rs/pull/565))
+- `Env::get_string_lossy` as a convenience method to work with environment variables directly. Getting a value out of an `Env` and treating its contents as unicode is a common case. Using this new method can simplify buildpack code. ([#565](https://github.com/heroku/libcnb.rs/pull/565))
 - `Clone` implementation for `libcnb::layer_env::Scope`. ([#566](https://github.com/heroku/libcnb.rs/pull/566))
 
 ## [0.11.5] - 2023-02-07
@@ -269,47 +196,41 @@ changes, please refer to the items below for migration advice.
 ### Changed
 
 - Update `toml` to `0.7.1`. If your buildpack interacts with TOML data directly, you probably want to bump
-  the `toml` version in your buildpack as well. ([#556](https://github.com/heroku/libcnb.rs/pull/556))
+the `toml` version in your buildpack as well. ([#556](https://github.com/heroku/libcnb.rs/pull/556))
 
 ## [0.11.4] - 2023-01-11
 
 ### Added
 
-- libcnb-data: Store struct now supports `clone()`
-  and `default()`. ([#547](https://github.com/heroku/libcnb.rs/pull/547))
+- libcnb-data: Store struct now supports `clone()` and `default()`. ([#547](https://github.com/heroku/libcnb.rs/pull/547))
 
 ## [0.11.3] - 2023-01-09
 
 ### Added
 
-- libcnb: Add `store` field to `BuildContext`, exposing the contents of `store.toml` if
-  present. ([#543](https://github.com/heroku/libcnb.rs/pull/543))
+- libcnb: Add `store` field to `BuildContext`, exposing the contents of `store.toml` if present. ([#543](https://github.com/heroku/libcnb.rs/pull/543))
 
 ## [0.11.2] - 2022-12-15
 
 ### Fixed
 
-- libcnb-test: `TestContext::download_sbom_files` now checks the exit code of the `pack sbom download` command it
-  runs. ([#520](https://github.com/heroku/libcnb.rs/pull/520))
+- libcnb-test: `TestContext::download_sbom_files` now checks the exit code of the `pack sbom download` command it runs. ([#520](https://github.com/heroku/libcnb.rs/pull/520))
 
 ### Changed
 
-- libcnb: Drop the use of the `stacker` crate when recursively removing layer
-  directories. ([#517](https://github.com/heroku/libcnb.rs/pull/517))
+- libcnb: Drop the use of the `stacker` crate when recursively removing layer directories. ([#517](https://github.com/heroku/libcnb.rs/pull/517))
 - libcnb-cargo: Updated to Clap v4. ([#511](https://github.com/heroku/libcnb.rs/pull/511))
 
 ## Added
 
-- libherokubuildpack: Add `command` and `write` modules for working with `std::process::Command` output
-  streams. ([#535](https://github.com/heroku/libcnb.rs/pull/535))
+- libherokubuildpack: Add `command` and `write` modules for working with `std::process::Command` output streams. ([#535](https://github.com/heroku/libcnb.rs/pull/535))
 
 ## [0.11.1] - 2022-09-29
 
 ### Fixed
 
 - All crates now properly include the `LICENSE` file. ([#506](https://github.com/heroku/libcnb.rs/pull/506))
-- Fix `libcnb` readme file metadata which prevented vendoring `libcnb`
-  via `cargo vendor`. ([#506](https://github.com/heroku/libcnb.rs/pull/506))
+- Fix `libcnb` readme file metadata which prevented vendoring `libcnb` via `cargo vendor`. ([#506](https://github.com/heroku/libcnb.rs/pull/506))
 
 ### Changed
 
@@ -324,9 +245,7 @@ changes, please refer to the items below for migration advice.
 
 ### Added
 
-- Add new crate `libherokubuildpack` with common code that can be useful when implementing buildpacks with libcnb.
-  Originally hosted in a separate, private, repository. Code from `libherokubuildpack` might eventually find its way
-  into libcnb.rs proper. At this point, consider it an incubator. ([#495](https://github.com/heroku/libcnb.rs/pull/495))
+- Add new crate `libherokubuildpack` with common code that can be useful when implementing buildpacks with libcnb. Originally hosted in a separate, private, repository. Code from `libherokubuildpack` might eventually find its way into libcnb.rs proper. At this point, consider it an incubator. ([#495](https://github.com/heroku/libcnb.rs/pull/495))
 
 ## [0.10.0] - 2022-08-31
 
@@ -337,70 +256,42 @@ version number. See the changelog below for other changes.
 
 ### Changed
 
-- libcnb.rs now targets [Buildpack API 0.8](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.8).
-  Buildpacks need to upgrade the `api` key to `0.8` in
-  their `buildpack.toml`. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- In accordance to the CNB specification `>=0.7`, `BuildpackId` no longer permits `sbom` as a buildpack
-  id. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- Replace builder style functions from `Launch` with a dedicated `LaunchBuilder` to be more consistent with other
-  builders in the library. Additionally, all fields of `Launch` can now be modified via the builder
-  pattern. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
-- Rename `paths` field in `launch::Slice` to `path_globs` and add docs to make it clearer that these strings are Go
-  standard library globs. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
-- Add explicit `DeleteLayerError` to provide more context when debugging layer handling
-  problems. ([#488](https://github.com/heroku/libcnb.rs/pull/488))
+- libcnb.rs now targets [Buildpack API 0.8](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.8). Buildpacks need to upgrade the `api` key to `0.8` in their `buildpack.toml`. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- In accordance to the CNB specification `>=0.7`, `BuildpackId` no longer permits `sbom` as a buildpack id. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Replace builder style functions from `Launch` with a dedicated `LaunchBuilder` to be more consistent with other builders in the library. Additionally, all fields of `Launch` can now be modified via the builder pattern. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
+- Rename `paths` field in `launch::Slice` to `path_globs` and add docs to make it clearer that these strings are Go standard library globs. ([#487](https://github.com/heroku/libcnb.rs/pull/487))
+- Add explicit `DeleteLayerError` to provide more context when debugging layer handling problems. ([#488](https://github.com/heroku/libcnb.rs/pull/488))
 
 ### Fixed
 
-- Fix `BuildpackApi` to use `u64` instead of `u32` for major and minor version
-  parts. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- Fix permission issues during layer handling when the layer contains read-only
-  directories. ([#488](https://github.com/heroku/libcnb.rs/pull/488))
+- Fix `BuildpackApi` to use `u64` instead of `u32` for major and minor version parts. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Fix permission issues during layer handling when the layer contains read-only directories. ([#488](https://github.com/heroku/libcnb.rs/pull/488))
 
 ### Added
 
-- Add `BuildResultBuilder::build_sbom`, `BuildResultBuilder::launch_sbom` and `LayerResultBuilder::sbom` to enable
-  buildpack authors to attach SBOM data for layers and launch. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Add `BuildResultBuilder::build_sbom`, `BuildResultBuilder::launch_sbom` and `LayerResultBuilder::sbom` to enable buildpack authors to attach SBOM data for layers and launch. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
 - Add `sbom::SbomFormat`, describing supported SBOM formats. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
 - Add `Buildpack::sbom_formats` field. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- Add support for setting a working directory for launch
-  processes. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
-- Add `TestContext::download_sbom_files` to allow testing of SBOM
-  logic. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Add support for setting a working directory for launch processes. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Add `TestContext::download_sbom_files` to allow testing of SBOM logic. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
 
 ### Removed
 
-- Remove support for legacy BOM.
-  Remove `Launch::bom`, `Build::bom`, `bom::Bom`, `bom::Entry`. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
+- Remove support for legacy BOM. Remove `Launch::bom`, `Build::bom`, `bom::Bom`, `bom::Entry`. ([#489](https://github.com/heroku/libcnb.rs/pull/489))
 
 [unreleased]: https://github.com/heroku/libcnb.rs/compare/v0.19.0...HEAD
-
 [0.19.0]: https://github.com/heroku/libcnb.rs/compare/v0.18.0...v0.19.0
-
 [0.18.0]: https://github.com/heroku/libcnb.rs/compare/v0.17.0...v0.18.0
-
 [0.17.0]: https://github.com/heroku/libcnb.rs/compare/v0.16.0...v0.17.0
-
 [0.16.0]: https://github.com/heroku/libcnb.rs/compare/v0.15.0...v0.16.0
-
 [0.15.0]: https://github.com/heroku/libcnb.rs/compare/v0.14.0...v0.15.0
-
 [0.14.0]: https://github.com/heroku/libcnb.rs/compare/v0.13.0...v0.14.0
-
 [0.13.0]: https://github.com/heroku/libcnb.rs/compare/v0.12.0...v0.13.0
-
 [0.12.0]: https://github.com/heroku/libcnb.rs/compare/v0.11.5...v0.12.0
-
 [0.11.5]: https://github.com/heroku/libcnb.rs/compare/v0.11.4...v0.11.5
-
 [0.11.4]: https://github.com/heroku/libcnb.rs/compare/v0.11.3...v0.11.4
-
 [0.11.3]: https://github.com/heroku/libcnb.rs/compare/v0.11.2...v0.11.3
-
 [0.11.2]: https://github.com/heroku/libcnb.rs/compare/v0.11.1...v0.11.2
-
 [0.11.1]: https://github.com/heroku/libcnb.rs/compare/v0.11.0...v0.11.1
-
 [0.11.0]: https://github.com/heroku/libcnb.rs/compare/v0.10.0...v0.11.0
-
 [0.10.0]: https://github.com/heroku/libcnb.rs/compare/libcnb/v0.9.0...v0.10.0

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -20,7 +20,7 @@ fs_extra = "1.3.0"
 libcnb-common.workspace = true
 libcnb-data.workspace = true
 libcnb-package.workspace = true
-regex-lite = "0.1.5"
+regex = "1.10.4"
 tempfile = "3.10.1"
 thiserror = "1.0.58"
 

--- a/libcnb-test/Cargo.toml
+++ b/libcnb-test/Cargo.toml
@@ -20,6 +20,7 @@ fs_extra = "1.3.0"
 libcnb-common.workspace = true
 libcnb-data.workspace = true
 libcnb-package.workspace = true
+regex-lite = "0.1.5"
 tempfile = "3.10.0"
 thiserror = "1.0.57"
 

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -26,4 +26,6 @@ use indoc as _;
 #[cfg(test)]
 use libcnb as _;
 #[cfg(test)]
+use regex_lite as _;
+#[cfg(test)]
 use ureq as _;

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -28,4 +28,4 @@ use libcnb as _;
 #[cfg(test)]
 use ureq as _;
 // This dependency is used by the `assert_not_contains` and `assert_not_contains_match` macros
-use regex_lite as _;
+use regex as _;

--- a/libcnb-test/src/lib.rs
+++ b/libcnb-test/src/lib.rs
@@ -26,6 +26,6 @@ use indoc as _;
 #[cfg(test)]
 use libcnb as _;
 #[cfg(test)]
-use regex_lite as _;
-#[cfg(test)]
 use ureq as _;
+// This dependency is used by the `assert_not_contains` and `assert_not_contains_match` macros
+use regex_lite as _;

--- a/libcnb-test/src/macros.rs
+++ b/libcnb-test/src/macros.rs
@@ -141,6 +141,116 @@ value (escaped): `{:?}`: {}"#,
     }};
 }
 
+/// Asserts that `left` contains the `right` pattern (regular expression).
+///
+/// Commonly used when asserting `pack` output in integration tests. Expands to a regular
+/// expression match test and logs `left` (in unescaped and escaped form) as well as `right`
+/// on failure.
+///
+/// Multi-line mode is automatically enabled on regular expressions. If this is not what you
+/// want it can be disabled by adding `(?-m)` to the start of your pattern.
+///
+/// # Example
+///
+/// ```
+/// use libcnb_test::assert_contains_match;
+///
+/// let output = "Hello World!\nHello Integration Test!";
+/// assert_contains_match!(output, "Test!$");
+/// ```
+#[macro_export]
+macro_rules! assert_contains_match {
+    ($left:expr, $right:expr $(,)?) => {{
+        let regex = regex_lite::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
+        if !regex.is_match(&$left) {
+            ::std::panic!(
+                r#"assertion failed: `(left matches right pattern)`
+left (unescaped):
+{}
+
+left (escaped): `{:?}`
+right: `{:?}`"#,
+                $left,
+                $left,
+                regex
+            )
+        }
+    }};
+
+    ($left:expr, $right:expr, $($arg:tt)+) => {{
+        let regex = regex_lite::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
+        if !regex.is_match(&$left) {
+            ::std::panic!(
+                r#"assertion failed: `(left matches right pattern)`
+left (unescaped):
+{}
+
+left (escaped): `{:?}`
+right: `{:?}`: {}"#,
+                $left,
+                $left,
+                regex,
+                ::core::format_args!($($arg)+)
+            )
+        }
+    }};
+}
+
+/// Asserts that `left` does not contain the `right` pattern (regular expression).
+///
+/// Commonly used when asserting `pack` output in integration tests. Expands to a regular
+/// expression match test and logs `left` (in unescaped and escaped form) as well as `right`
+/// on failure.
+///
+/// Multi-line mode is automatically enabled on regular expressions. If this is not what you
+/// want it can be disabled by adding `(?-m)` to the start of your pattern.
+///
+/// # Example
+///
+/// ```
+/// use libcnb_test::assert_not_contains_match;
+///
+/// let output = "Hello World!\nHello Integration Test!";
+/// assert_not_contains_match!(output, "Test!$");
+/// ```
+#[macro_export]
+macro_rules! assert_not_contains_match {
+    ($left:expr, $right:expr $(,)?) => {{
+        let regex = regex_lite::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
+        if regex.is_match(&$left) {
+            ::std::panic!(
+                r#"assertion failed: `(left does not match right pattern)`
+left (unescaped):
+{}
+
+left (escaped): `{:?}`
+right: `{:?}`"#,
+                $left,
+                $left,
+                regex
+            )
+        }
+    }};
+
+    ($left:expr, $right:expr, $($arg:tt)+) => {{
+        let regex = regex_lite::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
+        if regex.is_match(&$left) {
+            ::std::panic!(
+                r#"assertion failed: `(left does not match right pattern)`
+left (unescaped):
+{}
+
+left (escaped): `{:?}`
+right: `{:?}`: {}"#,
+                $left,
+                $left,
+                regex,
+                ::core::format_args!($($arg)+)
+            )
+        }
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -331,5 +441,179 @@ Baz
 value (escaped): `\"Hello World!\\nFoo\\nBar\\nBaz\"`: Greeting must be empty!")]
     fn empty_multiline_failure_with_args() {
         assert_empty!("Hello World!\nFoo\nBar\nBaz", "Greeting must be empty!");
+    }
+
+    #[test]
+    fn contains_match_simple() {
+        assert_contains_match!("Hello World!", "(?i)hello world!");
+    }
+
+    #[test]
+    fn contains_match_simple_with_args() {
+        assert_contains_match!("Hello World!", "(?i)hello world!", "World must be greeted");
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: `(left matches right pattern)`
+left (unescaped):
+foo
+
+left (escaped): `\"foo\"`
+right: `Regex(\"(?m)bar\")`")]
+    fn contains_match_simple_failure() {
+        assert_contains_match!("foo", "bar");
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: `(left matches right pattern)`
+left (unescaped):
+Hello World!
+
+left (escaped): `\"Hello World!\"`
+right: `Regex(\"(?m)(?-i)world\")`: World must be case-sensitively greeted!")]
+    fn contains_match_simple_failure_with_args() {
+        assert_contains_match!(
+            "Hello World!",
+            "(?-i)world",
+            "World must be case-sensitively greeted!"
+        );
+    }
+
+    #[test]
+    fn contains_match_multiline() {
+        assert_contains_match!("Hello World!\nFoo\nBar\nBaz", "^Bar$");
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: `(left matches right pattern)`
+left (unescaped):
+Hello World!
+Foo
+Bar
+Baz
+
+left (escaped): `\"Hello World!\\nFoo\\nBar\\nBaz\"`
+right: `Regex(\"(?m)Eggs\")`")]
+    fn contains_match_multiline_failure() {
+        assert_contains_match!("Hello World!\nFoo\nBar\nBaz", "Eggs");
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: `(left matches right pattern)`
+left (unescaped):
+Hello World!
+Foo
+Bar
+Baz
+
+left (escaped): `\"Hello World!\\nFoo\\nBar\\nBaz\"`
+right: `Regex(\"(?m)Eggs\")`: We need eggs!")]
+    fn contains_match_multiline_failure_with_args() {
+        assert_contains_match!("Hello World!\nFoo\nBar\nBaz", "Eggs", "We need eggs!");
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "should be a valid regex: Error { msg: \"found open group without closing ')'\" }"
+    )]
+    fn contains_match_with_invalid_regex() {
+        assert_contains_match!("Hello World!", "(unclosed capture");
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "should be a valid regex: Error { msg: \"found open group without closing ')'\" }"
+    )]
+    fn contains_match_with_invalid_regex_and_args() {
+        assert_contains_match!("Hello World!", "(unclosed capture", "This should fail.");
+    }
+
+    #[test]
+    fn not_contains_match_simple() {
+        assert_not_contains_match!("Hello World!", "^World");
+    }
+
+    #[test]
+    fn not_contains_match_simple_with_args() {
+        assert_not_contains_match!("Hello World!", "^World", "World must not be at the start!");
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: `(left does not match right pattern)`
+left (unescaped):
+foobar
+
+left (escaped): `\"foobar\"`
+right: `Regex(\"(?m)bar\")`")]
+    fn not_contains_match_simple_failure() {
+        assert_not_contains_match!("foobar", "bar");
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: `(left does not match right pattern)`
+left (unescaped):
+Hello Germany!
+
+left (escaped): `\"Hello Germany!\"`
+right: `Regex(\"(?m)Germany!$\")`: Germany must not be greeted!")]
+    fn not_contains_match_simple_failure_with_args() {
+        assert_not_contains_match!(
+            "Hello Germany!",
+            "Germany!$",
+            "Germany must not be greeted!"
+        );
+    }
+
+    #[test]
+    fn not_contains_match_multiline() {
+        assert_not_contains_match!("Hello World!\nFoo\nBar\nBaz", "^Germany$");
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: `(left does not match right pattern)`
+left (unescaped):
+Hello World!
+Foo
+Bar
+Baz
+
+left (escaped): `\"Hello World!\\nFoo\\nBar\\nBaz\"`
+right: `Regex(\"(?m)^Bar$\")`")]
+    fn not_contains_match_multiline_failure() {
+        assert_not_contains_match!("Hello World!\nFoo\nBar\nBaz", "^Bar$");
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: `(left does not match right pattern)`
+left (unescaped):
+Hello Eggs!
+Foo
+Bar
+Baz
+
+left (escaped): `\"Hello Eggs!\\nFoo\\nBar\\nBaz\"`
+right: `Regex(\"(?m)Eggs!$\")`: We must not have eggs!")]
+    fn not_contains_match_multiline_failure_with_args() {
+        assert_not_contains_match!(
+            "Hello Eggs!\nFoo\nBar\nBaz",
+            "Eggs!$",
+            "We must not have eggs!"
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "should be a valid regex: Error { msg: \"found open group without closing ')'\" }"
+    )]
+    fn not_contains_match_with_invalid_regex() {
+        assert_not_contains_match!("Hello World!", "(unclosed capture");
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "should be a valid regex: Error { msg: \"found open group without closing ')'\" }"
+    )]
+    fn not_contains_match_with_invalid_regex_and_args() {
+        assert_not_contains_match!("Hello World!", "(unclosed capture", "This will fail");
     }
 }

--- a/libcnb-test/src/macros.rs
+++ b/libcnb-test/src/macros.rs
@@ -161,7 +161,7 @@ value (escaped): `{:?}`: {}"#,
 #[macro_export]
 macro_rules! assert_contains_match {
     ($left:expr, $right:expr $(,)?) => {{
-        let regex = regex_lite::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
+        let regex = regex::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
         if !regex.is_match(&$left) {
             ::std::panic!(
                 r#"assertion failed: `(left matches right pattern)`
@@ -178,7 +178,7 @@ right: `{:?}`"#,
     }};
 
     ($left:expr, $right:expr, $($arg:tt)+) => {{
-        let regex = regex_lite::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
+        let regex = regex::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
         if !regex.is_match(&$left) {
             ::std::panic!(
                 r#"assertion failed: `(left matches right pattern)`
@@ -216,7 +216,7 @@ right: `{:?}`: {}"#,
 #[macro_export]
 macro_rules! assert_not_contains_match {
     ($left:expr, $right:expr $(,)?) => {{
-        let regex = regex_lite::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
+        let regex = regex::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
         if regex.is_match(&$left) {
             ::std::panic!(
                 r#"assertion failed: `(left does not match right pattern)`
@@ -233,7 +233,7 @@ right: `{:?}`"#,
     }};
 
     ($left:expr, $right:expr, $($arg:tt)+) => {{
-        let regex = regex_lite::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
+        let regex = regex::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
         if regex.is_match(&$left) {
             ::std::panic!(
                 r#"assertion failed: `(left does not match right pattern)`

--- a/libcnb-test/src/macros.rs
+++ b/libcnb-test/src/macros.rs
@@ -513,19 +513,29 @@ right: `Regex(\"(?m)Eggs\")`: We need eggs!")]
     }
 
     #[test]
-    #[should_panic(
-        expected = "should be a valid regex: Error { msg: \"found open group without closing ')'\" }"
-    )]
+    #[should_panic(expected = "should be a valid regex: Syntax(
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+regex parse error:
+    (?m)(unclosed group
+        ^
+error: unclosed group
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+)")]
     fn contains_match_with_invalid_regex() {
-        assert_contains_match!("Hello World!", "(unclosed capture");
+        assert_contains_match!("Hello World!", "(unclosed group");
     }
 
     #[test]
-    #[should_panic(
-        expected = "should be a valid regex: Error { msg: \"found open group without closing ')'\" }"
-    )]
+    #[should_panic(expected = "should be a valid regex: Syntax(
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+regex parse error:
+    (?m)(unclosed group
+        ^
+error: unclosed group
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+)")]
     fn contains_match_with_invalid_regex_and_args() {
-        assert_contains_match!("Hello World!", "(unclosed capture", "This should fail.");
+        assert_contains_match!("Hello World!", "(unclosed group", "This should fail.");
     }
 
     #[test]
@@ -602,18 +612,28 @@ right: `Regex(\"(?m)Eggs!$\")`: We must not have eggs!")]
     }
 
     #[test]
-    #[should_panic(
-        expected = "should be a valid regex: Error { msg: \"found open group without closing ')'\" }"
-    )]
+    #[should_panic(expected = "should be a valid regex: Syntax(
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+regex parse error:
+    (?m)(unclosed group
+        ^
+error: unclosed group
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+)")]
     fn not_contains_match_with_invalid_regex() {
-        assert_not_contains_match!("Hello World!", "(unclosed capture");
+        assert_not_contains_match!("Hello World!", "(unclosed group");
     }
 
     #[test]
-    #[should_panic(
-        expected = "should be a valid regex: Error { msg: \"found open group without closing ')'\" }"
-    )]
+    #[should_panic(expected = "should be a valid regex: Syntax(
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+regex parse error:
+    (?m)(unclosed group
+        ^
+error: unclosed group
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+)")]
     fn not_contains_match_with_invalid_regex_and_args() {
-        assert_not_contains_match!("Hello World!", "(unclosed capture", "This will fail");
+        assert_not_contains_match!("Hello World!", "(unclosed group", "This will fail");
     }
 }

--- a/libcnb-test/src/macros.rs
+++ b/libcnb-test/src/macros.rs
@@ -211,7 +211,7 @@ right: `{:?}`: {}"#,
 /// use libcnb_test::assert_not_contains_match;
 ///
 /// let output = "Hello World!\nHello Integration Test!";
-/// assert_not_contains_match!(output, "Test!$");
+/// assert_not_contains_match!(output, "^Test!");
 /// ```
 #[macro_export]
 macro_rules! assert_not_contains_match {


### PR DESCRIPTION
Extracted these from https://github.com/heroku/buildpacks-apt/pull/8 which uses these macros to test for output that cannot be done reliably using just `assert_contains` and `assert_not_contains` because of the presence of random variations like the names of temporary test folders.