### PR TITLE
Update to Rust 2024 edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Raised Minimum Supported Rust Version (MSRV) to `1.85`. ([#913](https://github.com/heroku/libcnb.rs/pull/913))
+- Updated to Rust 2024 edition. ([#913](https://github.com/heroku/libcnb.rs/pull/913))
 - `libcnb`:
   - Implemented custom OTLP File Exporter instead of `opentelemetry-stdout` and updated `opentelemetry` libraries to `0.28`. ([#909](https://github.com/heroku/libcnb.rs/pull/909/))
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ members = [
 
 [workspace.package]
 version = "0.26.1"
-rust-version = "1.76"
-edition = "2021"
+rust-version = "1.85"
+edition = "2024"
 license = "BSD-3-Clause"
 
 [workspace.lints.rust]
@@ -35,8 +35,6 @@ pedantic = { level = "warn", priority = -1 }
 unwrap_used = "warn"
 # In most cases adding error docs provides little value.
 missing_errors_doc = "allow"
-# This lint is too noisy and enforces a style that reduces readability in many cases.
-module_name_repetitions = "allow"
 
 [workspace.dependencies]
 libcnb = { version = "=0.26.1", path = "libcnb" }

--- a/examples/basics/src/main.rs
+++ b/examples/basics/src/main.rs
@@ -1,7 +1,7 @@
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
-use libcnb::{buildpack_main, Buildpack};
+use libcnb::{Buildpack, buildpack_main};
 
 pub(crate) struct BasicBuildpack;
 

--- a/examples/execd/src/main.rs
+++ b/examples/execd/src/main.rs
@@ -2,7 +2,7 @@ use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::data::layer_name;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
-use libcnb::{additional_buildpack_binary_path, buildpack_main, Buildpack};
+use libcnb::{Buildpack, additional_buildpack_binary_path, buildpack_main};
 
 // Suppress warnings due to the `unused_crate_dependencies` lint not handling integration tests well.
 use fastrand as _;

--- a/examples/execd/tests/integration_test.rs
+++ b/examples/execd/tests/integration_test.rs
@@ -4,7 +4,7 @@
 // Required due to: https://github.com/rust-lang/rust/issues/95513
 #![allow(unused_crate_dependencies)]
 
-use libcnb_test::{assert_contains, assert_empty, BuildConfig, TestRunner};
+use libcnb_test::{BuildConfig, TestRunner, assert_contains, assert_empty};
 
 #[test]
 #[ignore = "integration test"]

--- a/libcnb-cargo/src/package/command.rs
+++ b/libcnb-cargo/src/package/command.rs
@@ -2,15 +2,16 @@ use crate::cli::PackageArgs;
 use crate::package::error::Error;
 use libcnb_data::buildpack::BuildpackId;
 use libcnb_package::buildpack_dependency_graph::build_libcnb_buildpacks_dependency_graph;
-use libcnb_package::cross_compile::{cross_compile_assistance, CrossCompileAssistance};
+use libcnb_package::cross_compile::{CrossCompileAssistance, cross_compile_assistance};
 use libcnb_package::dependency_graph::get_dependencies;
 use libcnb_package::output::create_packaged_buildpack_dir_resolver;
 use libcnb_package::util::absolutize_path;
-use libcnb_package::{find_cargo_workspace_root_dir, CargoProfile};
+use libcnb_package::{CargoProfile, find_cargo_workspace_root_dir};
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+#[allow(clippy::too_many_lines)]
 pub(crate) fn execute(args: &PackageArgs) -> Result<(), Error> {
     let current_dir = std::env::current_dir().map_err(Error::CannotGetCurrentDir)?;
 
@@ -49,7 +50,9 @@ pub(crate) fn execute(args: &PackageArgs) -> Result<(), Error> {
                     "Couldn't determine automatic cross-compile settings for target triple {}.",
                     args.target
                 );
-                eprintln!("This is not an error, but without proper cross-compile settings in your Cargo manifest and locally installed toolchains, compilation might fail.");
+                eprintln!(
+                    "This is not an error, but without proper cross-compile settings in your Cargo manifest and locally installed toolchains, compilation might fail."
+                );
                 eprintln!("To disable this warning, pass --no-cross-compile-assistance.");
                 Vec::new()
             }

--- a/libcnb-cargo/tests/integration_test.rs
+++ b/libcnb-cargo/tests/integration_test.rs
@@ -8,13 +8,13 @@ use libcnb_common::toml_file::read_toml_file;
 use libcnb_data::buildpack::{BuildpackDescriptor, BuildpackId};
 use libcnb_data::buildpack_id;
 use libcnb_data::package_descriptor::{PackageDescriptor, PackageDescriptorDependency};
-use libcnb_package::output::create_packaged_buildpack_dir_resolver;
 use libcnb_package::CargoProfile;
+use libcnb_package::output::create_packaged_buildpack_dir_resolver;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, fs};
-use tempfile::{tempdir_in, TempDir};
+use tempfile::{TempDir, tempdir_in};
 
 #[test]
 #[ignore = "integration test"]
@@ -58,8 +58,9 @@ fn package_single_composite_buildpack_in_monorepo_buildpack_project() {
         .output()
         .unwrap();
 
+    let package_dir = fixture_dir.path().join(DEFAULT_PACKAGE_DIR_NAME);
     let packaged_buildpack_dir_resolver = create_packaged_buildpack_dir_resolver(
-        &fixture_dir.path().join(DEFAULT_PACKAGE_DIR_NAME),
+        &package_dir,
         CargoProfile::Release,
         X86_64_UNKNOWN_LINUX_MUSL,
     );
@@ -144,8 +145,9 @@ fn package_all_buildpacks_in_monorepo_buildpack_project() {
         .output()
         .unwrap();
 
+    let package_dir = fixture_dir.path().join(DEFAULT_PACKAGE_DIR_NAME);
     let packaged_buildpack_dir_resolver = create_packaged_buildpack_dir_resolver(
-        &fixture_dir.path().join(DEFAULT_PACKAGE_DIR_NAME),
+        &package_dir,
         CargoProfile::Release,
         X86_64_UNKNOWN_LINUX_MUSL,
     );

--- a/libcnb-common/src/toml_file.rs
+++ b/libcnb-common/src/toml_file.rs
@@ -1,4 +1,4 @@
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use std::{fs, path::Path};
 
 /// An error that occurred during reading or writing a TOML file.

--- a/libcnb-data/src/build_plan.rs
+++ b/libcnb-data/src/build_plan.rs
@@ -1,5 +1,5 @@
-use serde::ser::Error;
 use serde::Serialize;
+use serde::ser::Error;
 use std::collections::VecDeque;
 use toml::value::Table;
 

--- a/libcnb-data/src/buildpack/api.rs
+++ b/libcnb-data/src/buildpack/api.rs
@@ -45,7 +45,7 @@ pub enum BuildpackApiError {
 
 #[cfg(test)]
 mod tests {
-    use serde_test::{assert_de_tokens, assert_de_tokens_error, Token};
+    use serde_test::{Token, assert_de_tokens, assert_de_tokens_error};
 
     use super::*;
 

--- a/libcnb-data/src/buildpack/version.rs
+++ b/libcnb-data/src/buildpack/version.rs
@@ -65,7 +65,7 @@ pub enum BuildpackVersionError {
 
 #[cfg(test)]
 mod tests {
-    use serde_test::{assert_de_tokens, assert_de_tokens_error, Token};
+    use serde_test::{Token, assert_de_tokens, assert_de_tokens_error};
 
     use super::*;
 

--- a/libcnb-data/src/launch.rs
+++ b/libcnb-data/src/launch.rs
@@ -312,7 +312,7 @@ libcnb_newtype!(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_test::{assert_ser_tokens, Token};
+    use serde_test::{Token, assert_ser_tokens};
 
     #[test]
     fn launch_builder_add_processes() {

--- a/libcnb-data/src/newtypes.rs
+++ b/libcnb-data/src/newtypes.rs
@@ -190,7 +190,7 @@ pub(crate) use libcnb_newtype;
 
 #[cfg(test)]
 mod tests {
-    use serde_test::{assert_de_tokens, assert_de_tokens_error, Token};
+    use serde_test::{Token, assert_de_tokens, assert_de_tokens_error};
 
     libcnb_newtype!(
         newtypes::tests,

--- a/libcnb-package/src/build.rs
+++ b/libcnb-package/src/build.rs
@@ -1,8 +1,8 @@
-use crate::cargo::{
-    cargo_binary_target_names, determine_buildpack_cargo_target_name,
-    DetermineBuildpackCargoTargetNameError,
-};
 use crate::CargoProfile;
+use crate::cargo::{
+    DetermineBuildpackCargoTargetNameError, cargo_binary_target_names,
+    determine_buildpack_cargo_target_name,
+};
 use cargo_metadata::Metadata;
 use std::collections::HashMap;
 use std::ffi::OsString;

--- a/libcnb-package/src/dependency_graph.rs
+++ b/libcnb-package/src/dependency_graph.rs
@@ -1,5 +1,5 @@
-use petgraph::visit::DfsPostOrder;
 use petgraph::Graph;
+use petgraph::visit::DfsPostOrder;
 use std::error::Error;
 
 /// A node of a dependency graph.
@@ -107,7 +107,7 @@ pub enum GetDependenciesError<I> {
 
 #[cfg(test)]
 mod tests {
-    use crate::dependency_graph::{create_dependency_graph, get_dependencies, DependencyNode};
+    use crate::dependency_graph::{DependencyNode, create_dependency_graph, get_dependencies};
     use std::convert::Infallible;
 
     impl DependencyNode<String, Infallible> for (&str, Vec<&str>) {

--- a/libcnb-package/src/output.rs
+++ b/libcnb-package/src/output.rs
@@ -33,8 +33,8 @@ pub fn default_buildpack_directory_name(buildpack_id: &BuildpackId) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::output::create_packaged_buildpack_dir_resolver;
     use crate::CargoProfile;
+    use crate::output::create_packaged_buildpack_dir_resolver;
     use libcnb_data::buildpack_id;
     use std::path::PathBuf;
 

--- a/libcnb-package/src/package.rs
+++ b/libcnb-package/src/package.rs
@@ -1,9 +1,9 @@
 use crate::build::build_buildpack_binaries;
-use crate::buildpack_kind::{determine_buildpack_kind, BuildpackKind};
-use crate::package_descriptor::{normalize_package_descriptor, NormalizePackageDescriptorError};
-use crate::{assemble_buildpack_directory, CargoProfile};
+use crate::buildpack_kind::{BuildpackKind, determine_buildpack_kind};
+use crate::package_descriptor::{NormalizePackageDescriptorError, normalize_package_descriptor};
+use crate::{CargoProfile, assemble_buildpack_directory};
 use cargo_metadata::MetadataCommand;
-use libcnb_common::toml_file::{read_toml_file, write_toml_file, TomlFileError};
+use libcnb_common::toml_file::{TomlFileError, read_toml_file, write_toml_file};
 use libcnb_data::buildpack::BuildpackId;
 use libcnb_data::package_descriptor::PackageDescriptor;
 use std::collections::BTreeMap;

--- a/libcnb-proc-macros/src/lib.rs
+++ b/libcnb-proc-macros/src/lib.rs
@@ -3,9 +3,9 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use std::path::PathBuf;
+use syn::Token;
 use syn::parse::{Parse, ParseStream};
 use syn::parse_macro_input;
-use syn::Token;
 
 /// Compiles the given regex using the `fancy_regex` crate and tries to match the given value. If
 /// the value matches the regex, the macro will expand to the first expression. Otherwise it will

--- a/libcnb-test/src/app.rs
+++ b/libcnb-test/src/app.rs
@@ -1,7 +1,7 @@
 use fs_extra::dir::CopyOptions;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 
 /// Copies an application directory to a temporary location.
 pub(crate) fn copy_app(app_dir: impl AsRef<Path>) -> Result<AppDir, PrepareAppError> {

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -1,12 +1,12 @@
-use libcnb_common::toml_file::{read_toml_file, TomlFileError};
+use libcnb_common::toml_file::{TomlFileError, read_toml_file};
 use libcnb_data::buildpack::{BuildpackDescriptor, BuildpackId};
 use libcnb_package::buildpack_dependency_graph::{
-    build_libcnb_buildpacks_dependency_graph, BuildBuildpackDependencyGraphError,
+    BuildBuildpackDependencyGraphError, build_libcnb_buildpacks_dependency_graph,
 };
-use libcnb_package::cross_compile::{cross_compile_assistance, CrossCompileAssistance};
-use libcnb_package::dependency_graph::{get_dependencies, GetDependenciesError};
+use libcnb_package::cross_compile::{CrossCompileAssistance, cross_compile_assistance};
+use libcnb_package::dependency_graph::{GetDependenciesError, get_dependencies};
 use libcnb_package::output::create_packaged_buildpack_dir_resolver;
-use libcnb_package::{find_cargo_workspace_root_dir, CargoProfile, FindCargoWorkspaceRootError};
+use libcnb_package::{CargoProfile, FindCargoWorkspaceRootError, find_cargo_workspace_root_dir};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::{fs, io};

--- a/libcnb-test/src/container_context.rs
+++ b/libcnb-test/src/container_context.rs
@@ -3,7 +3,7 @@ use crate::docker::{
 };
 use crate::log::LogOutput;
 use crate::util::CommandError;
-use crate::{util, ContainerConfig};
+use crate::{ContainerConfig, util};
 use std::net::SocketAddr;
 
 /// Context of a launched container.

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -234,9 +234,11 @@ mod tests {
         // Assert conditional '--trust-builder' flag works as expected:
         input.trust_builder = false;
         let command: Command = input.clone().into();
-        assert!(!command
-            .get_args()
-            .any(|arg| arg == OsStr::new("--trust-builder")));
+        assert!(
+            !command
+                .get_args()
+                .any(|arg| arg == OsStr::new("--trust-builder"))
+        );
     }
 
     #[test]

--- a/libcnb-test/src/test_context.rs
+++ b/libcnb-test/src/test_context.rs
@@ -1,8 +1,8 @@
 use crate::docker::DockerRunCommand;
 use crate::pack::PackSbomDownloadCommand;
 use crate::{
-    util, BuildConfig, ContainerConfig, ContainerContext, LogOutput, TemporaryDockerResources,
-    TestRunner,
+    BuildConfig, ContainerConfig, ContainerContext, LogOutput, TemporaryDockerResources,
+    TestRunner, util,
 };
 use libcnb_data::buildpack::BuildpackId;
 use libcnb_data::layer::LayerName;

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -1,7 +1,7 @@
 use crate::docker::{DockerRemoveImageCommand, DockerRemoveVolumeCommand};
 use crate::pack::PackBuildCommand;
 use crate::util::CommandError;
-use crate::{app, build, util, BuildConfig, BuildpackReference, PackResult, TestContext};
+use crate::{BuildConfig, BuildpackReference, PackResult, TestContext, app, build, util};
 use std::borrow::Borrow;
 use std::env;
 use std::path::PathBuf;
@@ -146,7 +146,7 @@ impl TestRunner {
                 BuildpackReference::Other(id) => {
                     pack_command.buildpack(id.clone());
                 }
-            };
+            }
         }
 
         let pack_result = util::run_command(pack_command);

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -11,8 +11,8 @@
 use indoc::{formatdoc, indoc};
 use libcnb_data::buildpack_id;
 use libcnb_test::{
-    assert_contains, assert_empty, assert_not_contains, BuildConfig, BuildpackReference,
-    ContainerConfig, PackResult, TestRunner,
+    BuildConfig, BuildpackReference, ContainerConfig, PackResult, TestRunner, assert_contains,
+    assert_empty, assert_not_contains,
 };
 use std::path::PathBuf;
 use std::time::Duration;
@@ -686,7 +686,7 @@ fn address_for_port_when_port_not_exposed() {
 fn address_for_port_when_container_crashed() {
     let mut container_name = String::new();
 
-    // AssertUnwindSafe is required so that `container_name`` can be mutated across the unwind boundary.
+    // AssertUnwindSafe is required so that `container_name` can be mutated across the unwind boundary.
     let err = panic::catch_unwind(panic::AssertUnwindSafe(|| {
         TestRunner::default().build(
             BuildConfig::new("heroku/builder:22", "tests/fixtures/procfile")

--- a/libcnb/src/build.rs
+++ b/libcnb/src/build.rs
@@ -1,5 +1,6 @@
 //! Provides build phase specific types and helpers.
 
+use crate::Target;
 use crate::buildpack::Buildpack;
 use crate::data::layer::LayerName;
 use crate::data::store::Store;
@@ -12,11 +13,10 @@ use crate::layer::{
     UncachedLayerDefinition,
 };
 use crate::sbom::Sbom;
-use crate::Target;
 use libcnb_data::generic::GenericMetadata;
 use libcnb_data::layer_content_metadata::LayerTypes;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::borrow::Borrow;
 use std::path::PathBuf;
 

--- a/libcnb/src/buildpack.rs
+++ b/libcnb/src/buildpack.rs
@@ -1,6 +1,6 @@
+use crate::Platform;
 use crate::build::{BuildContext, BuildResult};
 use crate::detect::{DetectContext, DetectResult};
-use crate::Platform;
 use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 

--- a/libcnb/src/detect.rs
+++ b/libcnb/src/detect.rs
@@ -1,7 +1,7 @@
 //! Provides detect phase specific types and helpers.
 
-use crate::buildpack::Buildpack;
 use crate::Target;
+use crate::buildpack::Buildpack;
 use crate::{data::build_plan::BuildPlan, data::buildpack::ComponentBuildpackDescriptor};
 use std::fmt::Debug;
 use std::path::PathBuf;

--- a/libcnb/src/error.rs
+++ b/libcnb/src/error.rs
@@ -29,10 +29,14 @@ pub enum Error<E> {
     #[error("Couldn't determine target arch: {0}")]
     CannotDetermineTargetArch(std::env::VarError),
 
-    #[error("Couldn't determine target distro name: {0}. Ensure the `io.buildpacks.base.distro.*` Docker labels are set on the base image.")]
+    #[error(
+        "Couldn't determine target distro name: {0}. Ensure the `io.buildpacks.base.distro.*` Docker labels are set on the base image."
+    )]
     CannotDetermineTargetDistroName(std::env::VarError),
 
-    #[error("Couldn't determine target distro version: {0}. Ensure the `io.buildpacks.base.distro.*` Docker labels are set on the base image.")]
+    #[error(
+        "Couldn't determine target distro version: {0}. Ensure the `io.buildpacks.base.distro.*` Docker labels are set on the base image."
+    )]
     CannotDetermineTargetDistroVersion(std::env::VarError),
 
     #[error("Couldn't create platform from platform path: {0}")]

--- a/libcnb/src/generic.rs
+++ b/libcnb/src/generic.rs
@@ -1,7 +1,7 @@
 //! Generic implementations for some libcnb types.
 
 use crate::platform::Platform;
-use crate::{read_platform_env, Env};
+use crate::{Env, read_platform_env};
 use std::fmt::{Debug, Display, Formatter};
 use std::path::Path;
 

--- a/libcnb/src/layer/shared.rs
+++ b/libcnb/src/layer/shared.rs
@@ -1,14 +1,14 @@
 // This lint triggers when both layer_dir and layers_dir are present which are quite common.
 #![allow(clippy::similar_names)]
 
-use crate::sbom::{cnb_sbom_path, Sbom};
+use crate::sbom::{Sbom, cnb_sbom_path};
 use crate::util::{default_on_not_found, remove_dir_recursively};
-use libcnb_common::toml_file::{read_toml_file, write_toml_file, TomlFileError};
+use libcnb_common::toml_file::{TomlFileError, read_toml_file, write_toml_file};
 use libcnb_data::layer::LayerName;
 use libcnb_data::layer_content_metadata::{LayerContentMetadata, LayerTypes};
 use libcnb_data::sbom::SBOM_FORMATS;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/libcnb/src/layer/struct_api/handling.rs
+++ b/libcnb/src/layer/struct_api/handling.rs
@@ -1,18 +1,18 @@
+use crate::Buildpack;
 use crate::layer::shared::{
-    delete_layer, read_layer, replace_layer_metadata, replace_layer_types, ReadLayerError,
-    WriteLayerError,
+    ReadLayerError, WriteLayerError, delete_layer, read_layer, replace_layer_metadata,
+    replace_layer_types,
 };
 use crate::layer::{
     EmptyLayerCause, IntoAction, InvalidMetadataAction, LayerError, LayerRef, LayerState,
     RestoredLayerAction,
 };
-use crate::Buildpack;
 use libcnb_common::toml_file::read_toml_file;
 use libcnb_data::generic::GenericMetadata;
 use libcnb_data::layer::LayerName;
 use libcnb_data::layer_content_metadata::{LayerContentMetadata, LayerTypes};
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 
@@ -147,11 +147,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::handle_layer;
+    use crate::Buildpack;
     use crate::build::{BuildContext, BuildResult};
     use crate::detect::{DetectContext, DetectResult};
     use crate::generic::{GenericError, GenericPlatform};
     use crate::layer::{EmptyLayerCause, InvalidMetadataAction, LayerState, RestoredLayerAction};
-    use crate::Buildpack;
     use libcnb_common::toml_file::read_toml_file;
     use libcnb_data::generic::GenericMetadata;
     use libcnb_data::layer_content_metadata::{LayerContentMetadata, LayerTypes};

--- a/libcnb/src/layer/struct_api/mod.rs
+++ b/libcnb/src/layer/struct_api/mod.rs
@@ -1,13 +1,13 @@
 pub(crate) mod handling;
 
 // BuildContext is only used in RustDoc (https://github.com/rust-lang/rust/issues/79542)
+use crate::Buildpack;
 #[allow(unused)]
 use crate::build::BuildContext;
-use crate::layer::shared::{replace_layer_exec_d_programs, replace_layer_sboms, WriteLayerError};
+use crate::layer::shared::{WriteLayerError, replace_layer_exec_d_programs, replace_layer_sboms};
 use crate::layer::{LayerError, ReadLayerError};
 use crate::layer_env::LayerEnv;
 use crate::sbom::Sbom;
-use crate::Buildpack;
 use libcnb_data::generic::GenericMetadata;
 use libcnb_data::layer::LayerName;
 use serde::Serialize;

--- a/libcnb/src/layer/trait_api/handling.rs
+++ b/libcnb/src/layer/trait_api/handling.rs
@@ -2,20 +2,20 @@
 #![allow(clippy::similar_names)]
 
 use super::Layer;
+use crate::Buildpack;
 use crate::build::BuildContext;
 use crate::data::layer::LayerName;
 use crate::data::layer_content_metadata::LayerContentMetadata;
 use crate::generic::GenericMetadata;
 use crate::layer::shared::{
-    delete_layer, replace_layer_exec_d_programs, replace_layer_sboms, ReadLayerError,
-    WriteLayerError,
+    ReadLayerError, WriteLayerError, delete_layer, replace_layer_exec_d_programs,
+    replace_layer_sboms,
 };
 use crate::layer::{ExistingLayerStrategy, LayerData, LayerError, MetadataMigration};
 use crate::layer_env::LayerEnv;
 use crate::sbom::Sbom;
-use crate::Buildpack;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -421,7 +421,7 @@ mod tests {
             other => {
                 panic!("Expected WriteLayerError::MissingExecDFile, but got {other:?}");
             }
-        };
+        }
     }
 
     #[test]

--- a/libcnb/src/layer/trait_api/mod.rs
+++ b/libcnb/src/layer/trait_api/mod.rs
@@ -2,15 +2,15 @@
 // the use of deprecated code is allowed in this module.
 #![allow(deprecated)]
 
+use crate::Buildpack;
 use crate::build::BuildContext;
 use crate::data::layer::LayerName;
 use crate::data::layer_content_metadata::{LayerContentMetadata, LayerTypes};
 use crate::generic::GenericMetadata;
 use crate::layer_env::LayerEnv;
 use crate::sbom::Sbom;
-use crate::Buildpack;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 

--- a/libcnb/src/layer/trait_api/tests.rs
+++ b/libcnb/src/layer/trait_api/tests.rs
@@ -19,7 +19,7 @@ use crate::layer::{
     ExistingLayerStrategy, Layer, LayerData, LayerResult, LayerResultBuilder, MetadataMigration,
 };
 use crate::layer_env::{LayerEnv, ModificationBehavior, Scope};
-use crate::{read_toml_file, Buildpack, Env, Target, LIBCNB_SUPPORTED_BUILDPACK_API};
+use crate::{Buildpack, Env, LIBCNB_SUPPORTED_BUILDPACK_API, Target, read_toml_file};
 use libcnb_data::buildpack::{BuildpackTarget, BuildpackVersion, ComponentBuildpackDescriptor};
 use libcnb_data::buildpack_plan::BuildpackPlan;
 use libcnb_data::layer_content_metadata::LayerContentMetadata;
@@ -29,7 +29,7 @@ use serde::Serialize;
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 
 const TEST_LAYER_LAUNCH: bool = true;
 const TEST_LAYER_BUILD: bool = true;

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -299,7 +299,9 @@ impl LayerEnv {
                 let target_delta = match scope {
                     Scope::Build => &mut result_layer_env.layer_paths_build,
                     Scope::Launch => &mut result_layer_env.layer_paths_launch,
-                    _ => unreachable!("Unexpected Scope in read_from_layer_dir implementation. This is a libcnb implementation error!"),
+                    _ => unreachable!(
+                        "Unexpected Scope in read_from_layer_dir implementation. This is a libcnb implementation error!"
+                    ),
                 };
 
                 target_delta.insert(ModificationBehavior::Prepend, name, path);
@@ -448,7 +450,7 @@ impl LayerEnvDelta {
                 ModificationBehavior::Append => {
                     let mut previous_value = result_env.get(name).cloned().unwrap_or_default();
 
-                    if previous_value.len() > 0 {
+                    if !previous_value.is_empty() {
                         previous_value.push(self.delimiter_for(name));
                     }
 
@@ -470,7 +472,7 @@ impl LayerEnvDelta {
                     result_env.insert(name, new_value);
                 }
                 ModificationBehavior::Delimiter => (),
-            };
+            }
         }
 
         result_env

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -8,12 +8,12 @@ use crate::sbom::cnb_sbom_path;
 #[cfg(feature = "trace")]
 use crate::tracing::start_trace;
 use crate::util::is_not_found_error_kind;
-use crate::{exit_code, Target, TomlFileError, LIBCNB_SUPPORTED_BUILDPACK_API};
+use crate::{LIBCNB_SUPPORTED_BUILDPACK_API, Target, TomlFileError, exit_code};
 use libcnb_common::toml_file::{read_toml_file, write_toml_file};
 use libcnb_data::buildpack::ComponentBuildpackDescriptor;
 use libcnb_data::store::Store;
-use serde::de::DeserializeOwned;
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
@@ -47,7 +47,9 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
                     "This buildpack uses Cloud Native Buildpacks API version {} (specified in buildpack.toml).",
                     &buildpack_descriptor.api,
                 );
-                eprintln!("However, the underlying libcnb.rs library only supports CNB API {LIBCNB_SUPPORTED_BUILDPACK_API}.");
+                eprintln!(
+                    "However, the underlying libcnb.rs library only supports CNB API {LIBCNB_SUPPORTED_BUILDPACK_API}."
+                );
                 exit(exit_code::GENERIC_CNB_API_VERSION_ERROR)
             }
         }
@@ -100,7 +102,9 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
                 other.unwrap_or("<unknown>")
             );
             eprintln!("The executable name is used to determine the current buildpack phase.");
-            eprintln!("You might want to create 'detect' and 'build' links to this executable and run those instead.");
+            eprintln!(
+                "You might want to create 'detect' and 'build' links to this executable and run those instead."
+            );
             exit(exit_code::GENERIC_UNEXPECTED_EXECUTABLE_NAME_ERROR)
         }
     };
@@ -251,13 +255,13 @@ pub fn libcnb_runtime_build<B: Buildpack>(
                 write_toml_file(&launch, layers_dir.join("launch.toml"))
                     .map_err(Error::CannotWriteLaunch)
                     .inspect_err(|err| trace_error(err))?;
-            };
+            }
 
             if let Some(store) = store {
                 write_toml_file(&store, layers_dir.join("store.toml"))
                     .map_err(Error::CannotWriteStore)
                     .inspect_err(|err| trace_error(err))?;
-            };
+            }
 
             for build_sbom in build_sboms {
                 fs::write(

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -1,17 +1,17 @@
 use futures_core::future::BoxFuture;
 use libcnb_data::buildpack::Buildpack;
 use opentelemetry::{
+    InstrumentationScope, KeyValue,
     global::{self, BoxedSpan},
     trace::{Span as SpanTrait, Status, Tracer, TracerProvider as TracerProviderTrait},
-    InstrumentationScope, KeyValue,
 };
 use opentelemetry_proto::transform::common::tonic::ResourceAttributesWithSchema;
 use opentelemetry_proto::transform::trace::tonic::group_spans_by_resource_and_scope;
 use opentelemetry_sdk::{
+    Resource,
     error::{OTelSdkError, OTelSdkResult},
     trace::SdkTracerProvider,
     trace::SpanExporter,
-    Resource,
 };
 use std::{
     fmt::Debug,
@@ -221,8 +221,10 @@ mod tests {
         assert!(tracing_contents.contains(
             "{\"key\":\"service.name\",\"value\":{\"stringValue\":\"company.com/foo\"}}"
         ));
-        assert!(tracing_contents
-            .contains("{\"key\":\"service.version\",\"value\":{\"stringValue\":\"0.0.99\"}}"));
+        assert!(
+            tracing_contents
+                .contains("{\"key\":\"service.version\",\"value\":{\"stringValue\":\"0.0.99\"}}")
+        );
 
         // Check span name
         assert!(tracing_contents.contains("\"name\":\"company_com_foo-bar\""));
@@ -231,8 +233,10 @@ mod tests {
         assert!(tracing_contents.contains(
             "{\"key\":\"buildpack_id\",\"value\":{\"stringValue\":\"company.com/foo\"}}"
         ));
-        assert!(tracing_contents
-            .contains("{\"key\":\"buildpack_version\",\"value\":{\"stringValue\":\"0.0.99\"}}"));
+        assert!(
+            tracing_contents
+                .contains("{\"key\":\"buildpack_version\",\"value\":{\"stringValue\":\"0.0.99\"}}")
+        );
         assert!(tracing_contents.contains(
                 "{\"key\":\"buildpack_name\",\"value\":{\"stringValue\":\"Foo buildpack for company.com\"}}"
         ));
@@ -247,8 +251,10 @@ mod tests {
         ));
 
         // Check error status
-        assert!(tracing_contents
-            .contains("\"message\":\"Custom { kind: Other, error: \\\"it's broken\\\" }"));
+        assert!(
+            tracing_contents
+                .contains("\"message\":\"Custom { kind: Other, error: \\\"it's broken\\\" }")
+        );
         assert!(tracing_contents.contains("\"code\":2"));
     }
 }

--- a/libherokubuildpack/src/inventory.rs
+++ b/libherokubuildpack/src/inventory.rs
@@ -233,9 +233,9 @@ where
 
 #[cfg(test)]
 mod test {
+    use crate::inventory::Inventory;
     use crate::inventory::artifact::{Arch, Artifact, Os};
     use crate::inventory::checksum::tests::BogusDigest;
-    use crate::inventory::Inventory;
 
     #[test]
     fn test_matching_artifact_resolution() {
@@ -256,9 +256,11 @@ mod test {
         let mut inventory = Inventory::new();
         inventory.push(create_artifact("foo", Os::Linux, Arch::Arm64));
 
-        assert!(inventory
-            .resolve(Os::Linux, Arch::Amd64, &String::from("foo"))
-            .is_none());
+        assert!(
+            inventory
+                .resolve(Os::Linux, Arch::Amd64, &String::from("foo"))
+                .is_none()
+        );
     }
 
     #[test]
@@ -266,9 +268,11 @@ mod test {
         let mut inventory = Inventory::new();
         inventory.push(create_artifact("foo", Os::Linux, Arch::Arm64));
 
-        assert!(inventory
-            .resolve(Os::Linux, Arch::Arm64, &String::from("bar"))
-            .is_none());
+        assert!(
+            inventory
+                .resolve(Os::Linux, Arch::Arm64, &String::from("bar"))
+                .is_none()
+        );
     }
 
     fn create_artifact(version: &str, os: Os, arch: Arch) -> Artifact<String, BogusDigest, ()> {

--- a/libherokubuildpack/src/inventory/checksum.rs
+++ b/libherokubuildpack/src/inventory/checksum.rs
@@ -91,7 +91,7 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
+    use serde_test::{Token, assert_de_tokens_error, assert_tokens};
 
     #[derive(Debug)]
     pub(crate) struct BogusDigest;

--- a/test-buildpacks/readonly-layer-files/src/main.rs
+++ b/test-buildpacks/readonly-layer-files/src/main.rs
@@ -3,7 +3,7 @@ use libcnb::data::layer_name;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericMetadata, GenericPlatform};
 use libcnb::layer::{CachedLayerDefinition, InvalidMetadataAction, RestoredLayerAction};
-use libcnb::{buildpack_main, Buildpack};
+use libcnb::{Buildpack, buildpack_main};
 use std::fs;
 use std::fs::Permissions;
 use std::os::unix::fs::PermissionsExt;

--- a/test-buildpacks/sbom/src/main.rs
+++ b/test-buildpacks/sbom/src/main.rs
@@ -7,7 +7,7 @@ use libcnb::layer::{
     CachedLayerDefinition, InvalidMetadataAction, LayerState, RestoredLayerAction,
 };
 use libcnb::sbom::Sbom;
-use libcnb::{buildpack_main, Buildpack};
+use libcnb::{Buildpack, buildpack_main};
 
 // Suppress warnings due to the `unused_crate_dependencies` lint not handling integration tests well.
 #[cfg(test)]

--- a/test-buildpacks/sbom/tests/integration_test.rs
+++ b/test-buildpacks/sbom/tests/integration_test.rs
@@ -114,29 +114,35 @@ fn test() {
         context.rebuild(&build_config, |context| {
             context.download_sbom_files(|sbom_files| {
                 // The buildpack removes restored SBOMs from the 'test' layer.
-                assert!(!sbom_files
-                    .path_for(
-                        &buildpack_id,
-                        SbomType::Layer(layer_name!("test")),
-                        SbomFormat::CycloneDxJson,
-                    )
-                    .exists());
+                assert!(
+                    !sbom_files
+                        .path_for(
+                            &buildpack_id,
+                            SbomType::Layer(layer_name!("test")),
+                            SbomFormat::CycloneDxJson,
+                        )
+                        .exists()
+                );
 
-                assert!(!sbom_files
-                    .path_for(
-                        &buildpack_id,
-                        SbomType::Layer(layer_name!("test")),
-                        SbomFormat::SpdxJson,
-                    )
-                    .exists());
+                assert!(
+                    !sbom_files
+                        .path_for(
+                            &buildpack_id,
+                            SbomType::Layer(layer_name!("test")),
+                            SbomFormat::SpdxJson,
+                        )
+                        .exists()
+                );
 
-                assert!(!sbom_files
-                    .path_for(
-                        &buildpack_id,
-                        SbomType::Layer(layer_name!("test")),
-                        SbomFormat::SyftJson,
-                    )
-                    .exists());
+                assert!(
+                    !sbom_files
+                        .path_for(
+                            &buildpack_id,
+                            SbomType::Layer(layer_name!("test")),
+                            SbomFormat::SyftJson,
+                        )
+                        .exists()
+                );
 
                 // The 'test2' layer will be cached between builds and should remain untouched, SBOM
                 // files included.

--- a/test-buildpacks/store/src/main.rs
+++ b/test-buildpacks/store/src/main.rs
@@ -2,7 +2,7 @@ use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::data::store::Store;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericMetadata, GenericPlatform};
-use libcnb::{buildpack_main, Buildpack};
+use libcnb::{Buildpack, buildpack_main};
 use toml::toml;
 
 // Suppress warnings due to the `unused_crate_dependencies` lint not handling integration tests well.

--- a/test-buildpacks/store/tests/integration_test.rs
+++ b/test-buildpacks/store/tests/integration_test.rs
@@ -4,7 +4,7 @@
 // Required due to: https://github.com/rust-lang/rust/issues/95513
 #![allow(unused_crate_dependencies)]
 
-use libcnb_test::{assert_contains, BuildConfig, TestRunner};
+use libcnb_test::{BuildConfig, TestRunner, assert_contains};
 use std::env::temp_dir;
 use std::fs;
 

--- a/test-buildpacks/tracing/src/main.rs
+++ b/test-buildpacks/tracing/src/main.rs
@@ -1,7 +1,7 @@
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericError, GenericMetadata, GenericPlatform};
-use libcnb::{buildpack_main, Buildpack};
+use libcnb::{Buildpack, buildpack_main};
 
 // Suppress warnings due to the `unused_crate_dependencies` lint not handling integration tests well.
 #[cfg(test)]

--- a/test-buildpacks/tracing/tests/integration_test.rs
+++ b/test-buildpacks/tracing/tests/integration_test.rs
@@ -1,7 +1,7 @@
 // Required due to: https://github.com/rust-lang/rust/issues/95513
 #![allow(unused_crate_dependencies)]
 
-use libcnb_test::{assert_contains, BuildConfig, BuildpackReference, TestRunner};
+use libcnb_test::{BuildConfig, BuildpackReference, TestRunner, assert_contains};
 use std::env::temp_dir;
 use std::fs;
 


### PR DESCRIPTION
Updates to the Rust 2024 edition, which is now available as of Rust 1.85:

- https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html
- https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html
- https://doc.rust-lang.org/edition-guide/rust-2024/index.html

Most changes were applied via either `cargo clippy --fix` or `cargo fmt` with the exception of a failure for the new `obfuscated_if_else`:
https://rust-lang.github.io/rust-clippy/master/index.html#obfuscated_if_else

I've also dropped the `module_name_repetitions` lint rule allow, since that lint is no longer part of `clippy::pedantic` due to being too noisy, so we no longer need to manually disable it.

GUS-W-17894359.