### PR TITLE
Make the run image `Target` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `libcnb`:
+  - Made `Target` (the type of `DetectContext::target` and `BuildContext::target`) public. ([#815](https://github.com/heroku/libcnb.rs/pull/815))
+
 ### Changed
 
 - `libcnb`:
   - `WriteLayerError` changed to contain more specific error enums instead of generic ones. ([#786](https://github.com/heroku/libcnb.rs/pull/786))
-
-### Fixed
-
-- `libcnb`
-  - Fixed the Docker label names mentioned in the rustdocs for `ContextTarget`'s `distro_name` and `distro_version`. ([#811](https://github.com/heroku/libcnb.rs/pull/811))
+- `libcnb-data`:
+  - Renamed `Target` to `BuildpackTarget` to disambiguate it from the new `libcnb::Target`. ([#815](https://github.com/heroku/libcnb.rs/pull/815))
 
 ## [0.19.0] - 2024-02-23
 
@@ -47,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Types, errors, macros and functions related to stacks. The concept of stacks has been removed from the CNB spec. Use `Target` instead. ([#773](https://github.com/heroku/libcnb.rs/pull/773))
+- Types, errors, macros and functions related to stacks. The concept of stacks has been removed from the CNB spec. Use targets instead. ([#773](https://github.com/heroku/libcnb.rs/pull/773))
 
 ## [0.17.0] - 2023-12-06
 

--- a/libcnb-data/src/buildpack/mod.rs
+++ b/libcnb-data/src/buildpack/mod.rs
@@ -81,7 +81,7 @@ impl<BM> BuildpackDescriptor<BM> {
 ///
 /// # Example:
 /// ```
-/// use libcnb_data::buildpack::{ComponentBuildpackDescriptor, Target};
+/// use libcnb_data::buildpack::{BuildpackTarget, ComponentBuildpackDescriptor};
 /// use libcnb_data::buildpack_id;
 ///
 /// let toml_str = r#"
@@ -108,11 +108,11 @@ impl<BM> BuildpackDescriptor<BM> {
 /// assert_eq!(buildpack_descriptor.buildpack.id, buildpack_id!("foo/bar"));
 /// assert_eq!(
 ///     buildpack_descriptor.targets,
-///     [Target {
+///     [BuildpackTarget {
 ///         os: Some(String::from("linux")),
 ///         arch: None,
 ///         variant: None,
-///         distros: vec![]
+///         distros: Vec::new()
 ///     }]
 /// );
 /// ```
@@ -124,7 +124,7 @@ pub struct ComponentBuildpackDescriptor<BM = GenericMetadata> {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub stacks: Vec<Stack>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub targets: Vec<Target>,
+    pub targets: Vec<BuildpackTarget>,
     pub metadata: BM,
     // As of 2024-02-09, the CNB spec does not forbid component buildpacks
     // to contain `order`. This is a change from buildpack API 0.9 where `order`
@@ -381,7 +381,7 @@ checksum = "abc123"
         assert_eq!(
             buildpack_descriptor.targets,
             [
-                Target {
+                BuildpackTarget {
                     os: Some(String::from("linux")),
                     arch: Some(String::from("amd64")),
                     variant: None,
@@ -390,19 +390,19 @@ checksum = "abc123"
                         version: String::from("18.04"),
                     }],
                 },
-                Target {
+                BuildpackTarget {
                     os: Some(String::from("linux")),
                     arch: Some(String::from("arm")),
                     variant: Some(String::from("v8")),
                     distros: Vec::new(),
                 },
-                Target {
+                BuildpackTarget {
                     os: Some(String::from("windows")),
                     arch: Some(String::from("amd64")),
                     variant: None,
                     distros: Vec::new(),
                 },
-                Target {
+                BuildpackTarget {
                     os: None,
                     arch: None,
                     variant: None,

--- a/libcnb-data/src/buildpack/target.rs
+++ b/libcnb-data/src/buildpack/target.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct Target {
+pub struct BuildpackTarget {
     pub os: Option<String>,
     pub arch: Option<String>,
     pub variant: Option<String>,

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -8,7 +8,7 @@ use crate::data::{
 };
 use crate::layer::{HandleLayerErrorOrBuildpackError, Layer, LayerData};
 use crate::sbom::Sbom;
-use crate::target::ContextTarget;
+use crate::Target;
 use std::path::PathBuf;
 
 /// Context for the build phase execution.
@@ -16,7 +16,7 @@ pub struct BuildContext<B: Buildpack + ?Sized> {
     pub layers_dir: PathBuf,
     pub app_dir: PathBuf,
     pub buildpack_dir: PathBuf,
-    pub target: ContextTarget,
+    pub target: Target,
     pub platform: B::Platform,
     pub buildpack_plan: BuildpackPlan,
     pub buildpack_descriptor: ComponentBuildpackDescriptor<B::Metadata>,

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -1,7 +1,7 @@
 //! Provides detect phase specific types and helpers.
 
 use crate::buildpack::Buildpack;
-use crate::target::ContextTarget;
+use crate::Target;
 use crate::{data::build_plan::BuildPlan, data::buildpack::ComponentBuildpackDescriptor};
 use std::fmt::Debug;
 use std::path::PathBuf;
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 pub struct DetectContext<B: Buildpack + ?Sized> {
     pub app_dir: PathBuf,
     pub buildpack_dir: PathBuf,
-    pub target: ContextTarget,
+    pub target: Target,
     pub platform: B::Platform,
     pub buildpack_descriptor: ComponentBuildpackDescriptor<B::Metadata>,
 }

--- a/libcnb/src/layer/tests.rs
+++ b/libcnb/src/layer/tests.rs
@@ -19,9 +19,8 @@ use crate::layer::{
     MetadataMigration,
 };
 use crate::layer_env::{LayerEnv, ModificationBehavior, Scope};
-use crate::target::ContextTarget;
-use crate::{read_toml_file, Buildpack, Env, LIBCNB_SUPPORTED_BUILDPACK_API};
-use libcnb_data::buildpack::{BuildpackVersion, ComponentBuildpackDescriptor, Target};
+use crate::{read_toml_file, Buildpack, Env, Target, LIBCNB_SUPPORTED_BUILDPACK_API};
+use libcnb_data::buildpack::{BuildpackTarget, BuildpackVersion, ComponentBuildpackDescriptor};
 use libcnb_data::buildpack_plan::BuildpackPlan;
 use libcnb_data::layer_content_metadata::LayerContentMetadata;
 use libcnb_data::layer_name;
@@ -901,7 +900,7 @@ fn build_context(temp_dir: &TempDir) -> BuildContext<TestBuildpack> {
         layers_dir,
         app_dir,
         buildpack_dir,
-        target: ContextTarget {
+        target: Target {
             os: String::from("linux"),
             arch: String::from("amd64"),
             arch_variant: None,
@@ -925,12 +924,12 @@ fn build_context(temp_dir: &TempDir) -> BuildContext<TestBuildpack> {
                 licenses: Vec::new(),
                 sbom_formats: HashSet::new(),
             },
-            stacks: vec![],
-            targets: vec![Target {
+            stacks: Vec::new(),
+            targets: vec![BuildpackTarget {
                 os: Some(String::from("linux")),
                 arch: Some(String::from("amd64")),
                 variant: None,
-                distros: vec![],
+                distros: Vec::new(),
             }],
             metadata: GenericMetadata::default(),
         },

--- a/libcnb/src/lib.rs
+++ b/libcnb/src/lib.rs
@@ -29,6 +29,7 @@ pub use error::*;
 pub use libcnb_common::toml_file::*;
 pub use platform::*;
 pub use runtime::*;
+pub use target::*;
 
 #[cfg(all(test, not(feature = "trace")))]
 use serde_json as _;

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -5,11 +5,10 @@ use crate::detect::{DetectContext, InnerDetectResult};
 use crate::error::Error;
 use crate::platform::Platform;
 use crate::sbom::cnb_sbom_path;
-use crate::target::ContextTarget;
 #[cfg(feature = "trace")]
 use crate::tracing::start_trace;
 use crate::util::is_not_found_error_kind;
-use crate::{exit_code, TomlFileError, LIBCNB_SUPPORTED_BUILDPACK_API};
+use crate::{exit_code, Target, TomlFileError, LIBCNB_SUPPORTED_BUILDPACK_API};
 use libcnb_common::toml_file::{read_toml_file, write_toml_file};
 use libcnb_data::buildpack::ComponentBuildpackDescriptor;
 use libcnb_data::store::Store;
@@ -358,7 +357,7 @@ fn read_buildpack_descriptor<BD: DeserializeOwned, E: Debug>() -> crate::Result<
     })
 }
 
-fn context_target<E>() -> crate::Result<ContextTarget, E>
+fn context_target<E>() -> crate::Result<Target, E>
 where
     E: Debug,
 {
@@ -368,7 +367,7 @@ where
     let distro_name = env::var("CNB_TARGET_DISTRO_NAME").ok();
     let distro_version = env::var("CNB_TARGET_DISTRO_VERSION").ok();
 
-    Ok(ContextTarget {
+    Ok(Target {
         os,
         arch,
         arch_variant,

--- a/libcnb/src/target.rs
+++ b/libcnb/src/target.rs
@@ -1,4 +1,4 @@
-pub struct ContextTarget {
+pub struct Target {
     /// The name of the target operating system.
     ///
     /// The value should conform to [Go's `$GOOS`](https://golang.org/doc/install/source#environment), for example


### PR DESCRIPTION
Previously `ContextTarget` (the type of `DetectContext::target` and `BuildContext::target`) was private, so couldn't be used by buildpacks migrating from stacks to targets.

It's now been made public, and also renamed to the slightly clearer `Target`. Since it wasn't public before, this rename on its own isn't a breaking change.

However, that means we now have two `Target`s, since `libcnb-data` has a `buildpack::Target`. Since the latter will be much less frequently used (and most of the other `buildpack::*` types are prefixed, eg `BuildpackId`, `BuildpackVersion` etc), I've renamed the `libcnb-data` type to `BuildpackTarget` to disambiguate it (which is a breaking change).

Lastly, since `ContextTarget` was never public, I've removed the existing changelog entry mentioning fixing the wording of the rustdocs (since the rustdocs weren't visible before).

GUS-W-15468609.