### PR TITLE
Add LLVM coverage support for integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `libcnb-test`:
-  - Added `BuildConfig::enable_coverage()` method and `LIBCNB_COVERAGE` env var for collecting LLVM source-based code coverage from integration tests. ([#1002](https://github.com/heroku/libcnb.rs/pull/1002))
+  - Added `BuildConfig::enable_instrumentation()` method and `LIBCNB_INSTRUMENTATION` env var for enabling LLVM source-based coverage instrumentation in integration tests. ([#1002](https://github.com/heroku/libcnb.rs/pull/1002))
 
 ## [0.30.4] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `libcnb-test`:
+  - Added `BuildConfig::enable_coverage()` method and `LIBCNB_COVERAGE` env var for collecting LLVM source-based code coverage from integration tests. ([#1002](https://github.com/heroku/libcnb.rs/pull/1002))
 
 ## [0.30.4] - 2026-04-13
 

--- a/libcnb-cargo/src/package/command.rs
+++ b/libcnb-cargo/src/package/command.rs
@@ -163,15 +163,16 @@ fn eprint_pack_command_hint(
 }
 
 fn eprint_compiled_buildpack_success(current_dir: &Path, target_dir: &Path) {
-    let size_string = calculate_dir_size(target_dir)
-        .map(|size_in_bytes| {
+    let size_string = calculate_dir_size(target_dir).map_or(
+        String::from("<unknown>"),
+        |size_in_bytes| {
             // Precision will only be lost for sizes bigger than 52 bits (~4 Petabytes), and even
             // then will only result in a less precise figure, so is not an issue.
             #[allow(clippy::cast_precision_loss)]
             let size_in_mib = size_in_bytes as f64 / (1024.0 * 1024.0);
             format!("{size_in_mib:.2}")
-        })
-        .unwrap_or(String::from("<unknown>"));
+        },
+    );
 
     let relative_output_path =
         pathdiff::diff_paths(target_dir, current_dir).unwrap_or_else(|| target_dir.to_path_buf());

--- a/libcnb-cargo/src/package/command.rs
+++ b/libcnb-cargo/src/package/command.rs
@@ -163,16 +163,14 @@ fn eprint_pack_command_hint(
 }
 
 fn eprint_compiled_buildpack_success(current_dir: &Path, target_dir: &Path) {
-    let size_string = calculate_dir_size(target_dir).map_or(
-        String::from("<unknown>"),
-        |size_in_bytes| {
+    let size_string =
+        calculate_dir_size(target_dir).map_or(String::from("<unknown>"), |size_in_bytes| {
             // Precision will only be lost for sizes bigger than 52 bits (~4 Petabytes), and even
             // then will only result in a less precise figure, so is not an issue.
             #[allow(clippy::cast_precision_loss)]
             let size_in_mib = size_in_bytes as f64 / (1024.0 * 1024.0);
             format!("{size_in_mib:.2}")
-        },
-    );
+        });
 
     let relative_output_path =
         pathdiff::diff_paths(target_dir, current_dir).unwrap_or_else(|| target_dir.to_path_buf());

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -12,13 +12,29 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
+/// Merges additional env vars into the cargo build env, appending to existing values with a space
+/// separator (e.g. for RUSTFLAGS) or inserting new entries.
+fn merge_cargo_env(
+    cargo_build_env: &mut Vec<(OsString, OsString)>,
+    additional: &[(OsString, OsString)],
+) {
+    for (key, value) in additional {
+        if let Some(existing) = cargo_build_env.iter_mut().find(|(k, _)| k == key) {
+            existing.1.push(" ");
+            existing.1.push(value);
+        } else {
+            cargo_build_env.push((key.clone(), value.clone()));
+        }
+    }
+}
+
 /// Packages the current crate as a buildpack into the provided directory.
 pub(crate) fn package_crate_buildpack(
     cargo_profile: CargoProfile,
     target_triple: impl AsRef<str>,
     cargo_manifest_dir: &Path,
     target_buildpack_dir: &Path,
-    coverage: bool,
+    additional_cargo_env: &[(OsString, OsString)],
 ) -> Result<PathBuf, PackageBuildpackError> {
     let buildpack_toml = cargo_manifest_dir.join("buildpack.toml");
 
@@ -37,7 +53,7 @@ pub(crate) fn package_crate_buildpack(
         target_triple,
         cargo_manifest_dir,
         target_buildpack_dir,
-        coverage,
+        additional_cargo_env,
     )
 }
 
@@ -47,7 +63,7 @@ pub(crate) fn package_buildpack(
     target_triple: impl AsRef<str>,
     cargo_manifest_dir: &Path,
     target_buildpack_dir: &Path,
-    coverage: bool,
+    additional_cargo_env: &[(OsString, OsString)],
 ) -> Result<PathBuf, PackageBuildpackError> {
     let mut cargo_build_env = match cross_compile_assistance(target_triple.as_ref()) {
         CrossCompileAssistance::HelpText(help_text) => {
@@ -59,15 +75,7 @@ pub(crate) fn package_buildpack(
         CrossCompileAssistance::Configuration { cargo_env } => cargo_env,
     };
 
-    if coverage {
-        let coverage_flag = OsString::from("-C instrument-coverage");
-        if let Some(existing) = cargo_build_env.iter_mut().find(|(k, _)| k == "RUSTFLAGS") {
-            existing.1.push(" ");
-            existing.1.push(&coverage_flag);
-        } else {
-            cargo_build_env.push((OsString::from("RUSTFLAGS"), coverage_flag));
-        }
-    }
+    merge_cargo_env(&mut cargo_build_env, additional_cargo_env);
 
     let workspace_root_path = find_cargo_workspace_root_dir(cargo_manifest_dir)
         .map_err(PackageBuildpackError::FindCargoWorkspaceRoot)?;

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -12,27 +12,6 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) struct CargoEnvAddition {
-    pub(crate) key: OsString,
-    pub(crate) value: OsString,
-    pub(crate) separator: OsString,
-}
-
-fn apply_cargo_env_additions(
-    cargo_build_env: &mut Vec<(OsString, OsString)>,
-    additions: &[CargoEnvAddition],
-) {
-    for addition in additions {
-        if let Some(existing) = cargo_build_env.iter_mut().find(|(k, _)| k == &addition.key) {
-            existing.1.push(&addition.separator);
-            existing.1.push(&addition.value);
-        } else {
-            cargo_build_env.push((addition.key.clone(), addition.value.clone()));
-        }
-    }
-}
-
 /// Packages the current crate as a buildpack into the provided directory.
 pub(crate) fn package_crate_buildpack(
     cargo_profile: CargoProfile,
@@ -148,6 +127,27 @@ pub(crate) enum PackageBuildpackError {
     GetDependencies(GetDependenciesError<BuildpackId>),
     #[error(transparent)]
     PackageBuildpack(libcnb_package::package::PackageBuildpackError),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct CargoEnvAddition {
+    pub(crate) key: OsString,
+    pub(crate) value: OsString,
+    pub(crate) separator: OsString,
+}
+
+fn apply_cargo_env_additions(
+    cargo_build_env: &mut Vec<(OsString, OsString)>,
+    additions: &[CargoEnvAddition],
+) {
+    for addition in additions {
+        if let Some(existing) = cargo_build_env.iter_mut().find(|(k, _)| k == &addition.key) {
+            existing.1.push(&addition.separator);
+            existing.1.push(&addition.value);
+        } else {
+            cargo_build_env.push((addition.key.clone(), addition.value.clone()));
+        }
+    }
 }
 
 #[cfg(test)]

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -144,3 +144,53 @@ pub(crate) enum PackageBuildpackError {
     #[error(transparent)]
     PackageBuildpack(libcnb_package::package::PackageBuildpackError),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_cargo_env_inserts_into_empty() {
+        let mut env = Vec::new();
+        merge_cargo_env(
+            &mut env,
+            &[(
+                OsString::from("RUSTFLAGS"),
+                OsString::from("-C opt-level=3"),
+            )],
+        );
+        assert_eq!(env.len(), 1);
+        assert_eq!(env[0].0, "RUSTFLAGS");
+        assert_eq!(env[0].1, "-C opt-level=3");
+    }
+
+    #[test]
+    fn merge_cargo_env_inserts_new_key_alongside_existing() {
+        let mut env = vec![(OsString::from("CC"), OsString::from("clang"))];
+        merge_cargo_env(
+            &mut env,
+            &[(OsString::from("RUSTFLAGS"), OsString::from("-C lto"))],
+        );
+        assert_eq!(env.len(), 2);
+        assert_eq!(env[0], (OsString::from("CC"), OsString::from("clang")));
+        assert_eq!(
+            env[1],
+            (OsString::from("RUSTFLAGS"), OsString::from("-C lto"))
+        );
+    }
+
+    #[test]
+    fn merge_cargo_env_appends_to_existing_key() {
+        let mut env = vec![(OsString::from("RUSTFLAGS"), OsString::from("-C linker=lld"))];
+        merge_cargo_env(
+            &mut env,
+            &[(
+                OsString::from("RUSTFLAGS"),
+                OsString::from("-C instrument-coverage"),
+            )],
+        );
+        assert_eq!(env.len(), 1);
+        assert_eq!(env[0].0, "RUSTFLAGS");
+        assert_eq!(env[0].1, "-C linker=lld -C instrument-coverage");
+    }
+}

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -12,18 +12,35 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-/// Merges additional env vars into the cargo build env, appending to existing values with a space
-/// separator (e.g. for RUSTFLAGS) or inserting new entries.
-fn merge_cargo_env(
+/// Describes how to merge an env var into the cargo build environment.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum CargoEnvUpdate {
+    /// Append the value to any existing value using the given separator (e.g. `" "` for RUSTFLAGS).
+    Append {
+        key: OsString,
+        value: OsString,
+        separator: OsString,
+    },
+}
+
+fn apply_cargo_env_updates(
     cargo_build_env: &mut Vec<(OsString, OsString)>,
-    additional: &[(OsString, OsString)],
+    updates: &[CargoEnvUpdate],
 ) {
-    for (key, value) in additional {
-        if let Some(existing) = cargo_build_env.iter_mut().find(|(k, _)| k == key) {
-            existing.1.push(" ");
-            existing.1.push(value);
-        } else {
-            cargo_build_env.push((key.clone(), value.clone()));
+    for update in updates {
+        match update {
+            CargoEnvUpdate::Append {
+                key,
+                value,
+                separator,
+            } => {
+                if let Some(existing) = cargo_build_env.iter_mut().find(|(k, _)| k == key) {
+                    existing.1.push(separator);
+                    existing.1.push(value);
+                } else {
+                    cargo_build_env.push((key.clone(), value.clone()));
+                }
+            }
         }
     }
 }
@@ -34,7 +51,7 @@ pub(crate) fn package_crate_buildpack(
     target_triple: impl AsRef<str>,
     cargo_manifest_dir: &Path,
     target_buildpack_dir: &Path,
-    additional_cargo_env: &[(OsString, OsString)],
+    additional_cargo_env: &[CargoEnvUpdate],
 ) -> Result<PathBuf, PackageBuildpackError> {
     let buildpack_toml = cargo_manifest_dir.join("buildpack.toml");
 
@@ -63,7 +80,7 @@ pub(crate) fn package_buildpack(
     target_triple: impl AsRef<str>,
     cargo_manifest_dir: &Path,
     target_buildpack_dir: &Path,
-    additional_cargo_env: &[(OsString, OsString)],
+    additional_cargo_env: &[CargoEnvUpdate],
 ) -> Result<PathBuf, PackageBuildpackError> {
     let mut cargo_build_env = match cross_compile_assistance(target_triple.as_ref()) {
         CrossCompileAssistance::HelpText(help_text) => {
@@ -75,7 +92,7 @@ pub(crate) fn package_buildpack(
         CrossCompileAssistance::Configuration { cargo_env } => cargo_env,
     };
 
-    merge_cargo_env(&mut cargo_build_env, additional_cargo_env);
+    apply_cargo_env_updates(&mut cargo_build_env, additional_cargo_env);
 
     let workspace_root_path = find_cargo_workspace_root_dir(cargo_manifest_dir)
         .map_err(PackageBuildpackError::FindCargoWorkspaceRoot)?;
@@ -150,14 +167,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn merge_cargo_env_inserts_into_empty() {
+    fn apply_cargo_env_append_inserts_into_empty() {
         let mut env = Vec::new();
-        merge_cargo_env(
+        apply_cargo_env_updates(
             &mut env,
-            &[(
-                OsString::from("RUSTFLAGS"),
-                OsString::from("-C opt-level=3"),
-            )],
+            &[CargoEnvUpdate::Append {
+                key: OsString::from("RUSTFLAGS"),
+                value: OsString::from("-C opt-level=3"),
+                separator: OsString::from(" "),
+            }],
         );
         assert_eq!(env.len(), 1);
         assert_eq!(env[0].0, "RUSTFLAGS");
@@ -165,11 +183,15 @@ mod tests {
     }
 
     #[test]
-    fn merge_cargo_env_inserts_new_key_alongside_existing() {
+    fn apply_cargo_env_append_inserts_new_key_alongside_existing() {
         let mut env = vec![(OsString::from("CC"), OsString::from("clang"))];
-        merge_cargo_env(
+        apply_cargo_env_updates(
             &mut env,
-            &[(OsString::from("RUSTFLAGS"), OsString::from("-C lto"))],
+            &[CargoEnvUpdate::Append {
+                key: OsString::from("RUSTFLAGS"),
+                value: OsString::from("-C lto"),
+                separator: OsString::from(" "),
+            }],
         );
         assert_eq!(env.len(), 2);
         assert_eq!(env[0], (OsString::from("CC"), OsString::from("clang")));
@@ -180,17 +202,19 @@ mod tests {
     }
 
     #[test]
-    fn merge_cargo_env_appends_to_existing_key() {
+    fn apply_cargo_env_append_joins_existing_key() {
         let mut env = vec![(OsString::from("RUSTFLAGS"), OsString::from("-C linker=lld"))];
-        merge_cargo_env(
+        apply_cargo_env_updates(
             &mut env,
-            &[(
-                OsString::from("RUSTFLAGS"),
-                OsString::from("-C instrument-coverage"),
-            )],
+            &[CargoEnvUpdate::Append {
+                key: OsString::from("RUSTFLAGS"),
+                value: OsString::from("-C instrument-coverage"),
+                separator: OsString::from(" "),
+            }],
         );
         assert_eq!(env.len(), 1);
         assert_eq!(env[0].0, "RUSTFLAGS");
         assert_eq!(env[0].1, "-C linker=lld -C instrument-coverage");
     }
+
 }

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -12,35 +12,23 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-/// Describes how to merge an env var into the cargo build environment.
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum CargoEnvUpdate {
-    /// Append the value to any existing value using the given separator (e.g. `" "` for RUSTFLAGS).
-    Append {
-        key: OsString,
-        value: OsString,
-        separator: OsString,
-    },
+pub(crate) struct CargoEnvAddition {
+    pub(crate) key: OsString,
+    pub(crate) value: OsString,
+    pub(crate) separator: OsString,
 }
 
-fn apply_cargo_env_updates(
+fn apply_cargo_env_additions(
     cargo_build_env: &mut Vec<(OsString, OsString)>,
-    updates: &[CargoEnvUpdate],
+    additions: &[CargoEnvAddition],
 ) {
-    for update in updates {
-        match update {
-            CargoEnvUpdate::Append {
-                key,
-                value,
-                separator,
-            } => {
-                if let Some(existing) = cargo_build_env.iter_mut().find(|(k, _)| k == key) {
-                    existing.1.push(separator);
-                    existing.1.push(value);
-                } else {
-                    cargo_build_env.push((key.clone(), value.clone()));
-                }
-            }
+    for addition in additions {
+        if let Some(existing) = cargo_build_env.iter_mut().find(|(k, _)| k == &addition.key) {
+            existing.1.push(&addition.separator);
+            existing.1.push(&addition.value);
+        } else {
+            cargo_build_env.push((addition.key.clone(), addition.value.clone()));
         }
     }
 }
@@ -51,7 +39,7 @@ pub(crate) fn package_crate_buildpack(
     target_triple: impl AsRef<str>,
     cargo_manifest_dir: &Path,
     target_buildpack_dir: &Path,
-    additional_cargo_env: &[CargoEnvUpdate],
+    cargo_env_additions: &[CargoEnvAddition],
 ) -> Result<PathBuf, PackageBuildpackError> {
     let buildpack_toml = cargo_manifest_dir.join("buildpack.toml");
 
@@ -70,7 +58,7 @@ pub(crate) fn package_crate_buildpack(
         target_triple,
         cargo_manifest_dir,
         target_buildpack_dir,
-        additional_cargo_env,
+        cargo_env_additions,
     )
 }
 
@@ -80,7 +68,7 @@ pub(crate) fn package_buildpack(
     target_triple: impl AsRef<str>,
     cargo_manifest_dir: &Path,
     target_buildpack_dir: &Path,
-    additional_cargo_env: &[CargoEnvUpdate],
+    cargo_env_additions: &[CargoEnvAddition],
 ) -> Result<PathBuf, PackageBuildpackError> {
     let mut cargo_build_env = match cross_compile_assistance(target_triple.as_ref()) {
         CrossCompileAssistance::HelpText(help_text) => {
@@ -92,7 +80,7 @@ pub(crate) fn package_buildpack(
         CrossCompileAssistance::Configuration { cargo_env } => cargo_env,
     };
 
-    apply_cargo_env_updates(&mut cargo_build_env, additional_cargo_env);
+    apply_cargo_env_additions(&mut cargo_build_env, cargo_env_additions);
 
     let workspace_root_path = find_cargo_workspace_root_dir(cargo_manifest_dir)
         .map_err(PackageBuildpackError::FindCargoWorkspaceRoot)?;
@@ -167,11 +155,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn apply_cargo_env_append_inserts_into_empty() {
+    fn apply_cargo_env_addition_inserts_into_empty() {
         let mut env = Vec::new();
-        apply_cargo_env_updates(
+        apply_cargo_env_additions(
             &mut env,
-            &[CargoEnvUpdate::Append {
+            &[CargoEnvAddition {
                 key: OsString::from("RUSTFLAGS"),
                 value: OsString::from("-C opt-level=3"),
                 separator: OsString::from(" "),
@@ -183,11 +171,11 @@ mod tests {
     }
 
     #[test]
-    fn apply_cargo_env_append_inserts_new_key_alongside_existing() {
+    fn apply_cargo_env_addition_inserts_new_key_alongside_existing() {
         let mut env = vec![(OsString::from("CC"), OsString::from("clang"))];
-        apply_cargo_env_updates(
+        apply_cargo_env_additions(
             &mut env,
-            &[CargoEnvUpdate::Append {
+            &[CargoEnvAddition {
                 key: OsString::from("RUSTFLAGS"),
                 value: OsString::from("-C lto"),
                 separator: OsString::from(" "),
@@ -202,11 +190,11 @@ mod tests {
     }
 
     #[test]
-    fn apply_cargo_env_append_joins_existing_key() {
+    fn apply_cargo_env_addition_joins_existing_key() {
         let mut env = vec![(OsString::from("RUSTFLAGS"), OsString::from("-C linker=lld"))];
-        apply_cargo_env_updates(
+        apply_cargo_env_additions(
             &mut env,
-            &[CargoEnvUpdate::Append {
+            &[CargoEnvAddition {
                 key: OsString::from("RUSTFLAGS"),
                 value: OsString::from("-C instrument-coverage"),
                 separator: OsString::from(" "),

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -8,6 +8,7 @@ use libcnb_package::dependency_graph::{GetDependenciesError, get_dependencies};
 use libcnb_package::output::create_packaged_buildpack_dir_resolver;
 use libcnb_package::{CargoProfile, FindCargoWorkspaceRootError, find_cargo_workspace_root_dir};
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
@@ -17,6 +18,7 @@ pub(crate) fn package_crate_buildpack(
     target_triple: impl AsRef<str>,
     cargo_manifest_dir: &Path,
     target_buildpack_dir: &Path,
+    coverage: bool,
 ) -> Result<PathBuf, PackageBuildpackError> {
     let buildpack_toml = cargo_manifest_dir.join("buildpack.toml");
 
@@ -35,6 +37,7 @@ pub(crate) fn package_crate_buildpack(
         target_triple,
         cargo_manifest_dir,
         target_buildpack_dir,
+        coverage,
     )
 }
 
@@ -44,8 +47,9 @@ pub(crate) fn package_buildpack(
     target_triple: impl AsRef<str>,
     cargo_manifest_dir: &Path,
     target_buildpack_dir: &Path,
+    coverage: bool,
 ) -> Result<PathBuf, PackageBuildpackError> {
-    let cargo_build_env = match cross_compile_assistance(target_triple.as_ref()) {
+    let mut cargo_build_env = match cross_compile_assistance(target_triple.as_ref()) {
         CrossCompileAssistance::HelpText(help_text) => {
             return Err(PackageBuildpackError::CrossCompileToolchainNotFound(
                 help_text,
@@ -54,6 +58,16 @@ pub(crate) fn package_buildpack(
         CrossCompileAssistance::NoAssistance => Vec::new(),
         CrossCompileAssistance::Configuration { cargo_env } => cargo_env,
     };
+
+    if coverage {
+        let coverage_flag = OsString::from("-C instrument-coverage");
+        if let Some(existing) = cargo_build_env.iter_mut().find(|(k, _)| k == "RUSTFLAGS") {
+            existing.1.push(" ");
+            existing.1.push(&coverage_flag);
+        } else {
+            cargo_build_env.push((OsString::from("RUSTFLAGS"), coverage_flag));
+        }
+    }
 
     let workspace_root_path = find_cargo_workspace_root_dir(cargo_manifest_dir)
         .map_err(PackageBuildpackError::FindCargoWorkspaceRoot)?;

--- a/libcnb-test/src/build.rs
+++ b/libcnb-test/src/build.rs
@@ -216,5 +216,4 @@ mod tests {
         assert_eq!(env[0].0, "RUSTFLAGS");
         assert_eq!(env[0].1, "-C linker=lld -C instrument-coverage");
     }
-
 }

--- a/libcnb-test/src/build_config.rs
+++ b/libcnb-test/src/build_config.rs
@@ -106,8 +106,8 @@ impl BuildConfig {
     /// Note: `.profraw` files accumulate across runs. Clean the output directory
     /// before a fresh coverage collection if stale data is a concern.
     ///
-    /// Can also be enabled globally by setting `LIBCNB_INSTRUMENTATION` to `1`, `true`, or `yes`
-    /// (case-insensitive).
+    /// Can also be enabled globally by setting `LIBCNB_INSTRUMENTATION` to `1` or `true`
+    /// (case-insensitive). Invalid values will cause a panic.
     ///
     /// # Example
     /// ```no_run

--- a/libcnb-test/src/build_config.rs
+++ b/libcnb-test/src/build_config.rs
@@ -100,8 +100,11 @@ impl BuildConfig {
     /// Enables LLVM source-based code coverage collection for this build.
     ///
     /// When enabled, the buildpack binary is compiled with `-C instrument-coverage`
-    /// and `.profraw` files are extracted from the container via a volume mount
-    /// to `{workspace_root}/target/coverage/profraw/`.
+    /// and `.profraw` files generated during the buildpack's detect/build phases
+    /// are written to `{workspace_root}/target/coverage/profraw/` via a volume mount.
+    ///
+    /// Note: `.profraw` files accumulate across runs. Clean the output directory
+    /// before a fresh coverage collection if stale data is a concern.
     ///
     /// Can also be enabled globally by setting `LIBCNB_COVERAGE` to `1`, `true`, or `yes`
     /// (case-insensitive).

--- a/libcnb-test/src/build_config.rs
+++ b/libcnb-test/src/build_config.rs
@@ -13,6 +13,7 @@ pub struct BuildConfig {
     pub(crate) target_triple: String,
     pub(crate) builder_name: String,
     pub(crate) buildpacks: Vec<BuildpackReference>,
+    pub(crate) coverage: bool,
     pub(crate) env: HashMap<String, String>,
     pub(crate) app_dir_preprocessor: Option<Rc<dyn Fn(PathBuf)>>,
     pub(crate) expected_pack_result: PackResult,
@@ -43,6 +44,7 @@ impl BuildConfig {
             target_triple: String::from("x86_64-unknown-linux-musl"),
             builder_name: builder_name.into(),
             buildpacks: vec![BuildpackReference::CurrentCrate],
+            coverage: false,
             env: HashMap::new(),
             app_dir_preprocessor: None,
             expected_pack_result: PackResult::Success,
@@ -92,6 +94,31 @@ impl BuildConfig {
     /// ```
     pub fn cargo_profile(&mut self, cargo_profile: CargoProfile) -> &mut Self {
         self.cargo_profile = cargo_profile;
+        self
+    }
+
+    /// Enables LLVM source-based code coverage collection for this build.
+    ///
+    /// When enabled, the buildpack binary is compiled with `-C instrument-coverage`
+    /// and `.profraw` files are extracted from the container via a volume mount
+    /// to `{workspace_root}/target/coverage/profraw/`.
+    ///
+    /// Can also be enabled globally by setting `LIBCNB_COVERAGE=1`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use libcnb_test::{BuildConfig, TestRunner};
+    ///
+    /// TestRunner::default().build(
+    ///     BuildConfig::new("heroku/builder:22", "tests/fixtures/app")
+    ///         .enable_coverage(),
+    ///     |context| {
+    ///         // ...
+    ///     },
+    /// );
+    /// ```
+    pub fn enable_coverage(&mut self) -> &mut Self {
+        self.coverage = true;
         self
     }
 

--- a/libcnb-test/src/build_config.rs
+++ b/libcnb-test/src/build_config.rs
@@ -13,7 +13,7 @@ pub struct BuildConfig {
     pub(crate) target_triple: String,
     pub(crate) builder_name: String,
     pub(crate) buildpacks: Vec<BuildpackReference>,
-    pub(crate) coverage: bool,
+    pub(crate) instrumentation_enabled: bool,
     pub(crate) env: HashMap<String, String>,
     pub(crate) app_dir_preprocessor: Option<Rc<dyn Fn(PathBuf)>>,
     pub(crate) expected_pack_result: PackResult,
@@ -44,7 +44,7 @@ impl BuildConfig {
             target_triple: String::from("x86_64-unknown-linux-musl"),
             builder_name: builder_name.into(),
             buildpacks: vec![BuildpackReference::CurrentCrate],
-            coverage: false,
+            instrumentation_enabled: false,
             env: HashMap::new(),
             app_dir_preprocessor: None,
             expected_pack_result: PackResult::Success,
@@ -97,7 +97,7 @@ impl BuildConfig {
         self
     }
 
-    /// Enables LLVM source-based code coverage collection for this build.
+    /// Enables LLVM source-based coverage instrumentation for this build.
     ///
     /// When enabled, the buildpack binary is compiled with `-C instrument-coverage`
     /// and `.profraw` files generated during the buildpack's detect/build phases
@@ -106,7 +106,7 @@ impl BuildConfig {
     /// Note: `.profraw` files accumulate across runs. Clean the output directory
     /// before a fresh coverage collection if stale data is a concern.
     ///
-    /// Can also be enabled globally by setting `LIBCNB_COVERAGE` to `1`, `true`, or `yes`
+    /// Can also be enabled globally by setting `LIBCNB_INSTRUMENTATION` to `1`, `true`, or `yes`
     /// (case-insensitive).
     ///
     /// # Example
@@ -115,14 +115,14 @@ impl BuildConfig {
     ///
     /// TestRunner::default().build(
     ///     BuildConfig::new("heroku/builder:22", "tests/fixtures/app")
-    ///         .enable_coverage(),
+    ///         .enable_instrumentation(),
     ///     |context| {
     ///         // ...
     ///     },
     /// );
     /// ```
-    pub fn enable_coverage(&mut self) -> &mut Self {
-        self.coverage = true;
+    pub fn enable_instrumentation(&mut self) -> &mut Self {
+        self.instrumentation_enabled = true;
         self
     }
 

--- a/libcnb-test/src/build_config.rs
+++ b/libcnb-test/src/build_config.rs
@@ -103,7 +103,8 @@ impl BuildConfig {
     /// and `.profraw` files are extracted from the container via a volume mount
     /// to `{workspace_root}/target/coverage/profraw/`.
     ///
-    /// Can also be enabled globally by setting `LIBCNB_COVERAGE=1`.
+    /// Can also be enabled globally by setting `LIBCNB_COVERAGE` to `1`, `true`, or `yes`
+    /// (case-insensitive).
     ///
     /// # Example
     /// ```no_run

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -11,19 +11,6 @@ pub(crate) struct VolumeMount {
     pub(crate) options: Option<String>,
 }
 
-impl From<&VolumeMount> for OsString {
-    fn from(mount: &VolumeMount) -> Self {
-        let mut s = OsString::from(&mount.source);
-        s.push(":");
-        s.push(&mount.target);
-        if let Some(ref opts) = mount.options {
-            s.push(":");
-            s.push(opts);
-        }
-        s
-    }
-}
-
 /// Represents a `pack build` command.
 #[derive(Clone, Debug)]
 pub(crate) struct PackBuildCommand {
@@ -162,8 +149,15 @@ impl From<PackBuildCommand> for Command {
         }
 
         for volume in &pack_build_command.volumes {
+            let mut arg = OsString::from(&volume.source);
+            arg.push(":");
+            arg.push(&volume.target);
+            if let Some(ref opts) = volume.options {
+                arg.push(":");
+                arg.push(opts);
+            }
             command.arg("--volume");
-            command.arg(OsString::from(volume));
+            command.arg(arg);
         }
 
         command

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -2,6 +2,24 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Command;
 
+/// Represents a volume mount for Docker containers.
+#[derive(Clone, Debug)]
+pub(crate) struct VolumeMount {
+    pub(crate) source: PathBuf,
+    pub(crate) target: PathBuf,
+    pub(crate) options: Option<String>,
+}
+
+impl std::fmt::Display for VolumeMount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.source.display(), self.target.display())?;
+        if let Some(ref opts) = self.options {
+            write!(f, ":{opts}")?;
+        }
+        Ok(())
+    }
+}
+
 /// Represents a `pack build` command.
 #[derive(Clone, Debug)]
 pub(crate) struct PackBuildCommand {
@@ -15,6 +33,7 @@ pub(crate) struct PackBuildCommand {
     pull_policy: PullPolicy,
     trust_builder: bool,
     trust_extra_buildpacks: bool,
+    volumes: Vec<VolumeMount>,
 }
 
 #[derive(Clone, Debug)]
@@ -67,6 +86,7 @@ impl PackBuildCommand {
             pull_policy: PullPolicy::IfNotPresent,
             trust_builder: true,
             trust_extra_buildpacks: true,
+            volumes: Vec::new(),
         }
     }
 
@@ -77,6 +97,12 @@ impl PackBuildCommand {
 
     pub(crate) fn env(&mut self, k: impl Into<String>, v: impl Into<String>) -> &mut Self {
         self.env.insert(k.into(), v.into());
+        self
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn volume(&mut self, v: VolumeMount) -> &mut Self {
+        self.volumes.push(v);
         self
     }
 }
@@ -130,6 +156,10 @@ impl From<PackBuildCommand> for Command {
 
         if pack_build_command.trust_extra_buildpacks {
             command.arg("--trust-extra-buildpacks");
+        }
+
+        for volume in &pack_build_command.volumes {
+            command.args(["--volume", &volume.to_string()]);
         }
 
         command
@@ -195,6 +225,7 @@ mod tests {
             pull_policy: PullPolicy::IfNotPresent,
             trust_builder: true,
             trust_extra_buildpacks: true,
+            volumes: Vec::new(),
         };
 
         let command: Command = input.clone().into();
@@ -271,5 +302,33 @@ mod tests {
         );
 
         assert_eq!(command.get_envs().collect::<Vec<_>>(), Vec::new());
+    }
+
+    #[test]
+    fn from_pack_build_command_with_volumes() {
+        let mut input = PackBuildCommand::new(
+            "builder:22",
+            "/tmp/app",
+            "my-image",
+            "build-cache",
+            "launch-cache",
+        );
+        input.volume(VolumeMount {
+            source: PathBuf::from("/host/path"),
+            target: PathBuf::from("/container/path"),
+            options: None,
+        });
+        input.volume(VolumeMount {
+            source: PathBuf::from("/other"),
+            target: PathBuf::from("/mnt"),
+            options: Some(String::from("ro")),
+        });
+
+        let command: Command = input.into();
+
+        let args: Vec<&OsStr> = command.get_args().collect();
+        assert!(args.contains(&OsStr::new("--volume")));
+        assert!(args.contains(&OsStr::new("/host/path:/container/path")));
+        assert!(args.contains(&OsStr::new("/other:/mnt:ro")));
     }
 }

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -3,14 +3,6 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::Command;
 
-/// Represents a volume mount for Docker containers.
-#[derive(Clone, Debug)]
-pub(crate) struct VolumeMount {
-    pub(crate) source: PathBuf,
-    pub(crate) target: PathBuf,
-    pub(crate) options: Option<String>,
-}
-
 /// Represents a `pack build` command.
 #[derive(Clone, Debug)]
 pub(crate) struct PackBuildCommand {
@@ -162,6 +154,14 @@ impl From<PackBuildCommand> for Command {
 
         command
     }
+}
+
+/// Represents a volume mount for Docker containers.
+#[derive(Clone, Debug)]
+pub(crate) struct VolumeMount {
+    pub(crate) source: PathBuf,
+    pub(crate) target: PathBuf,
+    pub(crate) options: Option<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -10,13 +11,16 @@ pub(crate) struct VolumeMount {
     pub(crate) options: Option<String>,
 }
 
-impl std::fmt::Display for VolumeMount {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}", self.source.display(), self.target.display())?;
-        if let Some(ref opts) = self.options {
-            write!(f, ":{opts}")?;
+impl From<&VolumeMount> for OsString {
+    fn from(mount: &VolumeMount) -> Self {
+        let mut s = OsString::from(&mount.source);
+        s.push(":");
+        s.push(&mount.target);
+        if let Some(ref opts) = mount.options {
+            s.push(":");
+            s.push(opts);
         }
-        Ok(())
+        s
     }
 }
 
@@ -100,7 +104,6 @@ impl PackBuildCommand {
         self
     }
 
-    #[allow(dead_code)]
     pub(crate) fn volume(&mut self, v: VolumeMount) -> &mut Self {
         self.volumes.push(v);
         self
@@ -159,7 +162,8 @@ impl From<PackBuildCommand> for Command {
         }
 
         for volume in &pack_build_command.volumes {
-            command.args(["--volume", &volume.to_string()]);
+            command.arg("--volume");
+            command.arg(OsString::from(volume));
         }
 
         command

--- a/libcnb-test/src/pack.rs
+++ b/libcnb-test/src/pack.rs
@@ -144,10 +144,11 @@ impl From<PackBuildCommand> for Command {
             let mut arg = OsString::from(&volume.source);
             arg.push(":");
             arg.push(&volume.target);
-            if let Some(ref opts) = volume.options {
-                arg.push(":");
-                arg.push(opts);
-            }
+            arg.push(":");
+            arg.push(match volume.mode {
+                VolumeMountMode::ReadOnly => "ro",
+                VolumeMountMode::ReadWrite => "rw",
+            });
             command.arg("--volume");
             command.arg(arg);
         }
@@ -161,7 +162,14 @@ impl From<PackBuildCommand> for Command {
 pub(crate) struct VolumeMount {
     pub(crate) source: PathBuf,
     pub(crate) target: PathBuf,
-    pub(crate) options: Option<String>,
+    pub(crate) mode: VolumeMountMode,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum VolumeMountMode {
+    #[allow(dead_code)]
+    ReadOnly,
+    ReadWrite,
 }
 
 #[derive(Clone, Debug)]
@@ -314,19 +322,19 @@ mod tests {
         input.volume(VolumeMount {
             source: PathBuf::from("/host/path"),
             target: PathBuf::from("/container/path"),
-            options: None,
+            mode: VolumeMountMode::ReadWrite,
         });
         input.volume(VolumeMount {
             source: PathBuf::from("/other"),
             target: PathBuf::from("/mnt"),
-            options: Some(String::from("ro")),
+            mode: VolumeMountMode::ReadOnly,
         });
 
         let command: Command = input.into();
 
         let args: Vec<&OsStr> = command.get_args().collect();
         assert!(args.contains(&OsStr::new("--volume")));
-        assert!(args.contains(&OsStr::new("/host/path:/container/path")));
+        assert!(args.contains(&OsStr::new("/host/path:/container/path:rw")));
         assert!(args.contains(&OsStr::new("/other:/mnt:ro")));
     }
 }

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -122,6 +122,7 @@ impl TestRunner {
                         &config.target_triple,
                         &cargo_manifest_dir,
                         buildpacks_target_dir.path(),
+                        false,
                     )
                     .unwrap_or_else(|error| {
                         panic!("Error packaging current crate as buildpack: {error}")
@@ -136,6 +137,7 @@ impl TestRunner {
                         &config.target_triple,
                         &cargo_manifest_dir,
                         buildpacks_target_dir.path(),
+                        false,
                     )
                     .unwrap_or_else(|error| {
                         panic!("Error packaging buildpack '{buildpack_id}': {error}")

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -1,7 +1,7 @@
+use crate::build::CargoEnvUpdate;
 use crate::docker::{DockerRemoveImageCommand, DockerRemoveVolumeCommand};
 use crate::pack::{PackBuildCommand, VolumeMount};
 use crate::util::CommandError;
-use crate::build::CargoEnvUpdate;
 use crate::{BuildConfig, BuildpackReference, PackResult, TestContext, app, build, util};
 use libcnb_package::find_cargo_workspace_root_dir;
 use std::borrow::Borrow;
@@ -200,7 +200,16 @@ fn configure_coverage(
 
     let dir = workspace_root.join("target/coverage/profraw");
     std::fs::create_dir_all(&dir).expect("Failed to create coverage output directory");
-    let dir = std::fs::canonicalize(&dir).expect("Failed to canonicalize coverage output directory");
+    // The CNB lifecycle runs buildpacks as a non-root user (e.g. uid 1000) which may differ
+    // from the host user, so the mounted directory must be world-writable.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o777))
+            .expect("Failed to set coverage directory permissions");
+    }
+    let dir =
+        std::fs::canonicalize(&dir).expect("Failed to canonicalize coverage output directory");
 
     pack_command.volume(VolumeMount {
         source: dir,

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -70,10 +70,6 @@ impl TestRunner {
     ) {
         let config = config.borrow();
 
-        let instrumentation_enabled = config.instrumentation_enabled
-            || env::var("LIBCNB_INSTRUMENTATION")
-                .is_ok_and(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"));
-
         let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").map_or_else(
             |error| panic!("Error determining Cargo manifest directory: {error}"),
             PathBuf::from,
@@ -121,47 +117,30 @@ impl TestRunner {
             pack_command.env(key, value);
         });
 
-        let cargo_env_additions: Vec<CargoEnvAddition> = if instrumentation_enabled {
-            configure_instrumentation(&cargo_manifest_dir, &mut pack_command)
+        let instrumentation_enabled =
+            config.instrumentation_enabled || instrumentation_enabled_via_env();
+
+        let instrumentation_setup = if instrumentation_enabled {
+            Some(configure_instrumentation(&cargo_manifest_dir))
         } else {
-            Vec::new()
+            None
         };
 
-        for buildpack in &config.buildpacks {
-            match buildpack {
-                BuildpackReference::CurrentCrate => {
-                    let crate_buildpack_dir = build::package_crate_buildpack(
-                        config.cargo_profile,
-                        &config.target_triple,
-                        &cargo_manifest_dir,
-                        buildpacks_target_dir.path(),
-                        &cargo_env_additions,
-                    )
-                    .unwrap_or_else(|error| {
-                        panic!("Error packaging current crate as buildpack: {error}")
-                    });
-                    pack_command.buildpack(crate_buildpack_dir);
-                }
+        if let Some(ref setup) = instrumentation_setup {
+            pack_command.volume(setup.volume.clone());
+            pack_command.env(&setup.pack_env.0, &setup.pack_env.1);
+        }
 
-                BuildpackReference::WorkspaceBuildpack(buildpack_id) => {
-                    let buildpack_dir = build::package_buildpack(
-                        buildpack_id,
-                        config.cargo_profile,
-                        &config.target_triple,
-                        &cargo_manifest_dir,
-                        buildpacks_target_dir.path(),
-                        &cargo_env_additions,
-                    )
-                    .unwrap_or_else(|error| {
-                        panic!("Error packaging buildpack '{buildpack_id}': {error}")
-                    });
-                    pack_command.buildpack(buildpack_dir);
-                }
+        let cargo_env_additions =
+            instrumentation_setup.map_or_else(Vec::new, |setup| setup.cargo_env_additions);
 
-                BuildpackReference::Other(id) => {
-                    pack_command.buildpack(id.clone());
-                }
-            }
+        for reference in create_buildpack_references(
+            config,
+            &cargo_manifest_dir,
+            buildpacks_target_dir.path(),
+            &cargo_env_additions,
+        ) {
+            pack_command.buildpack(reference);
         }
 
         let pack_result = util::run_command(pack_command);
@@ -191,45 +170,100 @@ impl TestRunner {
     }
 }
 
+fn create_buildpack_references(
+    config: &BuildConfig,
+    cargo_manifest_dir: &Path,
+    target_buildpack_dir: &Path,
+    cargo_env_additions: &[CargoEnvAddition],
+) -> Vec<crate::pack::BuildpackReference> {
+    config
+        .buildpacks
+        .iter()
+        .map(|buildpack| match buildpack {
+            BuildpackReference::CurrentCrate => {
+                let dir = build::package_crate_buildpack(
+                    config.cargo_profile,
+                    &config.target_triple,
+                    cargo_manifest_dir,
+                    target_buildpack_dir,
+                    cargo_env_additions,
+                )
+                .unwrap_or_else(|error| {
+                    panic!("Error packaging current crate as buildpack: {error}")
+                });
+                crate::pack::BuildpackReference::from(dir)
+            }
+            BuildpackReference::WorkspaceBuildpack(buildpack_id) => {
+                let dir = build::package_buildpack(
+                    buildpack_id,
+                    config.cargo_profile,
+                    &config.target_triple,
+                    cargo_manifest_dir,
+                    target_buildpack_dir,
+                    cargo_env_additions,
+                )
+                .unwrap_or_else(|error| {
+                    panic!("Error packaging buildpack '{buildpack_id}': {error}")
+                });
+                crate::pack::BuildpackReference::from(dir)
+            }
+            BuildpackReference::Other(id) => crate::pack::BuildpackReference::from(id.clone()),
+        })
+        .collect()
+}
+
+fn instrumentation_enabled_via_env() -> bool {
+    env::var("LIBCNB_INSTRUMENTATION")
+        .is_ok_and(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+}
+
 const INSTRUMENTATION_CONTAINER_DIR: &str = "/tmp/llvm-cov";
 
-fn configure_instrumentation(
-    cargo_manifest_dir: &Path,
-    pack_command: &mut PackBuildCommand,
-) -> Vec<CargoEnvAddition> {
+struct InstrumentationSetup {
+    volume: VolumeMount,
+    pack_env: (String, String),
+    cargo_env_additions: Vec<CargoEnvAddition>,
+}
+
+fn configure_instrumentation(cargo_manifest_dir: &Path) -> InstrumentationSetup {
     let workspace_root = find_cargo_workspace_root_dir(cargo_manifest_dir)
         .unwrap_or_else(|error| panic!("Error finding Cargo workspace root: {error}"));
 
     let dir = workspace_root.join("target/coverage/profraw");
-    std::fs::create_dir_all(&dir).expect("Failed to create coverage output directory");
+    std::fs::create_dir_all(&dir)
+        .unwrap_or_else(|error| panic!("Error creating coverage output directory: {error}"));
     // The CNB lifecycle runs buildpacks as a non-root user (e.g. uid 1000) which may differ
     // from the host user, so the mounted directory must be world-writable.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o777))
-            .expect("Failed to set coverage directory permissions");
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o777)).unwrap_or_else(
+            |error| {
+                panic!("Error setting coverage directory permissions: {error}");
+            },
+        );
     }
-    let dir =
-        std::fs::canonicalize(&dir).expect("Failed to canonicalize coverage output directory");
+    let dir = std::fs::canonicalize(&dir)
+        .unwrap_or_else(|error| panic!("Error canonicalizing coverage output directory: {error}"));
 
-    pack_command.volume(VolumeMount {
-        source: dir,
-        target: PathBuf::from(INSTRUMENTATION_CONTAINER_DIR),
-        options: Some(String::from("rw")),
-    });
-    // %p = PID, %m = binary signature hash — prevents clobbering across concurrent runs.
-    // See: https://doc.rust-lang.org/rustc/instrument-coverage.html
-    pack_command.env(
-        "LLVM_PROFILE_FILE",
-        format!("{INSTRUMENTATION_CONTAINER_DIR}/%p-%m.profraw"),
-    );
-
-    vec![CargoEnvAddition {
-        key: OsString::from("RUSTFLAGS"),
-        value: OsString::from("-C instrument-coverage"),
-        separator: OsString::from(" "),
-    }]
+    InstrumentationSetup {
+        volume: VolumeMount {
+            source: dir,
+            target: PathBuf::from(INSTRUMENTATION_CONTAINER_DIR),
+            options: Some(String::from("rw")),
+        },
+        // %p = PID, %m = binary signature hash — prevents clobbering across concurrent runs.
+        // See: https://doc.rust-lang.org/rustc/instrument-coverage.html
+        pack_env: (
+            String::from("LLVM_PROFILE_FILE"),
+            format!("{INSTRUMENTATION_CONTAINER_DIR}/%p-%m.profraw"),
+        ),
+        cargo_env_additions: vec![CargoEnvAddition {
+            key: OsString::from("RUSTFLAGS"),
+            value: OsString::from("-C instrument-coverage"),
+            separator: OsString::from(" "),
+        }],
+    }
 }
 
 #[allow(clippy::struct_field_names)]

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -2,9 +2,11 @@ use crate::docker::{DockerRemoveImageCommand, DockerRemoveVolumeCommand};
 use crate::pack::{PackBuildCommand, VolumeMount};
 use crate::util::CommandError;
 use crate::{BuildConfig, BuildpackReference, PackResult, TestContext, app, build, util};
+use libcnb_package::find_cargo_workspace_root_dir;
 use std::borrow::Borrow;
 use std::env;
-use std::path::PathBuf;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 use tempfile::tempdir;
 
 /// Runner for libcnb integration tests.
@@ -59,7 +61,6 @@ impl TestRunner {
         self.build_internal(docker_resources, config, f);
     }
 
-    #[allow(clippy::too_many_lines)]
     pub(crate) fn build_internal<C: Borrow<BuildConfig>, F: FnOnce(TestContext)>(
         &self,
         docker_resources: TemporaryDockerResources,
@@ -69,7 +70,8 @@ impl TestRunner {
         let config = config.borrow();
 
         let coverage_enabled = config.coverage
-            || env::var("LIBCNB_COVERAGE").is_ok_and(|v| v == "1");
+            || env::var("LIBCNB_COVERAGE")
+                .is_ok_and(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"));
 
         let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").map_or_else(
             |error| panic!("Error determining Cargo manifest directory: {error}"),
@@ -118,24 +120,11 @@ impl TestRunner {
             pack_command.env(key, value);
         });
 
-        if coverage_enabled {
-            let workspace_root = cargo_manifest_dir
-                .ancestors()
-                .find(|p| p.join("Cargo.lock").exists())
-                .unwrap_or_else(|| panic!("Could not find workspace root"))
-                .to_path_buf();
-
-            let dir = workspace_root.join("target/coverage/profraw");
-            std::fs::create_dir_all(&dir)
-                .expect("Failed to create coverage output directory");
-
-            pack_command.volume(VolumeMount {
-                source: dir,
-                target: PathBuf::from("/tmp/llvm-cov"),
-                options: Some(String::from("rw")),
-            });
-            pack_command.env("LLVM_PROFILE_FILE", "/tmp/llvm-cov/%p-%m.profraw");
-        }
+        let additional_cargo_env = if coverage_enabled {
+            configure_coverage(&cargo_manifest_dir, &mut pack_command)
+        } else {
+            Vec::new()
+        };
 
         for buildpack in &config.buildpacks {
             match buildpack {
@@ -145,7 +134,7 @@ impl TestRunner {
                         &config.target_triple,
                         &cargo_manifest_dir,
                         buildpacks_target_dir.path(),
-                        coverage_enabled,
+                        &additional_cargo_env,
                     )
                     .unwrap_or_else(|error| {
                         panic!("Error packaging current crate as buildpack: {error}")
@@ -160,7 +149,7 @@ impl TestRunner {
                         &config.target_triple,
                         &cargo_manifest_dir,
                         buildpacks_target_dir.path(),
-                        coverage_enabled,
+                        &additional_cargo_env,
                     )
                     .unwrap_or_else(|error| {
                         panic!("Error packaging buildpack '{buildpack_id}': {error}")
@@ -199,6 +188,31 @@ impl TestRunner {
 
         f(test_context);
     }
+}
+
+fn configure_coverage(
+    cargo_manifest_dir: &Path,
+    pack_command: &mut PackBuildCommand,
+) -> Vec<(OsString, OsString)> {
+    let workspace_root = find_cargo_workspace_root_dir(cargo_manifest_dir)
+        .unwrap_or_else(|error| panic!("Error finding Cargo workspace root: {error}"));
+
+    let dir = workspace_root.join("target/coverage/profraw");
+    std::fs::create_dir_all(&dir).expect("Failed to create coverage output directory");
+
+    pack_command.volume(VolumeMount {
+        source: dir,
+        target: PathBuf::from("/tmp/llvm-cov"),
+        options: Some(String::from("rw")),
+    });
+    // %p = PID, %m = binary signature hash — prevents clobbering across concurrent runs.
+    // See: https://doc.rust-lang.org/rustc/instrument-coverage.html
+    pack_command.env("LLVM_PROFILE_FILE", "/tmp/llvm-cov/%p-%m.profraw");
+
+    vec![(
+        OsString::from("RUSTFLAGS"),
+        OsString::from("-C instrument-coverage"),
+    )]
 }
 
 #[allow(clippy::struct_field_names)]

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -8,6 +8,8 @@ use std::borrow::Borrow;
 use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tempfile::tempdir;
 
 /// Runner for libcnb integration tests.
@@ -240,6 +242,8 @@ fn instrumentation_enabled_via_env() -> Result<bool, InvalidInstrumentationEnvVa
 
 const INSTRUMENTATION_CONTAINER_DIR: &str = "/tmp/llvm-cov";
 
+static PACK_INVOCATION_COUNTER: AtomicU64 = AtomicU64::new(0);
+
 struct InstrumentationSetup {
     volume: VolumeMount,
     pack_env: (String, String),
@@ -267,17 +271,26 @@ fn configure_instrumentation(cargo_manifest_dir: &Path) -> InstrumentationSetup 
     let dir = std::fs::canonicalize(&dir)
         .unwrap_or_else(|error| panic!("Error canonicalizing coverage output directory: {error}"));
 
+    let test_name = std::thread::current()
+        .name()
+        .unwrap_or("unknown")
+        .replace("::", "_");
+    let timestamp_ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let invocation_id = PACK_INVOCATION_COUNTER.fetch_add(1, Ordering::Relaxed);
+
     InstrumentationSetup {
         volume: VolumeMount {
             source: dir,
             target: PathBuf::from(INSTRUMENTATION_CONTAINER_DIR),
             mode: VolumeMountMode::ReadWrite,
         },
-        // %p = PID, %m = binary signature hash — prevents clobbering across concurrent runs.
-        // See: https://doc.rust-lang.org/rustc/instrument-coverage.html
         pack_env: (
             String::from("LLVM_PROFILE_FILE"),
-            format!("{INSTRUMENTATION_CONTAINER_DIR}/%p-%m.profraw"),
+            format!(
+                "{INSTRUMENTATION_CONTAINER_DIR}/{test_name}-{timestamp_ns}-{invocation_id}.profraw"
+            ),
         ),
         cargo_env_additions: vec![CargoEnvAddition {
             key: OsString::from("RUSTFLAGS"),

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -1,4 +1,4 @@
-use crate::build::CargoEnvUpdate;
+use crate::build::CargoEnvAddition;
 use crate::docker::{DockerRemoveImageCommand, DockerRemoveVolumeCommand};
 use crate::pack::{PackBuildCommand, VolumeMount};
 use crate::util::CommandError;
@@ -121,7 +121,7 @@ impl TestRunner {
             pack_command.env(key, value);
         });
 
-        let additional_cargo_env: Vec<CargoEnvUpdate> = if coverage_enabled {
+        let cargo_env_additions: Vec<CargoEnvAddition> = if coverage_enabled {
             configure_coverage(&cargo_manifest_dir, &mut pack_command)
         } else {
             Vec::new()
@@ -135,7 +135,7 @@ impl TestRunner {
                         &config.target_triple,
                         &cargo_manifest_dir,
                         buildpacks_target_dir.path(),
-                        &additional_cargo_env,
+                        &cargo_env_additions,
                     )
                     .unwrap_or_else(|error| {
                         panic!("Error packaging current crate as buildpack: {error}")
@@ -150,7 +150,7 @@ impl TestRunner {
                         &config.target_triple,
                         &cargo_manifest_dir,
                         buildpacks_target_dir.path(),
-                        &additional_cargo_env,
+                        &cargo_env_additions,
                     )
                     .unwrap_or_else(|error| {
                         panic!("Error packaging buildpack '{buildpack_id}': {error}")
@@ -194,7 +194,7 @@ impl TestRunner {
 fn configure_coverage(
     cargo_manifest_dir: &Path,
     pack_command: &mut PackBuildCommand,
-) -> Vec<CargoEnvUpdate> {
+) -> Vec<CargoEnvAddition> {
     let workspace_root = find_cargo_workspace_root_dir(cargo_manifest_dir)
         .unwrap_or_else(|error| panic!("Error finding Cargo workspace root: {error}"));
 
@@ -220,7 +220,7 @@ fn configure_coverage(
     // See: https://doc.rust-lang.org/rustc/instrument-coverage.html
     pack_command.env("LLVM_PROFILE_FILE", "/tmp/llvm-cov/%p-%m.profraw");
 
-    vec![CargoEnvUpdate::Append {
+    vec![CargoEnvAddition {
         key: OsString::from("RUSTFLAGS"),
         value: OsString::from("-C instrument-coverage"),
         separator: OsString::from(" "),

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -191,6 +191,8 @@ impl TestRunner {
     }
 }
 
+const COVERAGE_CONTAINER_DIR: &str = "/tmp/llvm-cov";
+
 fn configure_coverage(
     cargo_manifest_dir: &Path,
     pack_command: &mut PackBuildCommand,
@@ -213,12 +215,15 @@ fn configure_coverage(
 
     pack_command.volume(VolumeMount {
         source: dir,
-        target: PathBuf::from("/tmp/llvm-cov"),
+        target: PathBuf::from(COVERAGE_CONTAINER_DIR),
         options: Some(String::from("rw")),
     });
     // %p = PID, %m = binary signature hash — prevents clobbering across concurrent runs.
     // See: https://doc.rust-lang.org/rustc/instrument-coverage.html
-    pack_command.env("LLVM_PROFILE_FILE", "/tmp/llvm-cov/%p-%m.profraw");
+    pack_command.env(
+        "LLVM_PROFILE_FILE",
+        format!("{COVERAGE_CONTAINER_DIR}/%p-%m.profraw"),
+    );
 
     vec![CargoEnvAddition {
         key: OsString::from("RUSTFLAGS"),

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -117,8 +117,8 @@ impl TestRunner {
             pack_command.env(key, value);
         });
 
-        let instrumentation_enabled =
-            config.instrumentation_enabled || instrumentation_enabled_via_env();
+        let instrumentation_enabled = config.instrumentation_enabled
+            || instrumentation_enabled_via_env().unwrap_or_else(|error| panic!("{error}"));
 
         let instrumentation_setup = if instrumentation_enabled {
             Some(configure_instrumentation(&cargo_manifest_dir))
@@ -212,9 +212,30 @@ fn create_buildpack_references(
         .collect()
 }
 
-fn instrumentation_enabled_via_env() -> bool {
-    env::var("LIBCNB_INSTRUMENTATION")
-        .is_ok_and(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+#[derive(Debug)]
+struct InvalidInstrumentationEnvVar {
+    value: String,
+}
+
+impl std::fmt::Display for InvalidInstrumentationEnvVar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Invalid value for LIBCNB_INSTRUMENTATION: {:?}. Expected \"1\", \"true\", \"0\", or \"false\".",
+            self.value
+        )
+    }
+}
+
+fn instrumentation_enabled_via_env() -> Result<bool, InvalidInstrumentationEnvVar> {
+    match env::var("LIBCNB_INSTRUMENTATION") {
+        Err(_) => Ok(false),
+        Ok(v) => match v.to_ascii_lowercase().as_str() {
+            "1" | "true" => Ok(true),
+            "0" | "false" | "" => Ok(false),
+            _ => Err(InvalidInstrumentationEnvVar { value: v }),
+        },
+    }
 }
 
 const INSTRUMENTATION_CONTAINER_DIR: &str = "/tmp/llvm-cov";

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -1,6 +1,6 @@
 use crate::build::CargoEnvAddition;
 use crate::docker::{DockerRemoveImageCommand, DockerRemoveVolumeCommand};
-use crate::pack::{PackBuildCommand, VolumeMount};
+use crate::pack::{PackBuildCommand, VolumeMount, VolumeMountMode};
 use crate::util::CommandError;
 use crate::{BuildConfig, BuildpackReference, PackResult, TestContext, app, build, util};
 use libcnb_package::find_cargo_workspace_root_dir;
@@ -271,7 +271,7 @@ fn configure_instrumentation(cargo_manifest_dir: &Path) -> InstrumentationSetup 
         volume: VolumeMount {
             source: dir,
             target: PathBuf::from(INSTRUMENTATION_CONTAINER_DIR),
-            options: Some(String::from("rw")),
+            mode: VolumeMountMode::ReadWrite,
         },
         // %p = PID, %m = binary signature hash — prevents clobbering across concurrent runs.
         // See: https://doc.rust-lang.org/rustc/instrument-coverage.html

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -70,8 +70,8 @@ impl TestRunner {
     ) {
         let config = config.borrow();
 
-        let coverage_enabled = config.coverage
-            || env::var("LIBCNB_COVERAGE")
+        let instrumentation_enabled = config.instrumentation_enabled
+            || env::var("LIBCNB_INSTRUMENTATION")
                 .is_ok_and(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"));
 
         let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").map_or_else(
@@ -121,8 +121,8 @@ impl TestRunner {
             pack_command.env(key, value);
         });
 
-        let cargo_env_additions: Vec<CargoEnvAddition> = if coverage_enabled {
-            configure_coverage(&cargo_manifest_dir, &mut pack_command)
+        let cargo_env_additions: Vec<CargoEnvAddition> = if instrumentation_enabled {
+            configure_instrumentation(&cargo_manifest_dir, &mut pack_command)
         } else {
             Vec::new()
         };
@@ -191,9 +191,9 @@ impl TestRunner {
     }
 }
 
-const COVERAGE_CONTAINER_DIR: &str = "/tmp/llvm-cov";
+const INSTRUMENTATION_CONTAINER_DIR: &str = "/tmp/llvm-cov";
 
-fn configure_coverage(
+fn configure_instrumentation(
     cargo_manifest_dir: &Path,
     pack_command: &mut PackBuildCommand,
 ) -> Vec<CargoEnvAddition> {
@@ -215,14 +215,14 @@ fn configure_coverage(
 
     pack_command.volume(VolumeMount {
         source: dir,
-        target: PathBuf::from(COVERAGE_CONTAINER_DIR),
+        target: PathBuf::from(INSTRUMENTATION_CONTAINER_DIR),
         options: Some(String::from("rw")),
     });
     // %p = PID, %m = binary signature hash — prevents clobbering across concurrent runs.
     // See: https://doc.rust-lang.org/rustc/instrument-coverage.html
     pack_command.env(
         "LLVM_PROFILE_FILE",
-        format!("{COVERAGE_CONTAINER_DIR}/%p-%m.profraw"),
+        format!("{INSTRUMENTATION_CONTAINER_DIR}/%p-%m.profraw"),
     );
 
     vec![CargoEnvAddition {

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -1,6 +1,7 @@
 use crate::docker::{DockerRemoveImageCommand, DockerRemoveVolumeCommand};
 use crate::pack::{PackBuildCommand, VolumeMount};
 use crate::util::CommandError;
+use crate::build::CargoEnvUpdate;
 use crate::{BuildConfig, BuildpackReference, PackResult, TestContext, app, build, util};
 use libcnb_package::find_cargo_workspace_root_dir;
 use std::borrow::Borrow;
@@ -120,7 +121,7 @@ impl TestRunner {
             pack_command.env(key, value);
         });
 
-        let additional_cargo_env = if coverage_enabled {
+        let additional_cargo_env: Vec<CargoEnvUpdate> = if coverage_enabled {
             configure_coverage(&cargo_manifest_dir, &mut pack_command)
         } else {
             Vec::new()
@@ -193,12 +194,13 @@ impl TestRunner {
 fn configure_coverage(
     cargo_manifest_dir: &Path,
     pack_command: &mut PackBuildCommand,
-) -> Vec<(OsString, OsString)> {
+) -> Vec<CargoEnvUpdate> {
     let workspace_root = find_cargo_workspace_root_dir(cargo_manifest_dir)
         .unwrap_or_else(|error| panic!("Error finding Cargo workspace root: {error}"));
 
     let dir = workspace_root.join("target/coverage/profraw");
     std::fs::create_dir_all(&dir).expect("Failed to create coverage output directory");
+    let dir = std::fs::canonicalize(&dir).expect("Failed to canonicalize coverage output directory");
 
     pack_command.volume(VolumeMount {
         source: dir,
@@ -209,10 +211,11 @@ fn configure_coverage(
     // See: https://doc.rust-lang.org/rustc/instrument-coverage.html
     pack_command.env("LLVM_PROFILE_FILE", "/tmp/llvm-cov/%p-%m.profraw");
 
-    vec![(
-        OsString::from("RUSTFLAGS"),
-        OsString::from("-C instrument-coverage"),
-    )]
+    vec![CargoEnvUpdate::Append {
+        key: OsString::from("RUSTFLAGS"),
+        value: OsString::from("-C instrument-coverage"),
+        separator: OsString::from(" "),
+    }]
 }
 
 #[allow(clippy::struct_field_names)]

--- a/libcnb-test/src/test_runner.rs
+++ b/libcnb-test/src/test_runner.rs
@@ -1,5 +1,5 @@
 use crate::docker::{DockerRemoveImageCommand, DockerRemoveVolumeCommand};
-use crate::pack::PackBuildCommand;
+use crate::pack::{PackBuildCommand, VolumeMount};
 use crate::util::CommandError;
 use crate::{BuildConfig, BuildpackReference, PackResult, TestContext, app, build, util};
 use std::borrow::Borrow;
@@ -59,6 +59,7 @@ impl TestRunner {
         self.build_internal(docker_resources, config, f);
     }
 
+    #[allow(clippy::too_many_lines)]
     pub(crate) fn build_internal<C: Borrow<BuildConfig>, F: FnOnce(TestContext)>(
         &self,
         docker_resources: TemporaryDockerResources,
@@ -66,6 +67,9 @@ impl TestRunner {
         f: F,
     ) {
         let config = config.borrow();
+
+        let coverage_enabled = config.coverage
+            || env::var("LIBCNB_COVERAGE").is_ok_and(|v| v == "1");
 
         let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").map_or_else(
             |error| panic!("Error determining Cargo manifest directory: {error}"),
@@ -114,6 +118,25 @@ impl TestRunner {
             pack_command.env(key, value);
         });
 
+        if coverage_enabled {
+            let workspace_root = cargo_manifest_dir
+                .ancestors()
+                .find(|p| p.join("Cargo.lock").exists())
+                .unwrap_or_else(|| panic!("Could not find workspace root"))
+                .to_path_buf();
+
+            let dir = workspace_root.join("target/coverage/profraw");
+            std::fs::create_dir_all(&dir)
+                .expect("Failed to create coverage output directory");
+
+            pack_command.volume(VolumeMount {
+                source: dir,
+                target: PathBuf::from("/tmp/llvm-cov"),
+                options: Some(String::from("rw")),
+            });
+            pack_command.env("LLVM_PROFILE_FILE", "/tmp/llvm-cov/%p-%m.profraw");
+        }
+
         for buildpack in &config.buildpacks {
             match buildpack {
                 BuildpackReference::CurrentCrate => {
@@ -122,7 +145,7 @@ impl TestRunner {
                         &config.target_triple,
                         &cargo_manifest_dir,
                         buildpacks_target_dir.path(),
-                        false,
+                        coverage_enabled,
                     )
                     .unwrap_or_else(|error| {
                         panic!("Error packaging current crate as buildpack: {error}")
@@ -137,7 +160,7 @@ impl TestRunner {
                         &config.target_triple,
                         &cargo_manifest_dir,
                         buildpacks_target_dir.path(),
-                        false,
+                        coverage_enabled,
                     )
                     .unwrap_or_else(|error| {
                         panic!("Error packaging buildpack '{buildpack_id}': {error}")

--- a/libcnb-test/tests/fixtures/buildpacks/component-coverage/Cargo.toml
+++ b/libcnb-test/tests/fixtures/buildpacks/component-coverage/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "component-coverage"
+
+[workspace]

--- a/libcnb-test/tests/fixtures/buildpacks/component-coverage/buildpack.toml
+++ b/libcnb-test/tests/fixtures/buildpacks/component-coverage/buildpack.toml
@@ -1,0 +1,5 @@
+api = "0.8"
+
+[buildpack]
+id = "libcnb-test/coverage"
+version = "0.0.0"

--- a/libcnb-test/tests/fixtures/buildpacks/component-coverage/src/main.rs
+++ b/libcnb-test/tests/fixtures/buildpacks/component-coverage/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Coverage Buildpack");
+}

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -728,3 +728,45 @@ fn address_for_port_when_container_crashed() {
         "}
     );
 }
+
+#[test]
+#[ignore = "integration test"]
+fn build_with_coverage_produces_profraw() {
+    let coverage_dir = env::var("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("target/coverage/profraw");
+
+    if coverage_dir.exists() {
+        fs::remove_dir_all(&coverage_dir).unwrap();
+    }
+
+    TestRunner::default().build(
+        BuildConfig::new("heroku/builder:22", "tests/fixtures/empty")
+            .buildpacks([BuildpackReference::WorkspaceBuildpack(buildpack_id!(
+                "libcnb-test/a"
+            ))])
+            .enable_coverage(),
+        |context| {
+            assert_empty!(context.pack_stderr);
+            assert_contains!(context.pack_stdout, "Buildpack A");
+        },
+    );
+
+    assert!(
+        coverage_dir.exists(),
+        "Coverage directory should exist when coverage is enabled"
+    );
+    let profraw_files: Vec<_> = fs::read_dir(&coverage_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "profraw"))
+        .collect();
+    assert!(
+        !profraw_files.is_empty(),
+        "Expected at least one .profraw file in {}, found none",
+        coverage_dir.display()
+    );
+}

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -746,12 +746,12 @@ fn build_with_coverage_produces_profraw() {
     TestRunner::default().build(
         BuildConfig::new("heroku/builder:22", "tests/fixtures/empty")
             .buildpacks([BuildpackReference::WorkspaceBuildpack(buildpack_id!(
-                "libcnb-test/a"
+                "libcnb-test/coverage"
             ))])
             .enable_coverage(),
         |context| {
             assert_empty!(context.pack_stderr);
-            assert_contains!(context.pack_stdout, "Buildpack A");
+            assert_contains!(context.pack_stdout, "Coverage Buildpack");
         },
     );
 

--- a/libcnb-test/tests/integration_test.rs
+++ b/libcnb-test/tests/integration_test.rs
@@ -748,7 +748,7 @@ fn build_with_coverage_produces_profraw() {
             .buildpacks([BuildpackReference::WorkspaceBuildpack(buildpack_id!(
                 "libcnb-test/coverage"
             ))])
-            .enable_coverage(),
+            .enable_instrumentation(),
         |context| {
             assert_empty!(context.pack_stderr);
             assert_contains!(context.pack_stdout, "Coverage Buildpack");


### PR DESCRIPTION
## Summary

- Add `BuildConfig::enable_coverage()` and `LIBCNB_COVERAGE=1` env var support to `libcnb-test` for collecting LLVM source-based code coverage from integration tests running inside Docker containers
- When enabled, buildpack binaries are compiled with `-C instrument-coverage`, a volume mount extracts `.profraw` files from the container, and `LLVM_PROFILE_FILE` directs output to a known location on the host
- Add `VolumeMount` struct and `--volume` support to `PackBuildCommand`
- Includes integration test verifying profraw files are produced

W-22491168