### PR TITLE
Support for Docker "--volume" mounts during integration tests.

### DIFF
--- a/libcnb-test/src/container_config.rs
+++ b/libcnb-test/src/container_config.rs
@@ -31,6 +31,7 @@ pub struct ContainerConfig {
     pub(crate) command: Option<Vec<String>>,
     pub(crate) env: HashMap<String, String>,
     pub(crate) exposed_ports: HashSet<u16>,
+    pub(crate) volumes: Option<Vec<String>>,
 }
 
 impl ContainerConfig {
@@ -196,6 +197,33 @@ impl ContainerConfig {
             self.env(key.into(), value.into());
         });
 
+        self
+    }
+
+    /// Attaches container volumes. Useful for integration tests that
+    /// depend on persistent storage shared between container executions.
+    ///
+    /// See: [Docker CLI, Mount Volume](https://docs.docker.com/reference/cli/docker/container/run/#volume)
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{BuildConfig, ContainerConfig, TestRunner};
+    ///
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "tests/fixtures/app"),
+    ///     |context| {
+    ///         // ...
+    ///         context.start_container(
+    ///             ContainerConfig::new().volumes(["/shared/cache:/workspace/cache"]),
+    ///             |container| {
+    ///                 // ...
+    ///             },
+    ///         );
+    ///     },
+    /// );
+    /// ```
+    pub fn volumes<I: IntoIterator<Item = S>, S: Into<String>>(&mut self, volumes: I) -> &mut Self {
+        self.volumes = Some(volumes.into_iter().map(S::into).collect());
         self
     }
 }

--- a/libcnb-test/src/test_context.rs
+++ b/libcnb-test/src/test_context.rs
@@ -112,6 +112,10 @@ impl<'a> TestContext<'a> {
             docker_run_command.expose_port(*port);
         });
 
+        if let Some(volume) = &config.volumes {
+            docker_run_command.volumes(volume);
+        }
+
         // We create the ContainerContext early to ensure the cleanup in ContainerContext::drop
         // is still performed even if the Docker command panics.
         let container_context = ContainerContext {


### PR DESCRIPTION
This enables using Docker volumes in integration tests, by implementing `libcnb_test::ContainerConfig::volumes()`, which generates `--volume XXXXX` arguments on the underlying `docker run` command. 