### PR TITLE
Update README comment about `cargo add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Then, add the `libcnb` dependency to your project's `Cargo.toml`:
 cargo add libcnb
 ```
 
-Note: If you get an error about `cargo add` not being a supported command, make sure you are
-using Rust 1.62+, or else install [cargo-edit](https://github.com/killercup/cargo-edit).
+Note: If you get an error about `cargo add` not being a supported command, your Rust version is too old
+and will need to be updated (ideally to the latest stable version).
 
 Since we're writing a Cloud Native Buildpack, we also need a `buildpack.toml`. Use the template below and write it to a
 file named `buildpack.toml` in the root of your project, right next to `Cargo.toml`.


### PR DESCRIPTION
Since `libcnb.rs`'s minimum Rust version is now Rust 1.76, so the "or install cargo-edit" suggestion won't help if `cargo add` is missing, since the user will need to update their Rust version regardless.