### PR TITLE
Custom OTLP File Exporter + opentelemetry updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Implemented custom OTLP File Exporter instead of `opentelemetry-stdout` and updated `opentelemetry` libraries to `0.28`. ([#909](https://github.com/heroku/libcnb.rs/pull/909/))
+- `libcnb`:
+  - Implemented custom OTLP File Exporter instead of `opentelemetry-stdout` and updated `opentelemetry` libraries to `0.28`. ([#909](https://github.com/heroku/libcnb.rs/pull/909/))
 
 ## [0.26.1] - 2024-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Implemented custom OTLP File Exporter instead of `opentelemetry-stdout` and updated `opentelemetry` libraries to `0.28`. ([#909](https://github.com/heroku/libcnb.rs/pull/909/))
 
 ## [0.26.1] - 2024-12-10
 

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 trace = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
-    "dep:opentelemetry-proto ",
+    "dep:opentelemetry-proto",
     "dep:serde_json",
 ]
 

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -35,9 +35,9 @@ libcnb-common.workspace = true
 libcnb-data.workspace = true
 libcnb-proc-macros.workspace = true
 futures-core = { version = "0.3", optional = true }
-opentelemetry = { version = "0.27.0", optional = true, default-features = false }
-opentelemetry_sdk = { version = "0.27.0", optional = true, default-features = false }
-opentelemetry-proto = { version = "0.27.0", optional = true, default-features = false }
+opentelemetry = { version = "0.28.0", optional = true, default-features = false }
+opentelemetry_sdk = { version = "0.28.0", optional = true, default-features = false }
+opentelemetry-proto = { version = "0.28.0", optional = true, default-features = false }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = { version = "1.0.133", optional = true }
 thiserror = "2.0.6"

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 trace = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
-    "dep:opentelemetry-stdout",
+    "dep:opentelemetry_proto ",
 ]
 
 [dependencies]
@@ -27,15 +27,14 @@ cyclonedx-bom = { version = "0.8.0", optional = true }
 libcnb-common.workspace = true
 libcnb-data.workspace = true
 libcnb-proc-macros.workspace = true
+futures-core = "0.3"
 opentelemetry = { version = "0.24", optional = true }
 opentelemetry_sdk = { version = "0.24", optional = true }
-opentelemetry-stdout = { version = "0.5", optional = true, features = [
-    "trace",
-] }
+opentelemetry-proto = { version = "0.7", optional = true }
 serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.133"
 thiserror = "2.0.6"
 toml.workspace = true
 
 [dev-dependencies]
-serde_json = "1.0.133"
 tempfile = "3.14.0"

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -45,3 +45,4 @@ toml.workspace = true
 
 [dev-dependencies]
 tempfile = "3.14.0"
+serde_json = "1.0.133"

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 trace = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
-    # "dep:opentelemetry_proto ",
+    "dep:opentelemetry-proto ",
     "dep:serde_json",
 ]
 
@@ -31,7 +31,7 @@ libcnb-proc-macros.workspace = true
 futures-core = "0.3"
 opentelemetry = { version = "0.27.0", optional = true }
 opentelemetry_sdk = { version = "0.27.0", optional = true }
-opentelemetry-proto = { version = "0.27.0", optional = false }
+opentelemetry-proto = { version = "0.27.0", optional = true }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = { version = "1.0.133", optional = true }
 thiserror = "2.0.6"

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -18,7 +18,8 @@ workspace = true
 trace = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
-    "dep:opentelemetry_proto ",
+    # "dep:opentelemetry_proto ",
+    "dep:serde_json",
 ]
 
 [dependencies]
@@ -28,11 +29,11 @@ libcnb-common.workspace = true
 libcnb-data.workspace = true
 libcnb-proc-macros.workspace = true
 futures-core = "0.3"
-opentelemetry = { version = "0.24", optional = true }
-opentelemetry_sdk = { version = "0.24", optional = true }
-opentelemetry-proto = { version = "0.7", optional = true }
+opentelemetry = { version = "0.27.0", optional = true }
+opentelemetry_sdk = { version = "0.27.0", optional = true }
+opentelemetry-proto = { version = "0.27.0", optional = false }
 serde = { version = "1.0.215", features = ["derive"] }
-serde_json = "1.0.133"
+serde_json = { version = "1.0.133", optional = true }
 thiserror = "2.0.6"
 toml.workspace = true
 

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -16,9 +16,15 @@ workspace = true
 
 [features]
 trace = [
+    "dep:futures-core",
     "dep:opentelemetry",
+    "opentelemetry/trace",
     "dep:opentelemetry_sdk",
+    "opentelemetry_sdk/trace",
     "dep:opentelemetry-proto",
+    "opentelemetry-proto/trace",
+    "opentelemetry-proto/gen-tonic-messages",
+    "opentelemetry-proto/with-serde",
     "dep:serde_json",
 ]
 
@@ -28,10 +34,10 @@ cyclonedx-bom = { version = "0.8.0", optional = true }
 libcnb-common.workspace = true
 libcnb-data.workspace = true
 libcnb-proc-macros.workspace = true
-futures-core = "0.3"
-opentelemetry = { version = "0.27.0", optional = true }
-opentelemetry_sdk = { version = "0.27.0", optional = true }
-opentelemetry-proto = { version = "0.27.0", optional = true }
+futures-core = { version = "0.3", optional = true }
+opentelemetry = { version = "0.27.0", optional = true, default-features = false }
+opentelemetry_sdk = { version = "0.27.0", optional = true, default-features = false }
+opentelemetry-proto = { version = "0.27.0", optional = true, default-features = false }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = { version = "1.0.133", optional = true }
 thiserror = "2.0.6"

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -53,7 +53,7 @@ pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> Bu
 
     let resource = Resource::builder()
         // Define a resource that defines the trace provider.
-        // The buildpac name/version seems to map well to the suggestion here
+        // The buildpack name/version seems to map well to the suggestion here
         // https://opentelemetry.io/docs/specs/semconv/resource/#service.
         .with_attributes([
             KeyValue::new("service.name", buildpack.id.to_string()),
@@ -69,12 +69,10 @@ pub(crate) fn start_trace(buildpack: &Buildpack, phase_name: &'static str) -> Bu
         .open(&tracing_file_path)
         .map(|file| FileExporter::new(file, resource))
     {
-        // Write tracing data to a file, which may be read by other
-        // services. Wrap with a BufWriter to prevent serde from sending each
-        // JSON token to IO, and instead send entire JSON objects to IO.
-        Ok(exporter) => provider_builder.with_simple_exporter(exporter),
+        // Write tracing data to a file, which may be read by other services
+        Ok(exporter) => provider_builder.with_batch_exporter(exporter),
         // Failed tracing shouldn't fail a build, and any export logging here
-        // would likely confuse the user, so we won't export when the file has IO errors
+        // would likely confuse the user; don't export when the file has IO errors
         Err(_) => provider_builder,
     }
     .build();


### PR DESCRIPTION
As mentioned in #907, there was an upstream change to `opentelemetry-stdout`'s exporter: https://github.com/open-telemetry/opentelemetry-rust/pull/2040. With that change, the exporter lost the ability to send telemetry to a generic writer (like a buffer or file), and also lost `jsonl` serialization. This means we can't export in the correct format with newer versions of the `opentelemetry` libraries without a new exporter. This PR adds a custom OTLP File Exporter (spec is [here](https://opentelemetry.io/docs/specs/otel/protocol/file-exporter/)) for traces and updates the `opentelemetry` libraries to the latest.

Based on [this comment](https://github.com/open-telemetry/opentelemetry-rust/pull/2040#issuecomment-2508805391), and my [upstream issue](https://github.com/open-telemetry/opentelemetry-rust/issues/2602), there is interest in an OTLP File Exporter upstream, so this custom exporter shouldn't live here forever.

This exporter probably isn't quite good enough to upstream yet -- it supports traces, but not metrics or logs.

Bonus changes:

- Now uses batch export functionality, which is generally preferred according to the [spec](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md). In `opentelemetry-sdk` `0.28`, the batch export functionality no longer requires an async runtime (like `tokio`) and instead runs in a separate background thread (some details [here](https://github.com/open-telemetry/opentelemetry-rust/issues/2066)), which lowers the dependency overhead for us.
- Slightly better feature usage -- we're no longer compiling the `metrics` and `logs` features from `opentelemetry`, which we don't use anyway
- This uses a `LineWriter` rather than a `BufWriter` now. The former is better for our use case -- we want to write complete lines to the file to prevent writing partial json to the file and corrupting it.
- There were a truckload of random API changes in `opentelemetry`. Some things were moved, others renamed. Almost everything uses the builder pattern now.