### PR TITLE
Fix clippy warnings with newer Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,9 @@ unused_crate_dependencies = "warn"
 
 [workspace.lints.clippy]
 panic_in_result_fn = "warn"
-pedantic = "warn"
+# The explicit priority is required due to https://github.com/rust-lang/cargo/issues/13565.
+pedantic = { level = "warn", priority = -1 }
+
 unwrap_used = "warn"
 # In most cases adding error docs provides little value.
 missing_errors_doc = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ unused_crate_dependencies = "warn"
 panic_in_result_fn = "warn"
 # The explicit priority is required due to https://github.com/rust-lang/cargo/issues/13565.
 pedantic = { level = "warn", priority = -1 }
-
 unwrap_used = "warn"
 # In most cases adding error docs provides little value.
 missing_errors_doc = "allow"

--- a/libcnb-package/src/package.rs
+++ b/libcnb-package/src/package.rs
@@ -64,7 +64,7 @@ fn package_libcnb_buildpack(
     destination: &Path,
 ) -> Result<(), PackageLibcnbBuildpackError> {
     let cargo_metadata = MetadataCommand::new()
-        .manifest_path(&buildpack_directory.join("Cargo.toml"))
+        .manifest_path(buildpack_directory.join("Cargo.toml"))
         .exec()
         .map_err(PackageLibcnbBuildpackError::CargoMetadataError)?;
 


### PR DESCRIPTION
Similar to:

- https://github.com/heroku/buildpacks-python/blob/bb0264c8bb0c8b429951c97bf9fdfb894bb78878/Cargo.toml#L15-L16
- https://github.com/heroku/buildpacks-ruby/pull/314/commits/87c5302be420e394d3d8a2cbb6dc95df82ab6b79

```
$ cargo clippy --all-targets --all-features -- --deny warnings
    Checking num-rational v0.4.2
   Compiling libcnb-proc-macros v0.22.0 (/Users/rschneeman/Documents/projects/work/libcnb.rs/libcnb-proc-macros)
    Checking libcnb-common v0.22.0 (/Users/rschneeman/Documents/projects/work/libcnb.rs/libcnb-common)
    Checking time v0.3.30
    Checking ahash v0.8.11
    Checking opentelemetry_sdk v0.21.2
error: lint group `pedantic` has the same priority (0) as a lint
  --> Cargo.toml:33:1
   |
33 | pedantic = "warn"
   | ^^^^^^^^   ------ has an implicit priority of 0
34 | unwrap_used = "warn"
   | ----------- has the same priority as this lint
   |
   = note: the order of the lints in the table is ignored by Cargo
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#lint_groups_priority
   = note: `#[deny(clippy::lint_groups_priority)]` on by default
help: to have lints override the group set `pedantic` to a lower priority
   |
33 | pedantic = { level = "warn", priority = -1 }
   |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```