### PR TITLE
Allow tests to target a specific platform

### DIFF
--- a/libcnb-cargo/src/cli.rs
+++ b/libcnb-cargo/src/cli.rs
@@ -24,8 +24,8 @@ pub(crate) struct PackageArgs {
     #[arg(long)]
     pub(crate) release: bool,
     /// Build for the target triple
-    #[arg(long, default_value = "x86_64-unknown-linux-musl")]
-    pub(crate) target: String,
+    #[arg(long)]
+    pub(crate) target: Option<String>,
     /// Directory for packaged buildpacks, defaults to 'packaged' in Cargo workspace root
     #[arg(long)]
     pub(crate) package_dir: Option<PathBuf>,

--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -108,8 +108,8 @@ pub enum CrossCompileAssistance {
 }
 
 // Constants for supported target triples
-const AARCH64_UNKNOWN_LINUX_MUSL: &str = "aarch64-unknown-linux-musl";
-const X86_64_UNKNOWN_LINUX_MUSL: &str = "x86_64-unknown-linux-musl";
+pub const AARCH64_UNKNOWN_LINUX_MUSL: &str = "aarch64-unknown-linux-musl";
+pub const X86_64_UNKNOWN_LINUX_MUSL: &str = "x86_64-unknown-linux-musl";
 
 // Constants for `std::env::consts::OS` and `std::env::consts::ARCH`
 const OS_LINUX: &str = "linux";

--- a/libcnb-package/src/lib.rs
+++ b/libcnb-package/src/lib.rs
@@ -9,6 +9,7 @@ pub mod dependency_graph;
 pub mod output;
 pub mod package;
 pub mod package_descriptor;
+pub mod target_platform;
 pub mod util;
 
 use crate::build::BuildpackBinaries;

--- a/libcnb-package/src/target_platform.rs
+++ b/libcnb-package/src/target_platform.rs
@@ -1,0 +1,58 @@
+use std::fmt::Display;
+
+#[derive(Clone)]
+pub struct TargetPlatform {
+    pub os: TargetOs,
+    pub arch: TargetArch,
+}
+
+impl TargetPlatform {
+    #[must_use]
+    pub fn new(os: TargetOs, arch: TargetArch) -> Self {
+        TargetPlatform { os, arch }
+    }
+}
+
+impl Default for TargetPlatform {
+    fn default() -> Self {
+        TargetPlatform::new(TargetOs::Linux, default_arch())
+    }
+}
+
+impl From<&TargetPlatform> for String {
+    fn from(value: &TargetPlatform) -> Self {
+        value.to_string()
+    }
+}
+
+impl Display for TargetPlatform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let os = match self.os {
+            TargetOs::Linux => "linux",
+        };
+        let arch = match self.arch {
+            TargetArch::Amd64 => "amd64",
+            TargetArch::Arm64 => "arm64",
+        };
+        write!(f, "{os}/{arch}")
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum TargetOs {
+    Linux,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum TargetArch {
+    Amd64,
+    Arm64,
+}
+
+fn default_arch() -> TargetArch {
+    match std::env::consts::ARCH {
+        "amd64" | "x86_64" => TargetArch::Amd64,
+        "arm64" | "aarch64" => TargetArch::Arm64,
+        _ => panic!("Unsupported target arch: {}", std::env::consts::ARCH),
+    }
+}

--- a/libcnb-test/src/build_config.rs
+++ b/libcnb-test/src/build_config.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 pub use libcnb_package::CargoProfile;
+use libcnb_package::target_platform::TargetPlatform;
 
 /// Configuration for a test.
 #[derive(Clone)]
@@ -16,6 +17,7 @@ pub struct BuildConfig {
     pub(crate) env: HashMap<String, String>,
     pub(crate) app_dir_preprocessor: Option<Rc<dyn Fn(PathBuf)>>,
     pub(crate) expected_pack_result: PackResult,
+    pub(crate) platform: TargetPlatform,
 }
 
 impl BuildConfig {
@@ -41,6 +43,7 @@ impl BuildConfig {
             app_dir: PathBuf::from(app_dir.as_ref()),
             cargo_profile: CargoProfile::Dev,
             target_triple: String::from("x86_64-unknown-linux-musl"),
+            platform: TargetPlatform::default(),
             builder_name: builder_name.into(),
             buildpacks: vec![BuildpackReference::CurrentCrate],
             env: HashMap::new(),
@@ -113,6 +116,11 @@ impl BuildConfig {
     /// ```
     pub fn target_triple(&mut self, target_triple: impl Into<String>) -> &mut Self {
         self.target_triple = target_triple.into();
+        self
+    }
+
+    pub fn platform(&mut self, platform: impl Into<TargetPlatform>) -> &mut Self {
+        self.platform = platform.into();
         self
     }
 

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -15,6 +15,7 @@ pub(crate) struct PackBuildCommand {
     pull_policy: PullPolicy,
     trust_builder: bool,
     trust_extra_buildpacks: bool,
+    platform: String,
 }
 
 #[derive(Clone, Debug)]
@@ -54,6 +55,7 @@ impl PackBuildCommand {
         image_name: impl Into<String>,
         build_cache_volume_name: impl Into<String>,
         launch_cache_volume_name: impl Into<String>,
+        platform: impl Into<String>,
     ) -> Self {
         Self {
             build_cache_volume_name: build_cache_volume_name.into(),
@@ -67,6 +69,7 @@ impl PackBuildCommand {
             pull_policy: PullPolicy::IfNotPresent,
             trust_builder: true,
             trust_extra_buildpacks: true,
+            platform: platform.into(),
         }
     }
 
@@ -102,6 +105,8 @@ impl From<PackBuildCommand> for Command {
             ),
             "--path",
             &pack_build_command.path.to_string_lossy(),
+            "--platform",
+            &pack_build_command.platform,
             "--pull-policy",
             match pack_build_command.pull_policy {
                 PullPolicy::Always => "always",
@@ -195,6 +200,7 @@ mod tests {
             pull_policy: PullPolicy::IfNotPresent,
             trust_builder: true,
             trust_extra_buildpacks: true,
+            platform: String::from("linux/amd64"),
         };
 
         let command: Command = input.clone().into();
@@ -214,6 +220,8 @@ mod tests {
                 "type=launch;format=volume;name=launch-cache-volume",
                 "--path",
                 "/tmp/foo/bar",
+                "--platform",
+                "linux/amd64",
                 "--pull-policy",
                 "if-not-present",
                 "--buildpack",

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -108,6 +108,7 @@ impl TestRunner {
             &docker_resources.image_name,
             &docker_resources.build_cache_volume_name,
             &docker_resources.launch_cache_volume_name,
+            &config.platform,
         );
 
         config.env.iter().for_each(|(key, value)| {


### PR DESCRIPTION
Also picks better defaults for the test runner and `libcnb package`.

Fixes #843
Fixes #869