### PR TITLE
Add `assert_matches!` macro to libcnb-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `libcnb-test`:
+  - Added `assert_matches!` macro for asserting that expressions match specific patterns, with optional guards. ([#996](https://github.com/heroku/libcnb.rs/pull/996))
+
 
 ## [0.30.3] - 2026-03-02
 

--- a/libcnb-test/src/macros.rs
+++ b/libcnb-test/src/macros.rs
@@ -266,38 +266,38 @@ right: `{:?}`: {}",
 /// use libcnb_test::assert_matches;
 ///
 /// let result: Result<i32, String> = Ok(42);
-/// assert_matches!(result, Ok(x) if *x > 40);
+/// assert_matches!(result, Ok(x) if x > 40);
 /// ```
 #[macro_export]
 macro_rules! assert_matches {
     // With a guard (e.g. `Ok(x) if x > 10`)
     ($expression:expr, $pattern:pat if $guard:expr $(,)?) => {
-        assert!(
-            matches!(&$expression, $pattern if $guard),
-            "Expected match pattern: {} where {}, but got {:?}",
-            stringify!($pattern),
-            stringify!($guard),
-            $expression
-        );
+        match $expression {
+            $pattern if $guard => {}
+            ref _actual => {
+                ::std::panic!(
+                    "Expected match pattern: {} where {}, but got {:?}",
+                    stringify!($pattern),
+                    stringify!($guard),
+                    _actual
+                );
+            }
+        }
     };
 
     // Without a guard (injects `if true` to force branch coverage)
-    ($expression:expr, $pattern:pat $(,)?) => {{
-        // Suppress clippy::redundant_pattern_matching within the macro expansion.
-        // This macro is designed to work with arbitrary patterns (e.g., `Some(x) if x > 5`),
-        // but clippy complains when users write simple patterns like `Ok(_)` or `Err(_)`,
-        // suggesting `.is_ok()` or `.is_err()` instead. Since this is a generic assertion
-        // macro for pattern matching, we suppress the lint here so external consumers
-        // don't need to add #[allow] attributes to their tests.
-        #[allow(clippy::redundant_pattern_matching)]
-        let result = matches!(&$expression, $pattern if true);
-        assert!(
-            result,
-            "Expected match pattern: {}, but got {:?}",
-            stringify!($pattern),
-            $expression
-        );
-    }};
+    ($expression:expr, $pattern:pat $(,)?) => {
+        match $expression {
+            $pattern if true => {}
+            ref _actual => {
+                ::std::panic!(
+                    "Expected match pattern: {}, but got {:?}",
+                    stringify!($pattern),
+                    _actual
+                );
+            }
+        }
+    };
 }
 
 #[cfg(test)]
@@ -695,7 +695,7 @@ error: unclosed group
     #[test]
     fn assert_matches_ok_with_guard() {
         let result: Result<i32, String> = Ok(42);
-        assert_matches!(result, Ok(x) if *x > 40);
+        assert_matches!(result, Ok(x) if x > 40);
     }
 
     #[test]
@@ -712,10 +712,10 @@ error: unclosed group
     }
 
     #[test]
-    #[should_panic(expected = "Expected match pattern: Ok(x) where *x > 50, but got Ok(42)")]
+    #[should_panic(expected = "Expected match pattern: Ok(x) where x > 50, but got Ok(42)")]
     fn assert_matches_failure_with_guard() {
         let result: Result<i32, String> = Ok(42);
-        assert_matches!(result, Ok(x) if *x > 50);
+        assert_matches!(result, Ok(x) if x > 50);
     }
 
     #[test]

--- a/libcnb-test/src/macros.rs
+++ b/libcnb-test/src/macros.rs
@@ -251,6 +251,55 @@ right: `{:?}`: {}",
     }};
 }
 
+/// Asserts that an expression matches a given pattern.
+///
+/// This is a polyfill for `assert_matches!` to ensure 100% region coverage.
+/// Unlike the crate or standard macros, this implementation is stable and avoids
+/// generating unreachable panic branches that `llvm-cov` flags as uncovered regions.
+///
+/// Additionally, for expressions with a guard, this macro improves test error output
+/// by explicitly printing the pattern, guard condition, and actual value on failure.
+///
+/// # Example
+///
+/// ```
+/// use libcnb_test::assert_matches;
+///
+/// let result: Result<i32, String> = Ok(42);
+/// assert_matches!(result, Ok(x) if *x > 40);
+/// ```
+#[macro_export]
+macro_rules! assert_matches {
+    // With a guard (e.g. `Ok(x) if x > 10`)
+    ($expression:expr, $pattern:pat if $guard:expr $(,)?) => {
+        assert!(
+            matches!(&$expression, $pattern if $guard),
+            "Expected match pattern: {} where {}, but got {:?}",
+            stringify!($pattern),
+            stringify!($guard),
+            $expression
+        );
+    };
+
+    // Without a guard (injects `if true` to force branch coverage)
+    ($expression:expr, $pattern:pat $(,)?) => {{
+        // Suppress clippy::redundant_pattern_matching within the macro expansion.
+        // This macro is designed to work with arbitrary patterns (e.g., `Some(x) if x > 5`),
+        // but clippy complains when users write simple patterns like `Ok(_)` or `Err(_)`,
+        // suggesting `.is_ok()` or `.is_err()` instead. Since this is a generic assertion
+        // macro for pattern matching, we suppress the lint here so external consumers
+        // don't need to add #[allow] attributes to their tests.
+        #[allow(clippy::redundant_pattern_matching)]
+        let result = matches!(&$expression, $pattern if true);
+        assert!(
+            result,
+            "Expected match pattern: {}, but got {:?}",
+            stringify!($pattern),
+            $expression
+        );
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -635,5 +684,49 @@ error: unclosed group
 )")]
     fn not_contains_match_with_invalid_regex_and_args() {
         assert_not_contains_match!("Hello World!", "(unclosed group", "This will fail");
+    }
+
+    #[test]
+    fn assert_matches_ok_simple() {
+        let result: Result<i32, String> = Ok(42);
+        assert_matches!(result, Ok(_));
+    }
+
+    #[test]
+    fn assert_matches_ok_with_guard() {
+        let result: Result<i32, String> = Ok(42);
+        assert_matches!(result, Ok(x) if *x > 40);
+    }
+
+    #[test]
+    fn assert_matches_err_simple() {
+        let result: Result<i32, String> = Err("error".to_string());
+        assert_matches!(result, Err(_));
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected match pattern: Ok(_), but got Err(\"error\")")]
+    fn assert_matches_failure_simple() {
+        let result: Result<i32, String> = Err("error".to_string());
+        assert_matches!(result, Ok(_));
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected match pattern: Ok(x) where *x > 50, but got Ok(42)")]
+    fn assert_matches_failure_with_guard() {
+        let result: Result<i32, String> = Ok(42);
+        assert_matches!(result, Ok(x) if *x > 50);
+    }
+
+    #[test]
+    fn assert_matches_option_some() {
+        let value: Option<&str> = Some("hello");
+        assert_matches!(value, Some("hello"));
+    }
+
+    #[test]
+    fn assert_matches_option_none() {
+        let value: Option<&str> = None;
+        assert_matches!(value, None);
     }
 }

--- a/libcnb-test/src/macros.rs
+++ b/libcnb-test/src/macros.rs
@@ -253,23 +253,44 @@ right: `{:?}`: {}",
 
 /// Asserts that an expression matches a given pattern.
 ///
-/// This is a polyfill for `assert_matches!` to ensure 100% region coverage.
-/// Unlike the crate or standard macros, this implementation is stable and avoids
-/// generating unreachable panic branches that `llvm-cov` flags as uncovered regions.
+/// This is a stable polyfill for `assert_matches!` that ensures 100% region coverage.
+/// Unlike the crate or standard library macros, this implementation avoids generating
+/// unreachable panic branches that `llvm-cov` flags as uncovered regions.
 ///
-/// Additionally, for expressions with a guard, this macro improves test error output
-/// by explicitly printing the pattern, guard condition, and actual value on failure.
-///
-/// # Example
+/// # Examples
 ///
 /// ```
 /// use libcnb_test::assert_matches;
 ///
 /// let result: Result<i32, String> = Ok(42);
+///
+/// // Simple pattern matching
+/// assert_matches!(result, Ok(_));
+///
+/// // With guard
 /// assert_matches!(result, Ok(x) if x > 40);
+///
+/// // With custom error message
+/// assert_matches!(result, Ok(x) if x > 40, "value should be greater than 40");
 /// ```
 #[macro_export]
 macro_rules! assert_matches {
+    // With a guard and custom message
+    ($expression:expr, $pattern:pat if $guard:expr, $($arg:tt)+) => {
+        match $expression {
+            $pattern if $guard => {}
+            ref _actual => {
+                ::std::panic!(
+                    "Expected match pattern: {} where {}, but got {:?}: {}",
+                    stringify!($pattern),
+                    stringify!($guard),
+                    _actual,
+                    ::core::format_args!($($arg)+)
+                );
+            }
+        }
+    };
+
     // With a guard (e.g. `Ok(x) if x > 10`)
     ($expression:expr, $pattern:pat if $guard:expr $(,)?) => {
         match $expression {
@@ -280,6 +301,21 @@ macro_rules! assert_matches {
                     stringify!($pattern),
                     stringify!($guard),
                     _actual
+                );
+            }
+        }
+    };
+
+    // Without a guard, with custom message
+    ($expression:expr, $pattern:pat, $($arg:tt)+) => {
+        match $expression {
+            $pattern if true => {}
+            ref _actual => {
+                ::std::panic!(
+                    "Expected match pattern: {}, but got {:?}: {}",
+                    stringify!($pattern),
+                    _actual,
+                    ::core::format_args!($($arg)+)
                 );
             }
         }
@@ -728,5 +764,35 @@ error: unclosed group
     fn assert_matches_option_none() {
         let value: Option<&str> = None;
         assert_matches!(value, None);
+    }
+
+    #[test]
+    fn assert_matches_ok_simple_with_message() {
+        let result: Result<i32, String> = Ok(42);
+        assert_matches!(result, Ok(_), "result should be Ok");
+    }
+
+    #[test]
+    fn assert_matches_ok_with_guard_and_message() {
+        let result: Result<i32, String> = Ok(42);
+        assert_matches!(result, Ok(x) if x > 40, "value should be greater than 40");
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Expected match pattern: Ok(_), but got Err(\"error\"): result must be Ok"
+    )]
+    fn assert_matches_failure_simple_with_message() {
+        let result: Result<i32, String> = Err("error".to_string());
+        assert_matches!(result, Ok(_), "result must be Ok");
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Expected match pattern: Ok(x) where x > 50, but got Ok(42): value must exceed threshold"
+    )]
+    fn assert_matches_failure_with_guard_and_message() {
+        let result: Result<i32, String> = Ok(42);
+        assert_matches!(result, Ok(x) if x > 50, "value must exceed threshold");
     }
 }


### PR DESCRIPTION
Add `assert_matches!` based on popular demand https://github.com/heroku/buildpacks-dotnet/pull/349#discussion_r2576267852

GUS-W-21970637