### PR TITLE
Reset color settings after writing body

### DIFF
--- a/libherokubuildpack/src/log.rs
+++ b/libherokubuildpack/src/log.rs
@@ -14,12 +14,12 @@ pub fn log_error(header: impl AsRef<str>, body: impl AsRef<str>) {
         .set_color(ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true))
         .unwrap();
     writeln!(&mut stream, "\n[Error: {}]", header.as_ref()).unwrap();
-    stream.reset().unwrap();
 
     stream
         .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
         .unwrap();
     writeln!(&mut stream, "{}", body.as_ref()).unwrap();
+    stream.reset().unwrap();
     stream.flush().unwrap();
 }
 
@@ -36,12 +36,12 @@ pub fn log_warning(header: impl AsRef<str>, body: impl AsRef<str>) {
         .set_color(ColorSpec::new().set_fg(Some(Color::Yellow)).set_bold(true))
         .unwrap();
     writeln!(&mut stream, "\n[Warning: {}]", header.as_ref()).unwrap();
-    stream.reset().unwrap();
 
     stream
         .set_color(ColorSpec::new().set_fg(Some(Color::Yellow)))
         .unwrap();
     writeln!(&mut stream, "{}", body.as_ref()).unwrap();
+    stream.reset().unwrap();
     stream.flush().unwrap();
 }
 


### PR DESCRIPTION
The color settings are currently reset immediately after writing the header value in the `log_warning` and `log_error` functions, but before setting and writing the (non-bold), colored body value.

As a result, the color setting persist after the function call (e.g. after logging a warning, subsequent `log_info` output will be yellow). I might be missing something here -- but I doubt that's the intended behavior?