### PR TITLE
Add `tracing-opentelemetry` to the OTel crate Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
       opentelemetry:
         patterns:
           - "opentelemetry*"
+          - "tracing-opentelemetry"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Since its version is closely tied to that of the other `opentelemetry*` crates, so it should be grouped/updated in the same Dependabot PR as them.

xref #930