### PR TITLE
Use `--locked` with Cargo where possible

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -47,7 +47,7 @@ jobs:
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
 
       - name: Install cargo-edit
-        run: cargo install cargo-edit
+        run: cargo install --locked cargo-edit
 
       - name: Record old crate version
         id: old-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
 
       - name: Install cargo-release
-        run: cargo install cargo-release
+        run: cargo install --locked cargo-release
 
       - name: Record new crate version
         id: new-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - libcnb-package:
-  - The `cargo build` command used when packing the buildpack is now run using `--locked` when the `CI` env var is set. ([#924](https://github.com/heroku/libcnb.rs/pull/924))
+  - The `cargo build` command used when packing the buildpack is now run using `--locked` when the `CI` env var is set. ([#925](https://github.com/heroku/libcnb.rs/pull/925))
 
 ## [0.28.0] - 2025-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- libcnb-package:
+  - The `cargo build` command used when packing the buildpack is now run using `--locked` when the `CI` env var is set. ([#924](https://github.com/heroku/libcnb.rs/pull/924))
 
 ## [0.28.0] - 2025-03-03
 

--- a/libcnb-package/src/build.rs
+++ b/libcnb-package/src/build.rs
@@ -5,6 +5,7 @@ use crate::cargo::{
 };
 use cargo_metadata::Metadata;
 use std::collections::HashMap;
+use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
@@ -104,6 +105,11 @@ fn build_binary(
     target_name: impl AsRef<str>,
 ) -> Result<PathBuf, BuildError> {
     let mut cargo_args = vec!["build", "--target", target_triple.as_ref()];
+
+    if env::var_os("CI").is_some() {
+        cargo_args.push("--locked");
+    }
+
     match cargo_profile {
         CargoProfile::Dev => {
             // We enable stripping for dev builds too, since debug builds are extremely


### PR DESCRIPTION
The Cargo `--locked` argument ensures that Cargo will fail with an error if `Cargo.lock` is out of sync with `Cargo.toml`, rather than the lockfile being silently updated.

Since this repo is a library, we currently don't commit its `Cargo.lock` to Git (though we might want to revisit that for a few reasons in the future).

However, there are still some places where we should be using `--locked` that aren't already.

GUS-W-18062544.