### PR TITLE
Update to opentelemetry 0.24

### DIFF
--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -15,7 +15,11 @@ include = ["src/**/*", "LICENSE", "README.md"]
 workspace = true
 
 [features]
-trace = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-stdout"]
+trace = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-stdout",
+]
 
 [dependencies]
 anyhow = { version = "1.0.94", optional = true }
@@ -23,9 +27,11 @@ cyclonedx-bom = { version = "0.8.0", optional = true }
 libcnb-common.workspace = true
 libcnb-data.workspace = true
 libcnb-proc-macros.workspace = true
-opentelemetry = { version = "0.21.0", optional = true }
-opentelemetry_sdk = { version = "0.21.2", optional = true }
-opentelemetry-stdout = { version = "0.2.0", optional = true, features = ["trace"] }
+opentelemetry = { version = "0.24", optional = true }
+opentelemetry_sdk = { version = "0.24", optional = true }
+opentelemetry-stdout = { version = "0.5", optional = true, features = [
+    "trace",
+] }
 serde = { version = "1.0.215", features = ["derive"] }
 thiserror = "2.0.6"
 toml.workspace = true

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -75,12 +75,10 @@ pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> Bu
     // Get a tracer identified by the instrumentation scope/library. The libcnb
     // crate name/version seems to map well to the suggestion here:
     // https://opentelemetry.io/docs/specs/otel/trace/api/#get-a-tracer.
-    let tracer = provider.versioned_tracer(
-        env!("CARGO_PKG_NAME"),
-        Some(env!("CARGO_PKG_VERSION")),
-        None as Option<&str>,
-        None,
-    );
+    let tracer = provider
+        .tracer_builder(env!("CARGO_PKG_NAME"))
+        .with_version(env!("CARGO_PKG_VERSION"))
+        .build();
 
     let mut span = tracer.start(trace_name);
     span.set_attributes([
@@ -190,6 +188,6 @@ mod tests {
         // Check error status
         assert!(tracing_contents
             .contains("\"message\":\"Custom { kind: Other, error: \\\"it's broken\\\" }"));
-        assert!(tracing_contents.contains("\"code\":1"));
+        assert!(tracing_contents.contains("\"code\":2"));
     }
 }


### PR DESCRIPTION
This updates opentelemetry to the last version that supports JSONL file exports -- at least for the moment. There was an upstream change to simplify the `opentelemetry-stdout` exporter: https://github.com/open-telemetry/opentelemetry-rust/pull/2040. With that change, the exporter lost the ability to send telemetry to a generic writer (like a buffer or file), and also lost `jsonl` serialization. Based on [this comment](https://github.com/open-telemetry/opentelemetry-rust/pull/2040#issuecomment-2508805391), there is interest in bringing this functionality back in some other form. 

I've opened an issue upstream: https://github.com/open-telemetry/opentelemetry-rust/issues/2602

Supersedes #886 