### PR TITLE
Update workspace resolver version to 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "examples/basics",
     "examples/execd",


### PR DESCRIPTION
For virtual workspaces (workspaces where there isn't a top level crate, only member crates), there is no top-level Rust `edition` property from which Cargo can infer its resolver version. Instead, one must specify the resolver version explicitly.

Now we're using Rust 2024 edition (which defaults to resolver version 3 for crates using that edition), we should update the overall workspace resolver version from 2 to 3 for parity with it.

See:
https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

GUS-W-17894359.