### PR TITLE
Use `tracing` library to generate spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - libcnb:
-  - Tracing spans, events, and errors from libcnb.rs are now generated via the `tracing` library. ([#918](https://github.com/heroku/libcnb.rs/pull/918))
+  - Tracing spans, events, and errors from libcnb.rs are now generated via the `tracing` library, and tracing data output has changed. ([#918](https://github.com/heroku/libcnb.rs/pull/918))
 
 ## [0.27.0] - 2025-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - libcnb:
-  - `tracing` library macros buildpack code inherit tracing context from libcnb.rs. ([#918](https://github.com/heroku/libcnb.rs/pull/918))
+  - The `tracing` crate is now setup for OTLP File Exports. Buildpacks using `tracing` will inherit tracing context from `libcnb.rs`. ([#918](https://github.com/heroku/libcnb.rs/pull/918))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- libcnb:
+  - `tracing` library macros buildpack code inherit tracing context from libcnb.rs. ([#918](https://github.com/heroku/libcnb.rs/pull/918))
+
+### Changed
+
+- libcnb:
+  - Tracing spans, events, and errors from libcnb.rs are now generated via the `tracing` library. ([#918](https://github.com/heroku/libcnb.rs/pull/918))
 
 ## [0.27.0] - 2025-02-27
 
@@ -274,7 +283,7 @@ Highlight of this release is the bump to [Buildpack API 0.9](https://github.com/
 ### Changed
 
 - Update `toml` to `0.7.1`. If your buildpack interacts with TOML data directly, you probably want to bump
-the `toml` version in your buildpack as well. ([#556](https://github.com/heroku/libcnb.rs/pull/556))
+  the `toml` version in your buildpack as well. ([#556](https://github.com/heroku/libcnb.rs/pull/556))
 
 ## [0.11.4] - 2023-01-11
 

--- a/libcnb/Cargo.toml
+++ b/libcnb/Cargo.toml
@@ -26,6 +26,9 @@ trace = [
     "opentelemetry-proto/gen-tonic-messages",
     "opentelemetry-proto/with-serde",
     "dep:serde_json",
+    "dep:tracing",
+    "dep:tracing-opentelemetry",
+    "dep:tracing-subscriber",
 ]
 
 [dependencies]
@@ -41,6 +44,9 @@ opentelemetry-proto = { version = "0.28.0", optional = true, default-features = 
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = { version = "1.0.139", optional = true }
 thiserror = "2.0.11"
+tracing = { version = "0.1", optional = true }
+tracing-opentelemetry = { version = "0.29", optional = true }
+tracing-subscriber = { version = "0.3", optional = true }
 toml.workspace = true
 
 [dev-dependencies]

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -19,7 +19,6 @@ use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::{env, fs};
-use tracing::Level;
 
 /// Main entry point for this framework.
 ///
@@ -137,13 +136,13 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
     #[cfg(feature = "trace")]
     let _trace_guard = init_tracing(&buildpack_descriptor.buildpack, "detect");
     #[cfg(feature = "trace")]
-    let _span_guard = tracing::span!(Level::INFO, "libcnb-detect").entered();
+    let _span_guard = tracing::span!(tracing::Level::INFO, "libcnb-detect").entered();
     #[cfg(feature = "trace")]
     let trace_error =
         |error: &dyn std::error::Error| tracing::error!(?error, "libcnb-detect-error");
 
     #[cfg(not(feature = "trace"))]
-    let mut trace_error = |_: &dyn std::error::Error| {};
+    let trace_error = |_: &dyn std::error::Error| {};
 
     let platform = B::Platform::from_path(&args.platform_dir_path)
         .map_err(Error::CannotCreatePlatformFromPath)
@@ -168,7 +167,7 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
     match detect_result.0 {
         InnerDetectResult::Fail => {
             #[cfg(feature = "trace")]
-            tracing::event!(Level::INFO, "libcnb-detect-failed");
+            tracing::event!(tracing::Level::INFO, "libcnb-detect-failed");
             Ok(exit_code::DETECT_DETECTION_FAILED)
         }
         InnerDetectResult::Pass { build_plan } => {
@@ -178,7 +177,7 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
                     .inspect_err(|err| trace_error(err))?;
             }
             #[cfg(feature = "trace")]
-            tracing::event!(Level::INFO, "libcnb-detect-passed");
+            tracing::event!(tracing::Level::INFO, "libcnb-detect-passed");
             Ok(exit_code::DETECT_DETECTION_PASSED)
         }
     }
@@ -205,7 +204,7 @@ pub fn libcnb_runtime_build<B: Buildpack>(
     #[cfg(feature = "trace")]
     let _trace_guard = init_tracing(&buildpack_descriptor.buildpack, "build");
     #[cfg(feature = "trace")]
-    let _span_guard = tracing::span!(Level::INFO, "libcnb-build").entered();
+    let _span_guard = tracing::span!(tracing::Level::INFO, "libcnb-build").entered();
 
     #[cfg(feature = "trace")]
     let trace_error = |error: &dyn std::error::Error| {
@@ -213,7 +212,7 @@ pub fn libcnb_runtime_build<B: Buildpack>(
     };
 
     #[cfg(not(feature = "trace"))]
-    let mut trace_error = |_: &dyn std::error::Error| {};
+    let trace_error = |_: &dyn std::error::Error| {};
 
     let platform = Platform::from_path(&args.platform_dir_path)
         .map_err(Error::CannotCreatePlatformFromPath)
@@ -285,7 +284,7 @@ pub fn libcnb_runtime_build<B: Buildpack>(
             }
 
             #[cfg(feature = "trace")]
-            tracing::event!(Level::INFO, "libcnb-build-success");
+            tracing::event!(tracing::Level::INFO, "libcnb-build-success");
             Ok(exit_code::GENERIC_SUCCESS)
         }
     }

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -138,10 +138,11 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
     #[cfg(feature = "trace")]
     let _span_guard = tracing::span!(tracing::Level::INFO, "libcnb-detect").entered();
 
-    let trace_error = |error: &Error<<B as Buildpack>::Error>| {
-        #[cfg(feature = "trace")]
-        tracing::error!(?error, "libcnb-detect-error");
-    };
+    #[cfg(feature = "trace")]
+    let trace_error =
+        |error: &Error<<B as Buildpack>::Error>| tracing::error!(?error, "libcnb-detect-error");
+    #[cfg(not(feature = "trace"))]
+    let trace_error = |_: &Error<<B as Buildpack>::Error>| {};
 
     let platform = B::Platform::from_path(&args.platform_dir_path)
         .map_err(Error::CannotCreatePlatformFromPath)
@@ -202,10 +203,11 @@ pub fn libcnb_runtime_build<B: Buildpack>(
     #[cfg(feature = "trace")]
     let _span_guard = tracing::span!(tracing::Level::INFO, "libcnb-build").entered();
 
-    let trace_error = |error: &Error<<B as Buildpack>::Error>| {
-        #[cfg(feature = "trace")]
-        tracing::error!(?error, "libcnb-build-error");
-    };
+    #[cfg(feature = "trace")]
+    let trace_error =
+        |error: &Error<<B as Buildpack>::Error>| tracing::error!(?error, "libcnb-build-error");
+    #[cfg(not(feature = "trace"))]
+    let trace_error = |_: &Error<<B as Buildpack>::Error>| {};
 
     let platform = Platform::from_path(&args.platform_dir_path)
         .map_err(Error::CannotCreatePlatformFromPath)

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -137,10 +137,7 @@ pub fn libcnb_runtime_detect<B: Buildpack>(
     #[cfg(feature = "trace")]
     let _trace_guard = init_tracing(&buildpack_descriptor.buildpack, "detect");
     #[cfg(feature = "trace")]
-    let span = tracing::span!(Level::INFO, "libcnb-detect");
-    #[cfg(feature = "trace")]
-    let _span_guard = span.enter();
-
+    let _span_guard = tracing::span!(Level::INFO, "libcnb-detect").entered();
     #[cfg(feature = "trace")]
     let trace_error =
         |error: &dyn std::error::Error| tracing::error!(?error, "libcnb-detect-error");
@@ -208,9 +205,7 @@ pub fn libcnb_runtime_build<B: Buildpack>(
     #[cfg(feature = "trace")]
     let _trace_guard = init_tracing(&buildpack_descriptor.buildpack, "build");
     #[cfg(feature = "trace")]
-    let span = tracing::span!(Level::INFO, "libcnb-build");
-    #[cfg(feature = "trace")]
-    let _span_guard = span.enter();
+    let _span_guard = tracing::span!(Level::INFO, "libcnb-build").entered();
 
     #[cfg(feature = "trace")]
     let trace_error = |error: &dyn std::error::Error| {

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -202,8 +202,7 @@ mod tests {
 
         {
             let _trace_guard = init_tracing(&buildpack, "bar");
-            let span = tracing::span!(Level::INFO, "span-name");
-            let _span_guard = span.enter();
+            let _span_guard = tracing::span!(Level::INFO, "span-name").entered();
             tracing::event!(Level::INFO, "baz-event");
             let err = std::io::Error::new(ErrorKind::Unsupported, "oh no!");
             tracing::error!(

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -21,6 +21,7 @@ use std::{
     path::Path,
     sync::{Arc, Mutex},
 };
+use tracing::Level;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -106,6 +107,10 @@ pub(crate) fn init_tracing(buildpack: &Buildpack, phase_name: &'static str) -> B
 
     tracing_subscriber::registry()
         .with(OpenTelemetryLayer::new(tracer))
+        // Filter out noisy trace and debug spans from libraries like ureq
+        .with(tracing_subscriber::filter::LevelFilter::from_level(
+            Level::INFO,
+        ))
         .init();
 
     BuildpackTrace { provider }

--- a/test-buildpacks/tracing/tests/integration_test.rs
+++ b/test-buildpacks/tracing/tests/integration_test.rs
@@ -27,7 +27,7 @@ fn test_tracing_export_file() {
     TestRunner::default().build(&build_config, |context| {
         // Ensure expected span names for detect and build phases are present
         // in the file export contents.
-        assert_contains!(context.pack_stdout, "libcnb_test_buildpacks_tracing-detect");
-        assert_contains!(context.pack_stdout, "libcnb_test_buildpacks_tracing-build");
+        assert_contains!(context.pack_stdout, "libcnb-detect");
+        assert_contains!(context.pack_stdout, "libcnb-build");
     });
 }


### PR DESCRIPTION
Alternative to #917 -- personally, I prefer this one. This sets up `tracing` so that it emits trace data into our opentelemetry file exporter pipeline while correctly honoring the cascade of events from kodon, through libcnb, and buildpack specific spans.

Using `tracing` for recording span data in CNBs looks like this:

```rust
{
  // This span will be nested within libcnb.rs-generated span
  let _span_guard = tracing::span!(Level::INFO, "download-go", version = go_version).entered();
  do_the_download();
  // This event will be affiliated with the 'download-go' span
  tracing::event!(Level::INFO, "downloaded");
}
// The _span_guard is out of scope, so the 'download-go' span is ended
```

`tracing` is a widely used library, even within libraries. This seems like the more rust-like approach. #917 by comparison is the more `opentelemetry`-like approach and closer to that standard.

As an added bonus the `tracing` library automatically adds `code.lineno`, `code.filepath`, `code.namespace` attributes to spans and events.

There are some changes to the shape of the tracing data - some span names, some attributes have changed. Most of this is because we are accepting `tracing-opentelemetry` conventions.