### PR TITLE
Update test assertions to match new procfile output

### DIFF
--- a/libcnb-test/tests/fixtures/buildpacks/composite/buildpack.toml
+++ b/libcnb-test/tests/fixtures/buildpacks/composite/buildpack.toml
@@ -23,4 +23,4 @@ version = "0.0.0"
 
 [[order.group]]
 id = "heroku/procfile"
-version = "3.0.1"
+version = "4.0.0"

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -40,7 +40,7 @@ fn build_other_buildpack() {
 
                     - Processes from `Procfile`
                       - web: `python3 -u -m http.server ${PORT:+\"${PORT}\"}`
-                      - worker: `echo 'this is the worker process!'
+                      - worker: `echo 'this is the worker process!'`
                 "}
             );
         },
@@ -85,7 +85,7 @@ fn build_workspace_composite_buildpack() {
 
                     - Processes from `Procfile`
                       - web: `python3 -u -m http.server ${PORT:+\"${PORT}\"}`
-                      - worker: `echo 'this is the worker process!'
+                      - worker: `echo 'this is the worker process!'`
                 "}
             );
         },
@@ -112,7 +112,8 @@ fn build_multiple_buildpacks() {
 
                     - Processes from `Procfile`
                       - web: `python3 -u -m http.server ${PORT:+\"${PORT}\"}`
-                      - worker: `echo 'this is the worker process!'
+                      - worker: `echo 'this is the worker process!'`
+                    - Done (finished in < 0.1s)
                     Buildpack A
                 "}
             );

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -36,8 +36,11 @@ fn build_other_buildpack() {
             assert_contains!(
                 context.pack_stdout,
                 indoc! {"
-                    [Discovering process types]
-                    Procfile declares types -> web, worker
+                    ## Procfile Buildpack
+
+                    - Processes from `Procfile`
+                      - web: `python3 -u -m http.server ${PORT:+\"${PORT}\"}`
+                      - worker: `echo 'this is the worker process!'
                 "}
             );
         },
@@ -77,9 +80,12 @@ fn build_workspace_composite_buildpack() {
                 indoc! {"
                     Buildpack A
                     Buildpack B
-                    
-                    [Discovering process types]
-                    Procfile declares types -> web, worker
+
+                    ## Procfile Buildpack
+
+                    - Processes from `Procfile`
+                      - web: `python3 -u -m http.server ${PORT:+\"${PORT}\"}`
+                      - worker: `echo 'this is the worker process!'
                 "}
             );
         },
@@ -101,9 +107,12 @@ fn build_multiple_buildpacks() {
                 context.pack_stdout,
                 indoc! {"
                     Buildpack B
-                    
-                    [Discovering process types]
-                    Procfile declares types -> web, worker
+
+                    ## Procfile Buildpack
+
+                    - Processes from `Procfile`
+                      - web: `python3 -u -m http.server ${PORT:+\"${PORT}\"}`
+                      - worker: `echo 'this is the worker process!'
                     Buildpack A
                 "}
             );
@@ -706,15 +715,15 @@ fn address_for_port_when_container_crashed() {
             Error: No public port '12345' published for {container_name}
 
             This normally means that the container crashed. Container logs:
-            
+
             ## stderr:
-            
+
             some stderr
-            
+
             ## stdout:
-            
+
             some stdout
-            
+
         "}
     );
 }


### PR DESCRIPTION
Newer versions of the procfile buildpack have different output, so CI tests are failing. This fixes the tests.