### PR TITLE
Fix Clippy errors in newer versions of Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 
 [workspace.package]
 version = "0.30.4"
-rust-version = "1.85"
+rust-version = "1.96"
 edition = "2024"
 license = "BSD-3-Clause"
 

--- a/libcnb-cargo/src/package/command.rs
+++ b/libcnb-cargo/src/package/command.rs
@@ -163,15 +163,14 @@ fn eprint_pack_command_hint(
 }
 
 fn eprint_compiled_buildpack_success(current_dir: &Path, target_dir: &Path) {
-    let size_string = calculate_dir_size(target_dir)
-        .map(|size_in_bytes| {
+    let size_string =
+        calculate_dir_size(target_dir).map_or(String::from("<unknown>"), |size_in_bytes| {
             // Precision will only be lost for sizes bigger than 52 bits (~4 Petabytes), and even
             // then will only result in a less precise figure, so is not an issue.
             #[allow(clippy::cast_precision_loss)]
             let size_in_mib = size_in_bytes as f64 / (1024.0 * 1024.0);
             format!("{size_in_mib:.2}")
-        })
-        .unwrap_or(String::from("<unknown>"));
+        });
 
     let relative_output_path =
         pathdiff::diff_paths(target_dir, current_dir).unwrap_or_else(|| target_dir.to_path_buf());

--- a/libcnb/src/runtime.rs
+++ b/libcnb/src/runtime.rs
@@ -49,7 +49,7 @@ pub fn libcnb_runtime<B: Buildpack>(buildpack: &B) {
                 eprintln!("Error: Cloud Native Buildpack API mismatch");
                 eprintln!(
                     "This buildpack uses Cloud Native Buildpacks API version {} (specified in buildpack.toml).",
-                    &buildpack_descriptor.api,
+                    buildpack_descriptor.api,
                 );
                 eprintln!(
                     "However, the underlying libcnb.rs library only supports CNB API {LIBCNB_SUPPORTED_BUILDPACK_API}."


### PR DESCRIPTION
Fixes:

```
warning: redundant reference in `eprintln!` argument
  --> libcnb/src/runtime.rs:52:21
   |
52 |                     &buildpack_descriptor.api,
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `buildpack_descriptor.api`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/beta/index.html#useless_borrows_in_formatting
   = note: `#[warn(clippy::useless_borrows_in_formatting)]` on by default

    Checking idna v1.1.0
    Checking libcnb-test v0.30.4 (/Users/emorley/src/libcnb.rs/libcnb-test)
    Checking libcnb-cargo v0.30.4 (/Users/emorley/src/libcnb.rs/libcnb-cargo)
warning: `libcnb` (lib) generated 1 warning (run `cargo clippy --fix --lib -p libcnb -- ` to apply 1 suggestion)
    Checking examples-execd v0.0.0 (/Users/emorley/src/libcnb.rs/examples/execd)
    Checking examples-basics v0.0.0 (/Users/emorley/src/libcnb.rs/examples/basics)
    Checking tracing v0.0.0 (/Users/emorley/src/libcnb.rs/test-buildpacks/tracing)
    Checking readonly-layer-files v0.0.0 (/Users/emorley/src/libcnb.rs/test-buildpacks/readonly-layer-files)
    Checking sbom v0.0.0 (/Users/emorley/src/libcnb.rs/test-buildpacks/sbom)
    Checking store v0.0.0 (/Users/emorley/src/libcnb.rs/test-buildpacks/store)
    Checking url v2.5.7
warning: called `map(<f>).unwrap_or(<a>)` on a `Result` value
   --> libcnb-cargo/src/package/command.rs:166:23
    |
166 |       let size_string = calculate_dir_size(target_dir)
    |  _______________________^
167 | |         .map(|size_in_bytes| {
...   |
173 | |         })
174 | |         .unwrap_or(String::from("<unknown>"));
    | |_____________________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/beta/index.html#map_unwrap_or
    = note: `-W clippy::map-unwrap-or` implied by `-W clippy::pedantic`
    = help: to override `-W clippy::pedantic` add `#[allow(clippy::map_unwrap_or)]`
help: use `map_or(<a>, <f>)` instead
    |
167 ~         .map_or(String::from("<unknown>"), |size_in_bytes| {
168 |             // Precision will only be lost for sizes bigger than 52 bits (~4 Petabytes), and even
...
172 |             format!("{size_in_mib:.2}")
173 ~         });
    |
```

...using `cargo clippy --all-targets --fix && cargo fmt`.

As seen in eg:
https://github.com/heroku/libcnb.rs/actions/runs/25201207514/job/73892486212?pr=999#step:5:488

Also bumps MSRV to latest stable. (Since Clippy uses minimum Rust version to determine which lints to enable etc.)

GUS-W-22816907.