### PR TITLE
Serialize process working directory as working-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `libcnb-data`:
+  - The working directory for launch processes specifying a `WorkingDirectory::Directory` value is now respected. ([#831](https://github.com/heroku/libcnb.rs/pull/831))
 
 ## [0.21.0] - 2024-04-30
 

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -114,7 +114,7 @@ pub struct Process {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub default: bool,
     #[serde(
-        rename = "working-directory",
+        rename = "working-dir",
         default,
         skip_serializing_if = "WorkingDirectory::is_app"
     )]
@@ -405,7 +405,7 @@ command = ["foo"]
             r#"type = "web"
 command = ["foo"]
 default = true
-working-directory = "dist"
+working-dir = "dist"
 "#
         );
     }


### PR DESCRIPTION
Launch processes configured with a `WorkingDirectory::Directory` are currently incorrectly serialized. This PR fixes that by renaming the serialized `launch.toml` process working directory key from `working-directory` to `working-dir` ([as defined in the spec](https://github.com/buildpacks/spec/blob/7207c7dd711e28ddd045e0130e8a96e9200bf079/buildpack.md?plain=1#L909)).

This could be a breaking change for users of the library. However, a [quick GitHub search](https://github.com/search?q=WorkingDirectory%3A%3ADirectory+language%3ARust&type=code) didn't reveal any public/internal code that configures the working directory outside this repository.