### PR TITLE
Fix Clippy errors in latest Rust

### DIFF
--- a/examples/execd/src/bin/dice_roller.rs
+++ b/examples/execd/src/bin/dice_roller.rs
@@ -61,8 +61,8 @@ mod tests {
             .get("ROLL_1D20")
             .map(|value| value.parse::<u32>().unwrap());
 
-        assert!(roll_1d6_value.map_or(false, |value| (1..=6).contains(&value)));
-        assert!(roll_4d6_value.map_or(false, |value| (4..=32).contains(&value)));
-        assert!(roll_1d20_value.map_or(false, |value| (1..=20).contains(&value)));
+        assert!(roll_1d6_value.is_some_and(|value| (1..=6).contains(&value)));
+        assert!(roll_4d6_value.is_some_and(|value| (4..=32).contains(&value)));
+        assert!(roll_1d20_value.is_some_and(|value| (1..=20).contains(&value)));
     }
 }

--- a/libcnb-package/src/package_descriptor.rs
+++ b/libcnb-package/src/package_descriptor.rs
@@ -111,7 +111,7 @@ pub(crate) fn buildpack_id_from_libcnb_dependency(
     Some(&dependency.uri)
         .filter(|uri| {
             uri.scheme()
-                .map_or(false, |scheme| scheme.as_str() == "libcnb")
+                .is_some_and(|scheme| scheme.as_str() == "libcnb")
         })
         .map(|uri| uri.path().to_string().parse())
         .transpose()

--- a/libcnb-test/src/macros.rs
+++ b/libcnb-test/src/macros.rs
@@ -16,12 +16,12 @@ macro_rules! assert_contains {
     ($left:expr, $right:expr $(,)?) => {{
         if !$left.contains($right) {
             ::std::panic!(
-                r#"assertion failed: `(left contains right)`
+                r"assertion failed: `(left contains right)`
 left (unescaped):
 {}
 
 left (escaped): `{:?}`
-right: `{:?}`"#,
+right: `{:?}`",
                 $left,
                 $left,
                 $right,
@@ -32,12 +32,12 @@ right: `{:?}`"#,
     ($left:expr, $right:expr, $($arg:tt)+) => {{
         if !$left.contains($right) {
             ::std::panic!(
-                r#"assertion failed: `(left contains right)`
+                r"assertion failed: `(left contains right)`
 left (unescaped):
 {}
 
 left (escaped): `{:?}`
-right: `{:?}`: {}"#,
+right: `{:?}`: {}",
                 $left,
                 $left,
                 $right,
@@ -65,12 +65,12 @@ macro_rules! assert_not_contains {
     ($left:expr, $right:expr $(,)?) => {{
         if $left.contains($right) {
             ::std::panic!(
-                r#"assertion failed: `(left does not contain right)`
+                r"assertion failed: `(left does not contain right)`
 left (unescaped):
 {}
 
 left (escaped): `{:?}`
-right: `{:?}`"#,
+right: `{:?}`",
                 $left,
                 $left,
                 $right,
@@ -81,12 +81,12 @@ right: `{:?}`"#,
     ($left:expr, $right:expr, $($arg:tt)+) => {{
         if $left.contains($right) {
             ::std::panic!(
-                r#"assertion failed: `(left does not contain right)`
+                r"assertion failed: `(left does not contain right)`
 left (unescaped):
 {}
 
 left (escaped): `{:?}`
-right: `{:?}`: {}"#,
+right: `{:?}`: {}",
                 $left,
                 $left,
                 $right,
@@ -114,11 +114,11 @@ macro_rules! assert_empty {
     ($value:expr $(,)?) => {{
         if !$value.is_empty() {
             ::std::panic!(
-                r#"assertion failed: `(is empty)`
+                r"assertion failed: `(is empty)`
 value (unescaped):
 {}
 
-value (escaped): `{:?}`"#,
+value (escaped): `{:?}`",
                 $value,
                 $value,
             )
@@ -128,11 +128,11 @@ value (escaped): `{:?}`"#,
     ($value:expr, $($arg:tt)+) => {{
         if !$value.is_empty() {
             ::std::panic!(
-                r#"assertion failed: `(is empty)`
+                r"assertion failed: `(is empty)`
 value (unescaped):
 {}
 
-value (escaped): `{:?}`: {}"#,
+value (escaped): `{:?}`: {}",
                 $value,
                 $value,
                 ::core::format_args!($($arg)+)
@@ -164,12 +164,12 @@ macro_rules! assert_contains_match {
         let regex = regex::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
         if !regex.is_match(&$left) {
             ::std::panic!(
-                r#"assertion failed: `(left matches right pattern)`
+                r"assertion failed: `(left matches right pattern)`
 left (unescaped):
 {}
 
 left (escaped): `{:?}`
-right: `{:?}`"#,
+right: `{:?}`",
                 $left,
                 $left,
                 regex
@@ -181,12 +181,12 @@ right: `{:?}`"#,
         let regex = regex::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
         if !regex.is_match(&$left) {
             ::std::panic!(
-                r#"assertion failed: `(left matches right pattern)`
+                r"assertion failed: `(left matches right pattern)`
 left (unescaped):
 {}
 
 left (escaped): `{:?}`
-right: `{:?}`: {}"#,
+right: `{:?}`: {}",
                 $left,
                 $left,
                 regex,
@@ -219,12 +219,12 @@ macro_rules! assert_not_contains_match {
         let regex = regex::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
         if regex.is_match(&$left) {
             ::std::panic!(
-                r#"assertion failed: `(left does not match right pattern)`
+                r"assertion failed: `(left does not match right pattern)`
 left (unescaped):
 {}
 
 left (escaped): `{:?}`
-right: `{:?}`"#,
+right: `{:?}`",
                 $left,
                 $left,
                 regex
@@ -236,12 +236,12 @@ right: `{:?}`"#,
         let regex = regex::Regex::new(&format!("(?m){}", $right)).expect("should be a valid regex");
         if regex.is_match(&$left) {
             ::std::panic!(
-                r#"assertion failed: `(left does not match right pattern)`
+                r"assertion failed: `(left does not match right pattern)`
 left (unescaped):
 {}
 
 left (escaped): `{:?}`
-right: `{:?}`: {}"#,
+right: `{:?}`: {}",
                 $left,
                 $left,
                 regex,

--- a/libcnb-test/src/test_context.rs
+++ b/libcnb-test/src/test_context.rs
@@ -24,7 +24,7 @@ pub struct TestContext<'a> {
     pub(crate) runner: &'a TestRunner,
 }
 
-impl<'a> TestContext<'a> {
+impl TestContext<'_> {
     /// Starts a detached container using the provided [`ContainerConfig`].
     ///
     /// After the passed function has returned, the Docker container is removed.


### PR DESCRIPTION
Fixes Clippy errors like:

```
warning: unnecessary hashes around raw string literal
   --> libcnb-test/src/macros.rs:19:17
    |
19  | /                 r#"assertion failed: `(left contains right)`
20  | | left (unescaped):
21  | | {}
...   |
24  | | right: `{:?}`"#,
    | |_______________^
...
258 |           assert_contains!("Hello World!", "World");
    |           ----------------------------------------- in this macro invocation
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_raw_string_hashes
    = note: `-W clippy::needless-raw-string-hashes` implied by `-W clippy::pedantic`
    = help: to override `-W clippy::pedantic` add `#[allow(clippy::needless_raw_string_hashes)]`
    = note: this warning originates in the macro `assert_contains` (in Nightly builds, run with -Z macro-backtrace for more info)
help: remove all the hashes around the string literal
    |
19  ~                 r"assertion failed: `(left contains right)`
20  | left (unescaped):
...
23  | left (escaped): `{:?}`
24  ~ right: `{:?}`",
```

```
warning: the following explicit lifetimes could be elided: 'a
  --> libcnb-test/src/test_context.rs:27:6
   |
27 | impl<'a> TestContext<'a> {
   |      ^^              ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
   |
27 - impl<'a> TestContext<'a> {
27 + impl TestContext<'_> {
```

```
warning: this `map_or` is redundant
   --> libcnb-package/src/package_descriptor.rs:113:13
    |
113 | /             uri.scheme()
114 | |                 .map_or(false, |scheme| scheme.as_str() == "libcnb")
    | |____________________________________________________________________^ help: use is_some_and instead: `uri.scheme().is_some_and(|scheme| scheme.as_str() == "libcnb")`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
    = note: `#[warn(clippy::unnecessary_map_or)]` on by default
```