### PR TITLE
Ensure tracing export data is newline-separated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- libcnb:
+  - OTLP File Exports are now correctly newline-separated. ([#926](https://github.com/heroku/libcnb.rs/pull/926))
 - libcnb-package:
   - The `cargo build` command used when packing the buildpack is now run using `--locked` when the `CI` env var is set. ([#925](https://github.com/heroku/libcnb.rs/pull/925))
 

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -155,6 +155,7 @@ impl<W: Write + Send + Debug> SpanExporter for FileExporter<W> {
                 ))));
             }
         };
+
         Box::pin(std::future::ready(
             serde_json::to_writer(writer.get_mut(), &data)
                 .map_err(|e| OTelSdkError::InternalFailure(e.to_string())),
@@ -261,5 +262,8 @@ mod tests {
 
         // Check error status
         assert!(tracing_contents.contains("\"code\":2"));
+
+        // Ensure tracing ends with a newline
+        assert!(tracing_contents.ends_with("\n"));
     }
 }

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -158,7 +158,8 @@ impl<W: Write + Send + Debug> SpanExporter for FileExporter<W> {
 
         Box::pin(std::future::ready(
             serde_json::to_writer(writer.get_mut(), &data)
-                .map_err(|e| OTelSdkError::InternalFailure(e.to_string())),
+                .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))
+                .and(writeln!(writer).map_err(|e| OTelSdkError::InternalFailure(e.to_string()))),
         ))
     }
 

--- a/libcnb/src/tracing.rs
+++ b/libcnb/src/tracing.rs
@@ -265,6 +265,6 @@ mod tests {
         assert!(tracing_contents.contains("\"code\":2"));
 
         // Ensure tracing ends with a newline
-        assert!(tracing_contents.ends_with("\n"));
+        assert!(tracing_contents.ends_with('\n'));
     }
 }


### PR DESCRIPTION
When exporting tracing data batches multiple times (this happens when there more spans in the queue than the batch size), the JSON objects are incorrectly on the same line. This prevents JSONL parsers (like cnb-otel-collector) from working, as they expect valid JSON objects on each line.

To fix this, we insert a `\n` after each export batch.

Thanks @colincasey for uncovering this bug.