### PR TITLE
 Add `inventory::schedule` module for tracking release lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `libherokubuildpack`:
+  - Added `inventory::schedule` module with `Schedule` and `Release` types for tracking version lifecycle data such as end-of-life dates. ([#989](https://github.com/heroku/libcnb.rs/pull/989))
 
 ## [0.30.3] - 2026-03-02
 

--- a/libherokubuildpack/src/inventory.rs
+++ b/libherokubuildpack/src/inventory.rs
@@ -24,6 +24,13 @@
 //! - Extensible with metadata: The default inventory format covers a lot of common use cases,
 //!   but if you need more, you can extend it by adding custom metadata to each artifact.
 //!
+//! ## Schedule
+//!
+//! The [`schedule`] sub-module provides [`schedule::Schedule`] and [`schedule::Release`] types
+//! for associating version requirements with release lifecycle data such as end-of-life dates. It
+//! uses the [`version::VersionRequirement`] trait for version matching, and each release
+//! can carry arbitrary metadata for additional information such as support tier or channel name.
+//!
 //! ## Example usage
 //!
 //! This example demonstrates:
@@ -91,6 +98,7 @@
 //! ```
 pub mod artifact;
 pub mod checksum;
+pub mod schedule;
 pub mod version;
 
 #[cfg(feature = "inventory-semver")]

--- a/libherokubuildpack/src/inventory/artifact.rs
+++ b/libherokubuildpack/src/inventory/artifact.rs
@@ -115,7 +115,6 @@ impl FromStr for Arch {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::inventory::version::VersionRequirement;
 
     #[test]
     fn test_arch_display_format() {
@@ -159,11 +158,5 @@ mod tests {
             "foo".parse::<Os>().unwrap_err(),
             UnsupportedOsError(..)
         ));
-    }
-
-    impl VersionRequirement<String> for String {
-        fn satisfies(&self, version: &String) -> bool {
-            self == version
-        }
     }
 }

--- a/libherokubuildpack/src/inventory/schedule.rs
+++ b/libherokubuildpack/src/inventory/schedule.rs
@@ -1,0 +1,180 @@
+use crate::inventory::version::VersionRequirement;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::fmt::Formatter;
+use std::str::FromStr;
+
+/// Represents a release schedule for a set of version requirements.
+///
+/// A schedule maps version requirements to release lifecycle data such as end-of-life
+/// dates. It can be used by a buildpack to determine support status for a resolved version.
+///
+/// The schedule can be manipulated in-memory and then re-serialized to disk to facilitate
+/// both reading and writing schedule files.
+///
+/// # Example
+///
+/// ```rust
+/// use libherokubuildpack::inventory::schedule::{Schedule, Release};
+/// use semver::{Version, VersionReq};
+///
+/// // Create a release and add it to a schedule
+/// let new_release = Release {
+///     requirement: VersionReq::parse("^1.0").unwrap(),
+///     end_of_life: "2025-01-01".to_string(),
+///     metadata: None,
+/// };
+/// let mut schedule = Schedule::<VersionReq, String, Option<()>>::new();
+/// schedule.push(new_release.clone());
+///
+/// // Serialize the schedule to TOML
+/// let schedule_toml = schedule.to_string();
+/// assert_eq!(
+///     r#"[[releases]]
+/// requirement = "^1.0"
+/// end_of_life = "2025-01-01"
+/// "#,
+///     schedule_toml
+/// );
+///
+/// // Deserialize the schedule from TOML
+/// let parsed_schedule = schedule_toml
+///     .parse::<Schedule<VersionReq, String, Option<()>>>()
+///     .unwrap();
+///
+/// // Resolve a release for a given version
+/// let resolved_release = parsed_schedule.resolve(&Version::new(1, 2, 3)).unwrap();
+/// assert_eq!(resolved_release.end_of_life, "2025-01-01");
+/// ```
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Schedule<R, E, M> {
+    pub releases: Vec<Release<R, E, M>>,
+}
+
+/// A single entry in a [`Schedule`], covering versions that match `requirement`.
+///
+/// Each release carries an end-of-life value that can be used to determine
+/// when a release is no longer supported.
+///
+/// Metadata can be used to store additional information about the release.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Release<R, E, M> {
+    pub requirement: R,
+    pub end_of_life: E,
+    pub metadata: M,
+}
+
+impl<R, E, M> Default for Schedule<R, E, M> {
+    fn default() -> Self {
+        Self { releases: vec![] }
+    }
+}
+
+impl<R, E, M> Schedule<R, E, M> {
+    /// Creates a new empty schedule
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a new release to the in-memory schedule
+    pub fn push(&mut self, release: Release<R, E, M>) {
+        self.releases.push(release);
+    }
+
+    /// Return a single release as the first match for the given version.
+    ///
+    /// If multiple releases match the version, the first one in declaration order is returned.
+    /// This differs from [`Inventory::resolve`](super::Inventory::resolve), which returns the
+    /// highest matching version.
+    pub fn resolve<V>(&self, version: &V) -> Option<&Release<R, E, M>>
+    where
+        R: VersionRequirement<V>,
+    {
+        self.releases
+            .iter()
+            .find(|release| release.requirement.satisfies(version))
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ParseScheduleError {
+    #[error("TOML parsing error: {0}")]
+    TomlError(toml::de::Error),
+}
+
+impl<R, E, M> FromStr for Schedule<R, E, M>
+where
+    R: DeserializeOwned,
+    E: DeserializeOwned,
+    M: DeserializeOwned,
+{
+    type Err = ParseScheduleError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        toml::from_str(s).map_err(ParseScheduleError::TomlError)
+    }
+}
+
+impl<R, E, M> std::fmt::Display for Schedule<R, E, M>
+where
+    R: Serialize,
+    E: Serialize,
+    M: Serialize,
+{
+    #![allow(clippy::unwrap_used)]
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&toml::to_string(self).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_matching_release_resolution() {
+        let mut schedule = Schedule::new();
+        schedule.push(create_release("v1", "2025-01-01"));
+        schedule.push(create_release("v2", "2026-01-01"));
+
+        assert_eq!(
+            "2026-01-01",
+            &schedule
+                .resolve(&String::from("v2"))
+                .expect("should resolve matching release")
+                .end_of_life,
+        );
+    }
+
+    #[test]
+    fn test_dont_resolve_release_with_wrong_version() {
+        let mut schedule = Schedule::new();
+        schedule.push(create_release("v1", "2025-01-01"));
+
+        assert!(schedule.resolve(&String::from("v9")).is_none());
+    }
+
+    #[test]
+    fn test_resolve_returns_first_match() {
+        let mut schedule = Schedule::new();
+        schedule.push(create_release("v1", "first"));
+        schedule.push(create_release("v1", "second"));
+
+        assert_eq!(
+            "first",
+            &schedule
+                .resolve(&String::from("v1"))
+                .expect("should resolve matching release")
+                .end_of_life,
+        );
+    }
+
+    fn create_release(requirement: &str, eol: &str) -> Release<String, String, Option<()>> {
+        Release {
+            requirement: requirement.to_string(),
+            end_of_life: eol.to_string(),
+            metadata: None,
+        }
+    }
+}

--- a/libherokubuildpack/src/inventory/schedule.rs
+++ b/libherokubuildpack/src/inventory/schedule.rs
@@ -122,9 +122,8 @@ where
     E: Serialize,
     M: Serialize,
 {
-    #![allow(clippy::unwrap_used)]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&toml::to_string(self).unwrap())
+        f.write_str(&toml::to_string(self).expect("should serialize to TOML string"))
     }
 }
 

--- a/libherokubuildpack/src/inventory/version.rs
+++ b/libherokubuildpack/src/inventory/version.rs
@@ -27,3 +27,14 @@ where
         self.satisfies(version)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl VersionRequirement<String> for String {
+        fn satisfies(&self, version: &String) -> bool {
+            self == version
+        }
+    }
+}


### PR DESCRIPTION
Buildpacks that ship an `Inventory` of versioned artifacts often need to track when those versions reach end-of-life, as well as other lifecycle metadata, so they can warn users. Today each buildpack has to roll its own implementation, or encode lifecycle data in `Artifact` metadata - which may not be ideal when the information spans a range of artifacts rather than belonging to any single one. This PR adds a small, generic `schedule` sub-module inside `inventory` that provides shared plumbing for it.

This is an evolution of the approach first explored in [heroku/buildpacks-nodejs#1332](https://github.com/heroku/buildpacks-nodejs/pull/1332), extracted into `libherokubuildpack` so it can be reused across buildpacks. A minimal "reference"/POC implementation in the .NET CNB can be found here: [heroku/buildpacks-dotnet#404](https://github.com/heroku/buildpacks-dotnet/pull/404)

This is just a proposal for a possible solution. Feedback is more than welcome!

GUS-W-21778596

### What it adds

`Schedule<R, E, M>` holds a list of `Release<R, E, M>` entries:

```rust
pub struct Release<R, E, M> {
    pub requirement: R,   // which versions this release covers
    pub end_of_life: E,   // when this release line reaches EOL
    pub metadata: M,      // arbitrary extra data
}
```

`Schedule::resolve(&version)` finds the first release whose `requirement` satisfies the given version, using the existing `VersionRequirement<V>` trait from `inventory::version`.

`Schedule` and `Release` derive `Serialize` and `Deserialize`. `Schedule::resolve()` requires `R: VersionRequirement<V>` for version matching - like the `semver::VersionReq` does when the `inventory-semver` feature is enabled. Because any `VersionRequirement` implementor automatically satisfies `ArtifactRequirement` (via a blanket impl), a release's `requirement` can also be passed directly to `Inventory::resolve` to find matching artifacts within that release line.

**`E`** (`end_of_life`) is also generic - the module doesn't pull in a date library or define what "end-of-life" means. Consumers choose their own type (e.g. `time::Date`, `String`, `bool`, a custom enum).

**`M`** (`metadata`) follows the same pattern as `Artifact` - use it for additional release information such as support tier (LTS/STS), channel name, support/release dates, etc. Use `Option<()>` to omit it from serialization entirely.

TOML serialization and deserialization is provided via `FromStr` and `Display`, following the same patterns as `Inventory`.

### Example

Building a schedule and serializing it to TOML:

```rust
let mut schedule = Schedule::<VersionReq, String, Option<()>>::new();
schedule.push(Release {
    requirement: VersionReq::parse("^1.0").unwrap(),
    end_of_life: "2025-01-01".to_string(),
    metadata: None,
});

let toml = schedule.to_string();
assert_eq!(toml, r#"[[releases]]
requirement = "^1.0"
end_of_life = "2025-01-01"
"#);
```

Parsing a schedule from TOML and resolving a release for a version:

```rust
let schedule: Schedule<VersionReq, String, Option<()>> = toml.parse().unwrap();
let release = schedule.resolve(&Version::new(1, 2, 3)).unwrap();
assert_eq!(release.end_of_life, "2025-01-01");
```

Using a schedule alongside an inventory:

```rust
// Resolve an artifact from the inventory as usual
let artifact = inventory.resolve(os, arch, &version_req).unwrap();

// Find the release that covers this artifact's version
let release = schedule.resolve(&artifact.version).unwrap();

// Use end_of_life to warn about EOL versions
if today >= release.end_of_life {
    warn!("{} has reached end-of-life", release.requirement);
}

// Use the release's requirement to find the latest artifact in the same release
if let Some(latest) = inventory.resolve(artifact.os, artifact.arch, &release.requirement) {
    if latest.version > artifact.version {
        info!(
            "Newer version available: {} (released {})",
            latest.version, latest.metadata.release_date
        );
    }
}
```

A working implementation using this module is available in [heroku/buildpacks-dotnet#404](https://github.com/heroku/buildpacks-dotnet/pull/404).

### Design notes and limitations

- **No ordering or uniqueness constraints.** `Schedule::resolve` returns the first `Release` whose requirement satisfies the version. Consumers are responsible for ensuring releases are in the desired order and that requirements don't overlap ambiguously.
- **Pre-release versions are not matched by default.** Common `VersionRequirement` implementations (including `semver::VersionReq`) do not match pre-release versions unless the specific pre-release is named in the requirement. This is generally desirable - pre-releases aren't considered supported releases. Consumers needing pre-release tracking can implement custom `VersionRequirement` types.

### Other changes

Moves the shared `VersionRequirement<String> for String` test impl from `artifact::tests` to `version::tests` so both `artifact` and `schedule` tests reuse it without duplication.