### PR TITLE
Set CXX and AR environment variables for cross-compilation

### DIFF
--- a/libcnb-package/src/cross_compile.rs
+++ b/libcnb-package/src/cross_compile.rs
@@ -10,38 +10,54 @@ use which::which;
 /// any other issue has been detected.
 pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileAssistance {
     let target_triple = target_triple.as_ref();
-    let (gcc_binary_name, help_text) = match (target_triple, consts::OS, consts::ARCH) {
+    let (toolchain_prefix, help_text) = match (target_triple, consts::OS, consts::ARCH) {
         (AARCH64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_X86_64) => (
-            "aarch64-linux-gnu-gcc",
+            "aarch64-linux-gnu",
             indoc! {"
                 To install an aarch64 cross-compiler on Ubuntu:
                 sudo apt-get install g++-aarch64-linux-gnu libc6-dev-arm64-cross musl-tools
             "},
         ),
         (AARCH64_UNKNOWN_LINUX_MUSL, OS_MACOS, ARCH_X86_64 | ARCH_AARCH64) => (
-            "aarch64-unknown-linux-musl-gcc",
+            "aarch64-unknown-linux-musl",
             indoc! {"
                 To install an aarch64 cross-compiler on macOS:
                 brew install messense/macos-cross-toolchains/aarch64-unknown-linux-musl
             "},
         ),
+        // When the target matches the host architecture, Cargo will automatically select the
+        // appropriate default linker and set the required environment variables. We only need
+        // to verify that musl-gcc is available.
         (AARCH64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_AARCH64)
-        | (X86_64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_X86_64) => (
-            "musl-gcc",
-            indoc! {"
-                To install musl-tools on Ubuntu:
-                sudo apt-get install musl-tools
-            "},
-        ),
+        | (X86_64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_X86_64) => {
+            return match which("musl-gcc") {
+                Ok(_) => CrossCompileAssistance::Configuration {
+                    cargo_env: Vec::new(),
+                },
+                Err(_) => CrossCompileAssistance::HelpText(formatdoc! {"
+                    For cross-compilation from {0} {1} to {target_triple},
+                    a C compiler and linker for the target platform must be installed:
+
+                    To install musl-tools on Ubuntu:
+                    sudo apt-get install musl-tools
+
+                    You will also need to install the Rust target:
+                    rustup target add {target_triple}
+                    ",
+                    consts::ARCH,
+                    consts::OS
+                }),
+            };
+        }
         (X86_64_UNKNOWN_LINUX_MUSL, OS_LINUX, ARCH_AARCH64) => (
-            "x86_64-linux-gnu-gcc",
+            "x86_64-linux-gnu",
             indoc! {"
                 To install an x86_64 cross-compiler on Ubuntu:
                 sudo apt-get install g++-x86-64-linux-gnu libc6-dev-amd64-cross musl-tools
             "},
         ),
         (X86_64_UNKNOWN_LINUX_MUSL, OS_MACOS, ARCH_X86_64 | ARCH_AARCH64) => (
-            "x86_64-unknown-linux-musl-gcc",
+            "x86_64-unknown-linux-musl",
             indoc! {"
                 To install an x86_64 cross-compiler on macOS:
                 brew install messense/macos-cross-toolchains/x86_64-unknown-linux-musl
@@ -50,35 +66,46 @@ pub fn cross_compile_assistance(target_triple: impl AsRef<str>) -> CrossCompileA
         _ => return CrossCompileAssistance::NoAssistance,
     };
 
-    match which(gcc_binary_name) {
+    let gcc = format!("{toolchain_prefix}-gcc");
+    let gxx = format!("{toolchain_prefix}-g++");
+    let ar = format!("{toolchain_prefix}-ar");
+
+    match which(&gcc) {
         Ok(_) => {
-            // When the gcc binary name is `musl-gcc`, Cargo will automatically select the appropriate default linker,
-            // and set the required environment variables.
-            if gcc_binary_name == "musl-gcc" {
-                CrossCompileAssistance::Configuration {
-                    cargo_env: Vec::new(),
-                }
-            } else {
-                CrossCompileAssistance::Configuration {
-                    cargo_env: vec![
-                        (
-                            // Required until Cargo can auto-detect the musl-cross gcc/linker itself,
-                            // since otherwise it checks for a binary named 'musl-gcc' (which is handled above):
-                            // https://github.com/rust-lang/cargo/issues/4133
-                            OsString::from(format!(
-                                "CARGO_TARGET_{}_LINKER",
-                                target_triple.to_uppercase().replace('-', "_")
-                            )),
-                            OsString::from(gcc_binary_name),
-                        ),
-                        (
-                            // Required so that any crates that call out to gcc are also cross-compiled:
-                            // https://github.com/alexcrichton/cc-rs/issues/82
-                            OsString::from(format!("CC_{}", target_triple.replace('-', "_"))),
-                            OsString::from(gcc_binary_name),
-                        ),
-                    ],
-                }
+            let target_env_suffix = target_triple.replace('-', "_");
+            CrossCompileAssistance::Configuration {
+                cargo_env: vec![
+                    (
+                        // Required until Cargo can auto-detect the musl-cross gcc/linker itself,
+                        // since otherwise it checks for a binary named 'musl-gcc' (which is handled above):
+                        // https://github.com/rust-lang/cargo/issues/4133
+                        OsString::from(format!(
+                            "CARGO_TARGET_{}_LINKER",
+                            target_env_suffix.to_uppercase()
+                        )),
+                        OsString::from(&gcc),
+                    ),
+                    (
+                        // Required so that any crates that call out to gcc are also cross-compiled:
+                        // https://github.com/alexcrichton/cc-rs/issues/82
+                        OsString::from(format!("CC_{target_env_suffix}")),
+                        OsString::from(&gcc),
+                    ),
+                    (
+                        // Required so that crates using the `cc` crate for C++ compilation
+                        // use the cross-compilation toolchain instead of the host toolchain:
+                        // https://github.com/heroku/libcnb.rs/issues/725
+                        OsString::from(format!("CXX_{target_env_suffix}")),
+                        OsString::from(&gxx),
+                    ),
+                    (
+                        // Required so that crates using the `cc` crate to create static
+                        // libraries use the cross-compilation archiver:
+                        // https://github.com/heroku/libcnb.rs/issues/725
+                        OsString::from(format!("AR_{target_env_suffix}")),
+                        OsString::from(ar),
+                    ),
+                ],
             }
         }
         Err(_) => CrossCompileAssistance::HelpText(formatdoc! {"


### PR DESCRIPTION
## Summary

- Refactors `cross_compile_assistance()` to store a toolchain prefix per platform case and derive `gcc`, `g++`, and `ar` binary names via `format!`
- Sets `CXX_*` and `AR_*` environment variables alongside existing `CC_*` and `CARGO_TARGET_*_LINKER` for cross-compilation
- Ensures crates using CMake or the `cc` crate for C++ code (such as `aws-lc-sys`) find the correct cross-compiler toolchain

## Context

The [cross-compile toolchain docs](https://github.com/messense/homebrew-macos-cross-toolchains) recommend setting `CC`, `CXX`, and `AR` for the target platform, but we were only setting `CC`. This is possibly causing cross-compilation failures for crates that build C++ code via CMake (see heroku/buildpacks-deb-packages#181).

Fixes #725