### PR TITLE
Reduce scopes granted to `GITHUB_TOKEN` in GitHub Actions workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,6 +13,9 @@ on:
           - minor
           - patch
 
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ name: Release
 
 on: workflow_dispatch
 
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
As part of security-hardening our GHA workflows, this reduces the permissions granted to the automatically set `GITHUB_TOKEN` env var in GitHub Actions workflows to no more than what is required by that workflow.

See:
https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication

GUS-W-18053749.