### PR TITLE
Fix auto PATH ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- libcnb:
+  - Order of automatically applied environment variables by libcnb, such as `PATH=<layer>/bin`, now matches the upstream CNB lifecycle (Close [#900](https://github.com/heroku/libcnb.rs/issues/900)). ([#938](https://github.com/heroku/libcnb.rs/pull/938))
+
 
 ## [0.28.1] - 2025-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - libcnb:
-  - Order of automatically applied environment variables by libcnb, such as `PATH=<layer>/bin`, now matches the upstream CNB lifecycle (Close [#900](https://github.com/heroku/libcnb.rs/issues/900)). ([#938](https://github.com/heroku/libcnb.rs/pull/938))
+  - Order of automatically applied environment variables by libcnb, such as `PATH=<layer>/bin`, now matches the upstream CNB lifecycle. ([#938](https://github.com/heroku/libcnb.rs/pull/938))
 
 
 ## [0.28.1] - 2025-03-25

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -28,12 +28,14 @@ use std::path::Path;
 /// logic that uses the build tool to download dependencies. The download process does not need to
 /// know the layer name or any of the logic for constructing `PATH`.
 ///
-/// # Applying the delta
+/// ## Applying the delta
+///
 /// `LayerEnv` is not a static set of environment variables, but a delta. Layers can modify existing
 /// variables by appending, prepending or setting variables only if they were not already defined. If you only need a
 /// static set of environment variables, see [`Env`].
 ///
 /// To apply a `LayerEnv` delta to a given `Env`, use [`LayerEnv::apply`] like so:
+///
 /// ```
 /// use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 /// use libcnb::Env;
@@ -51,7 +53,8 @@ use std::path::Path;
 /// assert_eq!(modified_env.get("VAR2").unwrap(), "previous-value");
 /// ```
 ///
-/// # Implicit Entries
+/// ## Implicit Entries
+///
 /// Some directories in a layer directory are implicitly added to the layer environment if they
 /// exist. The prime example for this behaviour is the `bin` directory. If it exists, its path will
 /// be automatically appended to `PATH` using the operating systems path delimiter as the delimiter.
@@ -61,6 +64,7 @@ use std::path::Path;
 ///
 /// libcnb supports these, including all precedence and lifecycle rules, when a `LayerEnv` is read
 /// from disk:
+///
 /// ```
 /// use libcnb::layer_env::{LayerEnv, Scope};
 /// use std::fs;

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -935,13 +935,17 @@ mod tests {
             // Validate LayerEnv after reading it from disk
             let env = LayerEnv::read_from_layer_dir(layer_dir)
                 .unwrap()
-                .apply_to_empty(scope);
+                .apply_to_empty(scope.clone());
 
             let mut expected_env_value = OsString::new();
             expected_env_value.push(TEST_ENV_VALUE);
             expected_env_value.push(absolute_path.into_os_string());
 
-            assert_eq!(env.get(name), Some(&expected_env_value));
+            assert_eq!(
+                env.get(name),
+                Some(&expected_env_value),
+                "For ENV var `{name}` scope `{scope:?}`"
+            );
         }
     }
 

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -910,6 +910,7 @@ mod tests {
         fs::create_dir_all(layer_dir.join("bada/bing")).unwrap();
 
         let mut layer_env = LayerEnv::read_from_layer_dir(layer_dir).unwrap();
+        layer_env.insert(Scope::Build, ModificationBehavior::Delimiter, "PATH", ":");
         layer_env.insert(
             Scope::Build,
             ModificationBehavior::Prepend,

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -57,7 +57,7 @@ use std::path::Path;
 ///
 /// Some directories in a layer directory are implicitly added to the layer environment if they
 /// exist. The prime example for this behaviour is the `bin` directory. If it exists, its path will
-/// be automatically appended to `PATH` using the operating systems path delimiter as the delimiter.
+/// be automatically prepended to `PATH` using the operating systems path delimiter as the delimiter.
 ///
 /// A full list of these special directories can be found in the
 /// [Cloud Native Buildpack specification](https://github.com/buildpacks/spec/blob/main/buildpack.md#layer-paths).

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -139,8 +139,8 @@ impl LayerEnv {
     pub fn apply(&self, scope: Scope, env: &Env) -> Env {
         let deltas = match scope {
             Scope::All => vec![&self.all],
-            Scope::Build => vec![&self.all, &self.build, &self.layer_paths_build],
-            Scope::Launch => vec![&self.all, &self.launch, &self.layer_paths_launch],
+            Scope::Build => vec![&self.layer_paths_build, &self.all, &self.build],
+            Scope::Launch => vec![&self.layer_paths_launch, &self.all, &self.launch],
             Scope::Process(process) => {
                 let mut process_deltas = vec![&self.all];
                 if let Some(process_specific_delta) = self.process.get(&process) {

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -57,7 +57,7 @@ use std::path::Path;
 ///
 /// Some directories in a layer directory are implicitly added to the layer environment if they
 /// exist. The prime example for this behaviour is the `bin` directory. If it exists, its path will
-/// be automatically prepended to `PATH` using the operating systems path delimiter as the delimiter.
+/// be automatically added to `PATH` using the operating systems path delimiter as the delimiter.
 ///
 /// A full list of these special directories can be found in the
 /// [Cloud Native Buildpack specification](https://github.com/buildpacks/spec/blob/main/buildpack.md#layer-paths).

--- a/libcnb/src/layer_env.rs
+++ b/libcnb/src/layer_env.rs
@@ -923,12 +923,12 @@ mod tests {
             layer_env.write_to_layer_dir(layer_dir).unwrap();
             let env = layer_env.apply_to_empty(scope.clone());
             assert_eq!(
-                env.get("PATH").unwrap(),
                 &[layer_dir.join("explicit_path"), layer_dir.join("bin")]
                     .map(|dir| dir.as_os_str().to_owned())
                     .into_iter()
                     .collect::<Vec<OsString>>()
                     .join(OsStr::new(":")),
+                env.get("PATH").unwrap(),
                 "PATH was not prepended correctly for scope: `{scope:?}`"
             );
         }


### PR DESCRIPTION
In #900, I observed that the path of a layer's `./bin` dir (if present) is appended to any explicitly added paths by CNB lifecycle. Libcnb instead prepends the path.

This is fixed to match the upstream implementation by changing the order of path evaluation.

Close #900