### PR TITLE
libcnb-test: Use `--trust-extra-buildpacks` with `pack build`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.3
       - name: Install Pack CLI
-        uses: buildpacks/github-actions/setup-pack@v5.7.2
+        uses: buildpacks/github-actions/setup-pack@v5.7.4
       - name: Run integration tests
         # Runs only tests annotated with the `ignore` attribute (which in this repo, are the integration tests).
         run: cargo test -- --ignored
@@ -93,4 +93,4 @@ jobs:
         # This image used the experimental image extensions feature which has to be explicitly enabled and doesn't
         # work with `--trust-builder`. To unblock CI, the builder has been changed to `heroku/builder:22`. As soon as
         # we can, we should use a non-libc builder again.
-        run: pack build example-basics --force-color --builder heroku/builder:22 --trust-builder --buildpack packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_basics --path examples/
+        run: pack build example-basics --force-color --builder heroku/builder:22 --trust-builder --trust-extra-buildpacks --buildpack packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_basics --path examples/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `libcnb-test`:
+  - `pack build` is now run with `--trust-extra-buildpacks` to force the builder to be trusted after upstream changes in Pack CLI. Pack CLI v0.35.1+ is now required to use `libcnb-test`. ([#855](https://github.com/heroku/libcnb.rs/pull/855))
 
 ## [0.22.0] - 2024-06-18
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Successfully wrote buildpack directory: packaged/x86_64-unknown-linux-musl/debug
 💡 To test your buildpack locally with pack, run:
 pack build my-image-name \
   --buildpack packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_my-buildpack \
+  --trust-extra-buildpacks \
   --path /path/to/application
 
 /Users/example/src/my-buildpack/packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_my-buildpack
@@ -206,7 +207,7 @@ application code at all, we just create an empty directory and use that as our a
 
 ```console
 $ mkdir bogus-app
-$ pack build my-image --buildpack packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_my-buildpack --path bogus-app --builder heroku/builder:22
+$ pack build my-image --buildpack packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_my-buildpack --trust-extra-buildpacks --path bogus-app --builder heroku/builder:22
 ...
 ===> ANALYZING
 Image with name "my-image" not found

--- a/libcnb-cargo/README.md
+++ b/libcnb-cargo/README.md
@@ -46,6 +46,7 @@ Successfully wrote buildpack directory: packaged/x86_64-unknown-linux-musl/debug
 💡 To test your buildpack locally with pack, run:
 pack build my-image-name \
   --buildpack packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_my-buildpack \
+  --trust-extra-buildpacks \
   --path /path/to/application
 
 /Users/example/src/my-buildpack/packaged/x86_64-unknown-linux-musl/debug/libcnb-examples_my-buildpack

--- a/libcnb-cargo/src/package/command.rs
+++ b/libcnb-cargo/src/package/command.rs
@@ -147,6 +147,7 @@ fn eprint_pack_command_hint(
                 .to_string_lossy()
         );
     }
+    eprintln!("  --trust-extra-buildpacks \\");
     eprintln!("  --path /path/to/application");
     eprintln!();
 }

--- a/libcnb-test/README.md
+++ b/libcnb-test/README.md
@@ -15,7 +15,7 @@ The framework:
 Integration tests require the following to be available on the host:
 
 - [Docker](https://docs.docker.com/engine/install/)
-- [Pack CLI](https://buildpacks.io/docs/install-pack/)
+- [Pack CLI](https://buildpacks.io/docs/install-pack/) v0.35.1+
 - [Cross-compilation prerequisites](https://docs.rs/libcnb/latest/libcnb/#cross-compilation-prerequisites) (however `libcnb-cargo` itself is not required)
 
 Only local Docker daemons are fully supported. As such, if you are using Circle CI you must use the

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -14,6 +14,7 @@ pub(crate) struct PackBuildCommand {
     path: PathBuf,
     pull_policy: PullPolicy,
     trust_builder: bool,
+    trust_extra_buildpacks: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -65,6 +66,7 @@ impl PackBuildCommand {
             // Prevent redundant image-pulling, which slows tests and risks hitting registry rate limits.
             pull_policy: PullPolicy::IfNotPresent,
             trust_builder: true,
+            trust_extra_buildpacks: true,
         }
     }
 
@@ -124,6 +126,10 @@ impl From<PackBuildCommand> for Command {
 
         if pack_build_command.trust_builder {
             command.arg("--trust-builder");
+        }
+
+        if pack_build_command.trust_extra_buildpacks {
+            command.arg("--trust-extra-buildpacks");
         }
 
         command
@@ -188,6 +194,7 @@ mod tests {
             path: PathBuf::from("/tmp/foo/bar"),
             pull_policy: PullPolicy::IfNotPresent,
             trust_builder: true,
+            trust_extra_buildpacks: true,
         };
 
         let command: Command = input.clone().into();
@@ -218,6 +225,7 @@ mod tests {
                 "--env",
                 "ENV_FOO=FOO_VALUE",
                 "--trust-builder",
+                "--trust-extra-buildpacks",
             ]
         );
 

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -263,7 +263,12 @@ pack command failed with exit code 1!
 
 ## stderr:
 
-ERROR: failed to build: invalid builder 'invalid!'")]
+ERROR: forbidden image name: parsing builder image invalid!: could not parse reference: invalid!
+
+## stdout:
+
+
+")]
 fn unexpected_pack_failure() {
     TestRunner::default().build(
         BuildConfig::new("invalid!", "tests/fixtures/empty").buildpacks(Vec::new()),
@@ -306,7 +311,7 @@ fn expected_pack_failure() {
             assert_empty!(context.pack_stdout);
             assert_contains!(
                 context.pack_stderr,
-                "ERROR: failed to build: invalid builder 'invalid!'"
+                "ERROR: forbidden image name: parsing builder image invalid!"
             );
         },
     );


### PR DESCRIPTION
To force the builder to be trusted after changes were made in Pack CLI v0.35.0 to improve security:
https://github.com/buildpacks/pack/issues/2228

The new flag to restore the old behaviour was only added in Pack v0.35.1, so using `libcnb-test` now requires that Pack version or newer. (Adding a version check would require calling out to Pack before every test execution, which is not worth it given that it only affects tests, and this will be a one-off transition.)

Fixes #854.
GUS-W-16600037.