### PR TITLE
libherokubuildpack: Fix colour resetting for the `log_*` macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `libherokubuildpack`:
+  - Fixed `log_header`, `log_error` and `log_warning` to correctly reset the ANSI colour styles at the end of each line. ([#890](https://github.com/heroku/libcnb.rs/pull/890))
 
 ## [0.26.0] - 2024-11-18
 
 ### Changed
 
 - `libherokubuildpack`:
-  - Removed `buildpack_output` module. This functionality from ([#721](https://github.com/heroku/libcnb.rs/pull/721)) was experimental. The API was not stable and it is being removed. A similar API is available at [bullet_stream](https://crates.io/crates/bullet_stream). ([#852](https://github.com/heroku/libcnb.rs/pull/852)
+  - Removed `buildpack_output` module. This functionality from ([#721](https://github.com/heroku/libcnb.rs/pull/721)) was experimental. The API was not stable and it is being removed. A similar API is available at [bullet_stream](https://crates.io/crates/bullet_stream). ([#852](https://github.com/heroku/libcnb.rs/pull/852))
 
 ## [0.25.0] - 2024-10-23
 


### PR DESCRIPTION
This fixes some long-standing ANSI colour bugs with the `log_header`, `log_error` and `log_warning` macros. 

Whilst we soon want to move away to more advanced logging libraries that use the new logging style, there are still many buildpacks using these macros which will benefit short term from these fixes (Procfile, Go, Node.js, JVM, Python, PHP, buildpacks-release-phase, buildpacks-frontend-web).

The logging macros would previously emit output roughly like:

```
<colour>
[Error: Foo]
<reset><colour>Message line one.
Message line two.
```

This was not only missing the final `<reset>`, but also didn't wrap each line individually with colour codes/resets.

This causes issues when lines end up prefixed - such as the Git `remote:` prefix, or when using Pack CLI locally with an untrusted build (which adds the colourised `[builder]` prefixes) or `--timestamps` mode.

For example in this:

```
remote: <colour>
remote: [Error: Foo]
remote: <reset><colour>Message line one.
remote: Message line two.
```

...several of the `remote:`s would inherit the colours.

Instead what we need is:

```
remote: <colour><reset>
remote: <colour>[Error: Foo]<reset>
remote: <colour>Message line one.<reset>
remote: <colour>Message line two.<reset>
```

Fixes #555.
Closes #844.
GUS-W-17400078.