### PR TITLE
Add integration test support for Docker bind mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `libcnb-test`:
+  - Added `ContainerConfig::bind_mount` to support mounting a host machine file or directory into a container. ([#871](https://github.com/heroku/libcnb.rs/pull/871))
 
 ## [0.24.0] - 2024-10-17
 

--- a/libcnb-test/src/container_config.rs
+++ b/libcnb-test/src/container_config.rs
@@ -171,8 +171,8 @@ impl ContainerConfig {
         self
     }
 
-    /// Mount a `source` file or directory on the host machine into the container `target`. Useful
-    /// for integration tests that depend on persistent storage shared between container executions.
+    /// Mount a host file or directory `source` into the container `target`. Useful for
+    /// integration tests that depend on persistent storage shared between container executions.
     ///
     /// See: [Docker Engine: Bind Mounts](https://docs.docker.com/engine/storage/bind-mounts/)
     ///

--- a/libcnb-test/src/container_config.rs
+++ b/libcnb-test/src/container_config.rs
@@ -32,7 +32,7 @@ pub struct ContainerConfig {
     pub(crate) command: Option<Vec<String>>,
     pub(crate) env: HashMap<String, String>,
     pub(crate) exposed_ports: HashSet<u16>,
-    pub(crate) volumes: HashMap<PathBuf, PathBuf>,
+    pub(crate) bind_mounts: HashMap<PathBuf, PathBuf>,
 }
 
 impl ContainerConfig {
@@ -171,22 +171,21 @@ impl ContainerConfig {
         self
     }
 
-    /// Mounts a named volume `source` into the container `destination`. Useful for integration
-    /// tests that depend on persistent storage shared between container executions.
+    /// Mount a `source` file or directory on the host machine into the container `target`. Useful
+    /// for integration tests that depend on persistent storage shared between container executions.
     ///
-    /// See: [Docker CLI, Mount Volume](https://docs.docker.com/reference/cli/docker/container/run/#volume)
+    /// See: [Docker Engine: Bind Mounts](https://docs.docker.com/engine/storage/bind-mounts/)
     ///
     /// # Example
     /// ```no_run
     /// use libcnb_test::{BuildConfig, ContainerConfig, TestRunner};
-    /// use std::path::PathBuf;
     ///
     /// TestRunner::default().build(
     ///     BuildConfig::new("heroku/builder:22", "tests/fixtures/app"),
     ///     |context| {
     ///         // ...
     ///         context.start_container(
-    ///             ContainerConfig::new().volume(PathBuf::from("/shared/cache"), PathBuf::from("/workspace/cache")),
+    ///             ContainerConfig::new().bind_mount("/shared/cache", "/workspace/cache"),
     ///             |container| {
     ///                 // ...
     ///             },
@@ -194,12 +193,12 @@ impl ContainerConfig {
     ///     },
     /// );
     /// ```
-    pub fn volume(
+    pub fn bind_mount(
         &mut self,
         source: impl Into<PathBuf>,
-        destination: impl Into<PathBuf>,
+        target: impl Into<PathBuf>,
     ) -> &mut Self {
-        self.volumes.insert(source.into(), destination.into());
+        self.bind_mounts.insert(source.into(), target.into());
         self
     }
 

--- a/libcnb-test/src/container_config.rs
+++ b/libcnb-test/src/container_config.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// Config used when starting a container.
 ///
@@ -194,11 +194,12 @@ impl ContainerConfig {
     ///     },
     /// );
     /// ```
-    pub fn volume(&mut self, source: impl AsRef<Path>, destination: impl AsRef<Path>) -> &mut Self {
-        self.volumes.insert(
-            source.as_ref().to_path_buf(),
-            destination.as_ref().to_path_buf(),
-        );
+    pub fn volume(
+        &mut self,
+        source: impl Into<PathBuf>,
+        destination: impl Into<PathBuf>,
+    ) -> &mut Self {
+        self.volumes.insert(source.into(), destination.into());
         self
     }
 

--- a/libcnb-test/src/docker.rs
+++ b/libcnb-test/src/docker.rs
@@ -335,7 +335,7 @@ mod tests {
         docker_run_command.platform("linux/amd64");
         docker_run_command.remove(true);
         docker_run_command.volume(PathBuf::from("./test-cache"), PathBuf::from("/cache"));
-        docker_run_command.volume(PathBuf::from("foo"), PathBuf::from("/bar"));
+        docker_run_command.volume("foo", "/bar");
 
         let command: Command = docker_run_command.clone().into();
         assert_eq!(

--- a/libcnb-test/src/test_context.rs
+++ b/libcnb-test/src/test_context.rs
@@ -112,6 +112,10 @@ impl<'a> TestContext<'a> {
             docker_run_command.expose_port(*port);
         });
 
+        config.volumes.iter().for_each(|(source, destination)| {
+            docker_run_command.volume(source, destination);
+        });
+
         // We create the ContainerContext early to ensure the cleanup in ContainerContext::drop
         // is still performed even if the Docker command panics.
         let container_context = ContainerContext {

--- a/libcnb-test/src/test_context.rs
+++ b/libcnb-test/src/test_context.rs
@@ -112,8 +112,8 @@ impl<'a> TestContext<'a> {
             docker_run_command.expose_port(*port);
         });
 
-        config.volumes.iter().for_each(|(source, destination)| {
-            docker_run_command.volume(source, destination);
+        config.bind_mounts.iter().for_each(|(source, target)| {
+            docker_run_command.bind_mount(source, target);
         });
 
         // We create the ContainerContext early to ensure the cleanup in ContainerContext::drop


### PR DESCRIPTION
This PR adds support for configuring a container bind mount. See [this related discussion](https://github.com/heroku/libcnb.rs/pull/870#issuecomment-2428250702) for more details about the implementation.