### PR TITLE
Use IPv6 in in integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `libcnb-test`:
+  - The host returned by `TestContext::start_container` will now use IPv6 `::1` rather than IPv4 `127.0.0.1`. If you are using `ContainerContext::address_for_port` to assemble a URL, you may need to wrap the parsed `ip` in brackets `http://[{ip}]` ([]())
 
 ## [0.26.0] - 2024-11-18
 

--- a/libcnb-test/src/docker.rs
+++ b/libcnb-test/src/docker.rs
@@ -103,7 +103,7 @@ impl From<DockerRunCommand> for Command {
         }
 
         for port in &docker_run_command.exposed_ports {
-            command.args(["--publish", &format!("127.0.0.1::{port}")]);
+            command.args(["--publish", &format!("[::1]::{port}")]);
         }
 
         for (source, target) in &docker_run_command.bind_mounts {
@@ -355,9 +355,9 @@ mod tests {
                 "--env",
                 "FOO=1",
                 "--publish",
-                "127.0.0.1::12345",
+                "[::1]::12345",
                 "--publish",
-                "127.0.0.1::55555",
+                "[::1]::55555",
                 "--mount",
                 "type=bind,source=./test-cache,target=/cache",
                 "--mount",


### PR DESCRIPTION
Specify IPv6 host `::1` which is the equivalent of IPv4 host `127.0.0.1`.