### PR TITLE
Change `libherokubuildpack::download::download_file` backend to `reqwest`, support `rustls-tls-native-roots`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Updated `opentelemetry-proto` from 0.28.0 to 0.30.0
     - Updated `tracing-opentelemetry` from 0.29 to 0.31
 
+- libherokubuildpack:
+  - `download::download_file` now uses the operating system's certificate facilities when verifying certificates. ([#959](https://github.com/heroku/libcnb.rs/pull/959))
+
 ## [0.29.1] - 2025-08-01
 
 ### Fixed

--- a/libherokubuildpack/Cargo.toml
+++ b/libherokubuildpack/Cargo.toml
@@ -50,7 +50,7 @@ tar = { version = "0.4.44", default-features = false, optional = true }
 termcolor = { version = "1.4.1", optional = true }
 thiserror = { version = "2.0.12", optional = true }
 toml = { workspace = true, optional = true }
-reqwest = { version = "0.12.23", features = ["blocking", "rustls-tls-native-roots"], optional = true }
+reqwest = { version = "0.12.23", default-features = false, features = ["blocking", "rustls-tls-native-roots"], optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.177"

--- a/libherokubuildpack/Cargo.toml
+++ b/libherokubuildpack/Cargo.toml
@@ -50,7 +50,7 @@ tar = { version = "0.4.44", default-features = false, optional = true }
 termcolor = { version = "1.4.1", optional = true }
 thiserror = { version = "2.0.12", optional = true }
 toml = { workspace = true, optional = true }
-ureq = { version = "3.0.12", default-features = false, features = ["rustls"], optional = true }
+ureq = { version = "3.0.12", default-features = false, features = ["rustls", "platform-verifier"], optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.177"

--- a/libherokubuildpack/Cargo.toml
+++ b/libherokubuildpack/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 
 [features]
 default = ["command", "download", "digest", "error", "inventory", "log", "inventory-semver", "inventory-sha2", "tar", "toml", "fs", "write"]
-download = ["dep:ureq", "dep:thiserror"]
+download = ["dep:reqwest", "dep:thiserror"]
 digest = ["dep:sha2"]
 error = ["log", "dep:libcnb"]
 inventory = ["dep:hex", "dep:serde", "dep:thiserror", "dep:toml"]
@@ -50,8 +50,9 @@ tar = { version = "0.4.44", default-features = false, optional = true }
 termcolor = { version = "1.4.1", optional = true }
 thiserror = { version = "2.0.12", optional = true }
 toml = { workspace = true, optional = true }
-ureq = { version = "3.0.12", default-features = false, features = ["rustls", "platform-verifier"], optional = true }
+reqwest = { version = "0.12.23", features = ["blocking", "rustls-tls-native-roots"], optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.177"
 tempfile = "3.20.0"
+indoc = "2.0.6"

--- a/libherokubuildpack/src/download.rs
+++ b/libherokubuildpack/src/download.rs
@@ -1,15 +1,12 @@
 use std::{fs, io};
-use ureq::Agent;
-use ureq::tls::{RootCerts, TlsConfig};
 
 #[derive(thiserror::Error, Debug)]
 pub enum DownloadError {
-    // Boxed to prevent `large_enum_variant` errors since `ureq::Error` is massive.
     #[error("HTTP error while downloading file: {0}")]
-    HttpError(#[from] Box<ureq::Error>),
+    HttpError(#[from] reqwest::Error),
 
     #[error("I/O error while downloading file: {0}")]
-    IoError(#[from] std::io::Error),
+    IoError(#[from] io::Error),
 }
 
 /// Downloads a file via HTTP(S) to a local path.
@@ -37,19 +34,80 @@ pub fn download_file(
     uri: impl AsRef<str>,
     destination: impl AsRef<std::path::Path>,
 ) -> Result<(), DownloadError> {
-    let agent = Agent::config_builder()
-        .tls_config(
-            TlsConfig::builder()
-                .root_certs(RootCerts::PlatformVerifier)
-                .build(),
-        )
-        .build()
-        .new_agent();
+    let client = reqwest::blocking::ClientBuilder::new()
+        .use_rustls_tls()
+        .build()?;
 
-    let response = agent.get(uri.as_ref()).call().map_err(Box::new)?;
-    let mut reader = response.into_body().into_reader();
+    let mut response = client.get(uri.as_ref()).send()?;
     let mut file = fs::File::create(destination.as_ref())?;
-    io::copy(&mut reader, &mut file)?;
+
+    io::copy(&mut response, &mut file)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::download_file;
+    use indoc::indoc;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_self_signed_certificate() {
+        // Using unsafe to modify environment variables is not thread-safe but acceptable here
+        // since this test needs to simulate custom certificate scenarios and is the only test
+        // manipulating SSL_CERT_FILE. Since this test is testing that the function implicitly
+        // gets global state from environment variables, there is no other way of testing this.
+        unsafe {
+            std::env::remove_var("SSL_CERT_FILE");
+        }
+
+        let temp_file = NamedTempFile::new().unwrap();
+
+        assert!(download_file("https://self-signed.badssl.com", temp_file.path()).is_err());
+
+        let badssl_self_signed_cert_dir = tempfile::tempdir().unwrap();
+        let badssl_self_signed_cert = badssl_self_signed_cert_dir
+            .path()
+            .join("badssl_self_signed_cert.pem");
+
+        // https://github.com/rustls/rustls-native-certs/blob/main/tests/badssl-com-chain.pem
+        std::fs::write(
+            &badssl_self_signed_cert,
+            indoc! { "
+             -----BEGIN CERTIFICATE-----
+             MIIDeTCCAmGgAwIBAgIJAMnA8BB8xT6wMA0GCSqGSIb3DQEBCwUAMGIxCzAJBgNV
+             BAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNp
+             c2NvMQ8wDQYDVQQKDAZCYWRTU0wxFTATBgNVBAMMDCouYmFkc3NsLmNvbTAeFw0y
+             MTEwMTEyMDAzNTRaFw0yMzEwMTEyMDAzNTRaMGIxCzAJBgNVBAYTAlVTMRMwEQYD
+             VQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ8wDQYDVQQK
+             DAZCYWRTU0wxFTATBgNVBAMMDCouYmFkc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEB
+             BQADggEPADCCAQoCggEBAMIE7PiM7gTCs9hQ1XBYzJMY61yoaEmwIrX5lZ6xKyx2
+             PmzAS2BMTOqytMAPgLaw+XLJhgL5XEFdEyt/ccRLvOmULlA3pmccYYz2QULFRtMW
+             hyefdOsKnRFSJiFzbIRMeVXk0WvoBj1IFVKtsyjbqv9u/2CVSndrOfEk0TG23U3A
+             xPxTuW1CrbV8/q71FdIzSOciccfCFHpsKOo3St/qbLVytH5aohbcabFXRNsKEqve
+             ww9HdFxBIuGa+RuT5q0iBikusbpJHAwnnqP7i/dAcgCskgjZjFeEU4EFy+b+a1SY
+             QCeFxxC7c3DvaRhBB0VVfPlkPz0sw6l865MaTIbRyoUCAwEAAaMyMDAwCQYDVR0T
+             BAIwADAjBgNVHREEHDAaggwqLmJhZHNzbC5jb22CCmJhZHNzbC5jb20wDQYJKoZI
+             hvcNAQELBQADggEBAC4DensZ5tCTeCNJbHABYPwwqLUFOMITKOOgF3t8EqOan0CH
+             ST1NNi4jPslWrVhQ4Y3UbAhRBdqXl5N/NFfMzDosPpOjFgtifh8Z2s3w8vdlEZzf
+             A4mYTC8APgdpWyNgMsp8cdXQF7QOfdnqOfdnY+pfc8a8joObR7HEaeVxhJs+XL4E
+             CLByw5FR+svkYgCbQGWIgrM1cRpmXemt6Gf/XgFNP2PdubxqDEcnWlTMk8FCBVb1
+             nVDSiPjYShwnWsOOshshCRCAiIBPCKPX0QwKDComQlRrgMIvddaSzFFTKPoNZjC+
+             CUspSNnL7V9IIHvqKlRSmu+zIpm2VJCp1xLulk8=
+             -----END CERTIFICATE-----
+         "},
+        )
+        .unwrap();
+
+        unsafe {
+            std::env::set_var("SSL_CERT_FILE", badssl_self_signed_cert);
+        }
+
+        assert!(download_file("https://self-signed.badssl.com", temp_file.path()).is_ok());
+
+        unsafe {
+            std::env::remove_var("SSL_CERT_FILE");
+        }
+    }
 }

--- a/libherokubuildpack/src/download.rs
+++ b/libherokubuildpack/src/download.rs
@@ -58,6 +58,7 @@ mod test {
         // since this test needs to simulate custom certificate scenarios and is the only test
         // manipulating SSL_CERT_FILE. Since this test is testing that the function implicitly
         // gets global state from environment variables, there is no other way of testing this.
+        #[allow(unsafe_code)]
         unsafe {
             std::env::remove_var("SSL_CERT_FILE");
         }
@@ -100,12 +101,14 @@ mod test {
         )
         .unwrap();
 
+        #[allow(unsafe_code)]
         unsafe {
             std::env::set_var("SSL_CERT_FILE", badssl_self_signed_cert);
         }
 
         assert!(download_file("https://self-signed.badssl.com", temp_file.path()).is_ok());
 
+        #[allow(unsafe_code)]
         unsafe {
             std::env::remove_var("SSL_CERT_FILE");
         }


### PR DESCRIPTION
Adding `Platform certificate store support` from #958 without adding more than absolutely necessary. It's not a strict replacement of that PR. But platform certificate store support is something we immediately need now that can be implemented with a few lines of code. It's still not ideal to depend on `tokio` if there otherwise is no need for it. I consider this PR a stopgap and not a final solution.

Ref: GUS-W-19678535